### PR TITLE
Bundle support

### DIFF
--- a/libs/network-protocol/src/lib/queue/creators/create-decryption-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-decryption-queue.ts
@@ -3,7 +3,7 @@ import type { DecryptionQueueCreater } from '../model'
 import { isValidUnserializedEncryptedPacket, isValidUnencryptedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '../creators'
+import { createQueue } from './create-queue'
 
 export const createDecryptionQueue: DecryptionQueueCreater = (label, packetDecryption, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/network-protocol/src/lib/queue/creators/create-deobfuscation-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-deobfuscation-queue.ts
@@ -3,7 +3,7 @@ import type { DeobfuscationQueueCreater } from '../model'
 import { isValidObfuscatedPacket, isValidSerializedEncryptedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '../creators'
+import { createQueue } from './create-queue'
 
 export const createDeobfuscationQueue: DeobfuscationQueueCreater = (label, packetDeobfuscation, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/network-protocol/src/lib/queue/creators/create-deserialization-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-deserialization-queue.ts
@@ -3,7 +3,7 @@ import type { DeserializationQueueCreater } from '../model'
 import { isValidSerializedEncryptedPacket, isValidUnserializedEncryptedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '../creators'
+import { createQueue } from './create-queue'
 
 export const createDeserializationQueue: DeserializationQueueCreater = (label, packetDeserialization, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/network-protocol/src/lib/queue/creators/create-encryption-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-encryption-queue.ts
@@ -3,7 +3,7 @@ import type { EncryptionQueueCreater } from '../model'
 import { isValidUnencryptedPacket, isValidUnserializedEncryptedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '../creators'
+import { createQueue } from './create-queue'
 
 export const createEncryptionQueue: EncryptionQueueCreater = (label, packetEncryption, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/network-protocol/src/lib/queue/creators/create-obfuscation-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-obfuscation-queue.ts
@@ -3,7 +3,7 @@ import type { ObfuscationQueueCreater } from '../model'
 import { isValidSerializedEncryptedPacket, isValidObfuscatedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '../creators'
+import { createQueue } from './create-queue'
 
 export const createObfuscationQueue: ObfuscationQueueCreater = (label, packetObfuscation, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/network-protocol/src/lib/queue/creators/create-serialization-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-serialization-queue.ts
@@ -3,7 +3,7 @@ import type { SerializationQueueCreater } from '../model'
 import { isValidUnserializedEncryptedPacket, isValidSerializedEncryptedPacket } from '../../packet/validations'
 import { isValidQueueCreaterArguments } from '../validations'
 import { getValidationError } from '../utils'
-import { createQueue } from '.'
+import { createQueue } from './create-queue'
 
 export const createSerializationQueue: SerializationQueueCreater = (label, packetSerialization, logger, onSuccess, onFail) => {
   const validity = isValidQueueCreaterArguments({

--- a/libs/nexus/project.json
+++ b/libs/nexus/project.json
@@ -6,7 +6,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
-    "build": {},
+    "build": {
+      "options": {
+        "bundle": true,
+        "globalName": "HyperfrontendNexus"
+      }
+    },
     "typecheck": {}
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nx/jest": "22.3.3",
         "@nx/js": "22.3.3",
         "@nx/rollup": "22.3.3",
+        "@rollup/plugin-terser": "0.4.4",
         "@swc-node/register": "1.11.1",
         "@swc/core": "1.15.11",
         "@types/jest": "30.0.0",
@@ -3565,6 +3566,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -4639,6 +4651,29 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -18315,6 +18350,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -19187,6 +19232,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -19380,6 +19435,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/smob": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
+      "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "3.8.1",
@@ -19993,6 +20055,43 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nx/jest": "22.3.3",
     "@nx/js": "22.3.3",
     "@nx/rollup": "22.3.3",
+    "@rollup/plugin-terser": "0.4.4",
     "@swc-node/register": "1.11.1",
     "@swc/core": "1.15.11",
     "@types/jest": "30.0.0",

--- a/tools/package/src/executors/build/executor.ts
+++ b/tools/package/src/executors/build/executor.ts
@@ -1,26 +1,5 @@
 /**
  * Build executor for hyperfrontend library packages.
- *
- * WHAT THIS EXECUTOR DOES:
- * ------------------------
- * 1. Auto-detects library entry points (./browser, ./node, ./feature, etc.)
- * 2. Builds each entry point to ESM + CJS formats using Rollup
- * 3. Generates TypeScript declaration files (.d.ts)
- * 4. Creates a package.json with proper "exports" field for each entry
- * 5. Copies assets (README, LICENSE, etc.) to the dist folder
- *
- * WHY A CUSTOM EXECUTOR:
- * ----------------------
- * Nx's built-in `\@nx/js:tsc` executor doesn't support:
- * - Multiple entry points with subpath exports
- * - Dual ESM/CJS output from a single build
- * - Auto-detection of library structure
- *
- * This executor handles all hyperfrontend library patterns:
- * - Simple: Single entry at src/index.ts
- * - Platform: browser/ and node/ entries
- * - Feature: Multiple domain-specific entries
- * - Complex: Nested combinations of the above
  */
 import { type ExecutorContext, joinPathFragments, logger } from '@nx/devkit'
 import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
@@ -29,48 +8,20 @@ import type { BuildExecutorOptions } from './lib/types'
 import { resolveOutputPath, resolveTsConfigPath } from './lib/paths'
 import { discoverEntryPoints } from './lib/detect'
 import { copyAssets, copyDefaultAssets } from './lib/assets'
-import { buildUnifiedLibrary } from './lib/build-unified'
+import { buildUnifiedLibrary, buildBundledOutput } from './lib/build-unified'
 
 /**
  * Reads dependencies from package.json and returns all packages that should be external.
- *
- * WHY ALL DEPENDENCIES ARE EXTERNAL:
- * ----------------------------------
- * This is a library build, not an application build. The key difference:
- *
- * Application build: Bundle everything into a self-contained deployable.
- * Library build: Produce code that consumers will bundle themselves.
- *
- * If we bundled dependencies into library output:
- * - lodash used by our lib + lodash used by consumer = 2 copies of lodash
- * - Version mismatches cause subtle bugs (different lodash instances)
- * - Tree-shaking becomes impossible for the bundled portions
- * - Bundle sizes explode across the ecosystem
- *
- * By marking all deps as external, our output contains:
- *   import { debounce } from 'lodash'
- *
- * The consumer's bundler resolves this from their node_modules,
- * deduplicating and tree-shaking as appropriate.
- *
- * We include both dependencies and peerDependencies:
- * - dependencies: Required packages we use directly
- * - peerDependencies: Packages consumer must provide (e.g., React)
  *
  * @param projectRoot - Absolute path to the project root
  * @returns List of all dependencies to mark as external
  */
 function getExternalDependencies(projectRoot: string): string[] {
   const pkgPath = join(projectRoot, 'package.json')
-  if (!existsSync(pkgPath)) {
-    return []
-  }
+  if (!existsSync(pkgPath)) return []
+
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
-  const allDeps = {
-    ...pkg.dependencies,
-    ...pkg.peerDependencies,
-  }
-  return Object.keys(allDeps)
+  return Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies })
 }
 
 /**
@@ -100,7 +51,6 @@ export default async function runExecutor(
   const projectRoot = join(workspaceRoot, projectConfig.root)
   const projectRelativePath = projectConfig.root
 
-  // Resolve options with defaults using joinPathFragments for config paths
   const outputPath = resolveOutputPath(
     options.outputPath ?? joinPathFragments('dist', projectRelativePath),
     projectRelativePath,
@@ -113,9 +63,16 @@ export default async function runExecutor(
   )
   const assets = options.assets ?? []
 
-  // All dependencies from package.json should be external for library builds
   const packageDeps = getExternalDependencies(projectRoot)
   const external = [...(options.external ?? []), ...packageDeps]
+
+  const shouldBundle = options.bundle ?? false
+  const globalName = options.globalName
+
+  if (shouldBundle && !globalName) {
+    logger.error('globalName is required when bundle is true')
+    return { success: false }
+  }
 
   logger.info(`Building ${projectName}...`)
   logger.info(`  Project root: ${projectRoot}`)
@@ -124,33 +81,43 @@ export default async function runExecutor(
   if (packageDeps.length > 0) {
     logger.info(`  External deps: ${packageDeps.join(', ')}`)
   }
+  if (shouldBundle) {
+    logger.info(`  Bundle: enabled (global: ${globalName})`)
+  }
 
-  // Discover entry points
   const discovery = discoverEntryPoints(projectRoot)
   logger.info(`  Entry point category: ${discovery.category}`)
   logger.info(`  Entry points: ${discovery.entryPoints.map((e) => e.exportPath).join(', ')}`)
 
-  // Ensure output directory exists and is clean
   if (existsSync(outputPath)) {
     rmSync(outputPath, { recursive: true, force: true })
   }
   mkdirSync(outputPath, { recursive: true })
 
   try {
-    // Build using unified approach
     await buildUnifiedLibrary(
       projectRoot,
       outputPath,
       tsConfigPath,
       external,
       workspaceRoot,
-      discovery
+      discovery,
+      shouldBundle
     )
 
-    // Copy default assets
+    if (shouldBundle && globalName) {
+      await buildBundledOutput(
+        projectRoot,
+        outputPath,
+        tsConfigPath,
+        globalName,
+        workspaceRoot,
+        discovery
+      )
+    }
+
     copyDefaultAssets(projectRoot, outputPath, workspaceRoot)
 
-    // Copy additional assets
     if (assets.length > 0) {
       await copyAssets(assets, projectRoot, outputPath, workspaceRoot)
     }

--- a/tools/package/src/executors/build/lib/build-unified.ts
+++ b/tools/package/src/executors/build/lib/build-unified.ts
@@ -1,19 +1,6 @@
 /**
  * Unified library build utilities for the build executor.
- *
- * Handles any library structure by building all discovered entry points.
- *
- * ARCHITECTURE OVERVIEW:
- * -----------------------
- * This module uses Rollup to build TypeScript libraries with multiple entry points.
- * Each entry point (., ./browser, ./node, ./feature, etc.) is built separately to
- * produce both ESM and CJS outputs, enabling consumers to import specific subpaths
- * like `import { x } from '@hyperfrontend/lib/browser'`.
- *
- * WHY ROLLUP?
- * Rollup produces smaller, cleaner bundles than webpack for library publishing.
- * It tree-shakes effectively and preserves ES module semantics, which is critical
- * for libraries that need to work in both bundler and native ESM environments.
+ * Uses Rollup to build TypeScript libraries with multiple entry points.
  */
 import { logger } from '@nx/devkit'
 import { existsSync, mkdirSync, cpSync, rmSync } from 'node:fs'
@@ -21,31 +8,11 @@ import { execFileSync } from 'node:child_process'
 import { dirname, join, relative } from 'node:path'
 import { rollup, type RollupOptions, type OutputOptions, type RollupLog } from 'rollup'
 
-/*
- * PLUGIN SELECTION:
- *
- * @rollup/plugin-node-resolve:
- *   Resolves node_modules imports. Without this, Rollup can't find third-party packages.
- *   We configure it to NOT resolve @hyperfrontend/* packages since those are peer dependencies.
- *
- * @rollup/plugin-commonjs:
- *   Converts CommonJS modules to ES6. Required for packages like `jsonschema` that only
- *   export CommonJS. Without this, named imports from CJS packages fail with:
- *   "X is not exported by node_modules/package/index.js"
- *
- * @rollup/plugin-typescript:
- *   Compiles TypeScript and optionally generates declaration files. We generate
- *   declarations only for the root entry via this plugin; sub-entries use a separate
- *   tsc invocation to avoid complex per-entry declaration routing.
- *
- * @rollup/plugin-json:
- *   Allows importing .json files directly (e.g., JSON schemas). Without this,
- *   Rollup fails with "Expected ';' or '}' or <eof>" when encountering JSON syntax.
- */
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import typescript from '@rollup/plugin-typescript'
 import json from '@rollup/plugin-json'
+import terser from '@rollup/plugin-terser'
 import type { EntryPoint, EntryPointDiscovery } from './types'
 import { readProjectPackageJson, generatePackageJsonFromDiscovery } from './package-json'
 
@@ -68,23 +35,6 @@ export function createEntryPointRollupConfig(
   external: string[],
   isRootEntry: boolean
 ): RollupOptions {
-  /*
-   * EXTERNAL DEPENDENCY HANDLING:
-   *
-   * For library builds, we must NOT bundle dependencies into the output.
-   * Consumers will install these dependencies themselves. If we bundled them:
-   * 1. Bundle size would explode (duplicating shared deps across packages)
-   * 2. Version conflicts could occur (consumer might need different version)
-   * 3. Tree-shaking would be impossible for the bundled code
-   *
-   * We mark as external:
-   * - All dependencies from package.json (passed via `external` array)
-   * - All @hyperfrontend/* packages (always peer dependencies in this monorepo)
-   *
-   * The function approach (vs array) is needed because Rollup resolves imports
-   * BEFORE checking externals. By using a function, we can catch @hyperfrontend/*
-   * imports before they're resolved to source paths (which would cause TS6059).
-   */
   const isExternal = (id: string): boolean => {
     if (external.includes(id)) return true
     if (id.startsWith('@hyperfrontend/')) return true
@@ -95,96 +45,27 @@ export function createEntryPointRollupConfig(
     input: inputFile,
     external: isExternal,
 
-    /*
-     * WARNING SUPPRESSION:
-     *
-     * We suppress specific warnings that are expected and noisy:
-     *
-     * TS2307 ("Cannot find module '@hyperfrontend/...'")
-     *   This fires because we clear tsconfig paths to prevent source resolution.
-     *   TypeScript can't find type declarations for external packages at build time,
-     *   but that's fine - the runtime output correctly references them as bare imports.
-     *
-     * EMPTY_BUNDLE
-     *   Barrel files that only re-export from other files produce "empty" chunks.
-     *   This is expected behavior - the re-exports are handled by the module system.
-     *   The ESM/CJS outputs are still generated correctly.
-     */
     onwarn(warning: RollupLog, defaultHandler: (warning: RollupLog) => void) {
-      if (warning.plugin === 'typescript' && warning.message?.includes('TS2307')) {
-        return
-      }
-      if (warning.code === 'EMPTY_BUNDLE') {
-        return
-      }
+      if (warning.plugin === 'typescript' && warning.message?.includes('TS2307')) return
+      if (warning.code === 'EMPTY_BUNDLE') return
       defaultHandler(warning)
     },
 
     plugins: [
-      /*
-       * Plugin order matters!
-       * 1. json() - Must come early to transform JSON before other plugins see it
-       * 2. nodeResolve() - Resolves bare imports to node_modules paths
-       * 3. commonjs() - Converts CJS to ESM (must come after nodeResolve)
-       * 4. typescript() - Compiles TS (runs last on resolved, converted code)
-       */
       json(),
-
       nodeResolve({
         extensions: ['.ts', '.js'],
-        /*
-         * resolveOnly with negative lookahead regex:
-         * Only resolve packages that DON'T start with @hyperfrontend/
-         * This prevents Rollup from resolving internal packages to their source,
-         * which would cause TS6059 rootDir errors and incorrect bundling.
-         */
         resolveOnly: [/^(?!@hyperfrontend\/)/],
       }),
-
       commonjs(),
-
       typescript({
         tsconfig: tsConfigPath,
-
-        /*
-         * DECLARATION GENERATION STRATEGY:
-         *
-         * For root entry: Generate declarations via rollup-plugin-typescript.
-         * For sub-entries: Skip here, generate all at once via separate tsc call.
-         *
-         * Why this split approach?
-         * - Rollup's TS plugin generates declarations relative to each entry's output
-         * - For sub-entries, this creates complex nested paths that don't match exports
-         * - A single tsc invocation with --emitDeclarationOnly produces correct structure
-         *
-         * declarationMap must match declaration to avoid TS5069:
-         * "Option 'declarationMap' cannot be specified without 'declaration'"
-         */
         declaration: isRootEntry,
         declarationMap: isRootEntry,
         declarationDir: isRootEntry ? outputPath : undefined,
-
         rootDir: join(projectRoot, 'src'),
         outDir: outputPath,
         sourceMap: true,
-
-        /*
-         * PATH CLEARING - CRITICAL FOR MONOREPO BUILDS:
-         *
-         * The workspace tsconfig.base.json defines paths like:
-         *   "@hyperfrontend/data-utils": ["libs/utils/data/src/index.ts"]
-         *
-         * Without clearing these, TypeScript would:
-         * 1. Resolve @hyperfrontend/data-utils to libs/utils/data/src/index.ts
-         * 2. Try to compile that source file
-         * 3. Fail with TS6059: rootDir must contain all source files
-         *
-         * By setting paths: {}, we force TypeScript to leave @hyperfrontend/*
-         * imports as-is. They become external references in the output:
-         *   import { x } from '@hyperfrontend/data-utils'
-         *
-         * Consumers resolve these via their own node_modules.
-         */
         compilerOptions: {
           paths: {},
           baseUrl: projectRoot,
@@ -197,44 +78,136 @@ export function createEntryPointRollupConfig(
 /**
  * Creates output configurations for ESM and CJS formats.
  *
- * WHY DUAL FORMAT OUTPUT:
- * -----------------------
- * Modern JavaScript has two module systems that libraries must support:
- *
- * ESM (ES Modules) - index.esm.js:
- *   - Native browser support via <script type="module">
- *   - Used by modern bundlers (Vite, esbuild, Rollup)
- *   - Enables tree-shaking and static analysis
- *   - Syntax: import/export
- *
- * CJS (CommonJS) - index.cjs.js:
- *   - Required for Node.js (especially older versions)
- *   - Used by Jest, older tooling, and require() calls
- *   - Syntax: require/module.exports
- *
- * Package.json "exports" field routes consumers to the right format:
- *   "import": "./index.esm.js" (for import statements)
- *   "require": "./index.cjs.js" (for require calls)
- *
- * Source maps (.js.map) enable debugging with original TypeScript source.
- *
  * @param outputPath - Absolute path to the output directory
  * @param entryName - Name for the output files (default: 'index')
  * @returns Array of Rollup output configurations
  */
 export function createOutputConfigs(outputPath: string, entryName = 'index'): OutputOptions[] {
   return [
-    {
-      file: join(outputPath, `${entryName}.esm.js`),
-      format: 'esm',
-      sourcemap: true,
-    },
-    {
-      file: join(outputPath, `${entryName}.cjs.js`),
-      format: 'cjs',
-      sourcemap: true,
-    },
+    { file: join(outputPath, `${entryName}.esm.js`), format: 'esm', sourcemap: true },
+    { file: join(outputPath, `${entryName}.cjs.js`), format: 'cjs', sourcemap: true },
   ]
+}
+
+/**
+ * Creates Rollup configuration for a self-contained UMD/IIFE bundle.
+ *
+ * @param inputFile - Absolute path to the root entry file
+ * @param tsConfigPath - Absolute path to the tsconfig file
+ * @param projectRoot - Absolute path to the project root
+ * @param globalName - Global variable name (e.g., 'HyperfrontendNexus')
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param bundlePath - Absolute path to bundle output directory
+ * @returns Rollup configuration for bundled build
+ */
+function createBundleRollupConfig(
+  inputFile: string,
+  tsConfigPath: string,
+  projectRoot: string,
+  globalName: string,
+  workspaceRoot: string,
+  bundlePath: string
+): RollupOptions {
+  return {
+    input: inputFile,
+    external: [],
+
+    onwarn(warning: RollupLog, defaultHandler: (warning: RollupLog) => void) {
+      if (warning.plugin === 'typescript' && warning.message?.includes('TS2307')) return
+      if (warning.code === 'EMPTY_BUNDLE') return
+      if (warning.code === 'UNRESOLVED_IMPORT' && warning.exporter?.startsWith('@hyperfrontend/')) return
+      defaultHandler(warning)
+    },
+
+    plugins: [
+      json(),
+      nodeResolve({
+        extensions: ['.ts', '.js'],
+        browser: true,
+        preferBuiltins: false,
+      }),
+      commonjs(),
+      typescript({
+        tsconfig: tsConfigPath,
+        declaration: false,
+        declarationMap: false,
+        sourceMap: true,
+        compilerOptions: {
+          baseUrl: workspaceRoot,
+          outDir: bundlePath,
+        },
+      }),
+    ],
+  }
+}
+
+/**
+ * Creates output configurations for bundled UMD and IIFE formats.
+ *
+ * @param bundlePath - Output directory for bundles
+ * @param globalName - Global variable name
+ * @returns Array of Rollup output configurations
+ */
+function createBundleOutputConfigs(bundlePath: string, globalName: string): OutputOptions[] {
+  return [
+    { file: join(bundlePath, 'index.umd.js'), format: 'umd', name: globalName, sourcemap: true },
+    { file: join(bundlePath, 'index.umd.min.js'), format: 'umd', name: globalName, sourcemap: true, plugins: [terser()] },
+    { file: join(bundlePath, 'index.iife.js'), format: 'iife', name: globalName, sourcemap: true },
+    { file: join(bundlePath, 'index.iife.min.js'), format: 'iife', name: globalName, sourcemap: true, plugins: [terser()] },
+  ]
+}
+
+/**
+ * Builds self-contained UMD and IIFE bundles for CDN distribution.
+ *
+ * @param projectRoot - Absolute path to project root
+ * @param outputPath - Base output path for the library
+ * @param tsConfigPath - Absolute path to tsconfig file
+ * @param globalName - Global variable name for UMD/IIFE
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param discovery - Entry point discovery result
+ */
+export async function buildBundledOutput(
+  projectRoot: string,
+  outputPath: string,
+  tsConfigPath: string,
+  globalName: string,
+  workspaceRoot: string,
+  discovery: EntryPointDiscovery
+): Promise<void> {
+  logger.info('Building CDN bundles (UMD + IIFE)...')
+
+  const rootEntry = discovery.entryPoints.find((e) => e.isRoot)
+  if (!rootEntry) {
+    throw new Error('Bundle build requires a root entry point (src/index.ts)')
+  }
+
+  const bundlePath = join(outputPath, 'bundle')
+  mkdirSync(bundlePath, { recursive: true })
+
+  const rollupConfig = createBundleRollupConfig(
+    rootEntry.inputFile,
+    tsConfigPath,
+    projectRoot,
+    globalName,
+    workspaceRoot,
+    bundlePath
+  )
+  const outputConfigs = createBundleOutputConfigs(bundlePath, globalName)
+
+  const bundle = await rollup(rollupConfig)
+
+  try {
+    for (const output of outputConfigs) {
+      await bundle.write(output)
+      const filename = (output.file as string).split('/').pop()
+      logger.info(`  Built: bundle/${filename}`)
+    }
+  } finally {
+    await bundle.close()
+  }
+
+  logger.info('CDN bundles complete')
 }
 
 /**
@@ -253,11 +226,8 @@ async function buildSingleEntryPoint(
   projectRoot: string,
   external: string[]
 ): Promise<void> {
-  const entryOutputPath = entry.srcPath
-    ? join(outputBasePath, entry.srcPath)
-    : outputBasePath
+  const entryOutputPath = entry.srcPath ? join(outputBasePath, entry.srcPath) : outputBasePath
 
-  // Ensure output directory exists
   mkdirSync(entryOutputPath, { recursive: true })
 
   const rollupConfig = createEntryPointRollupConfig(
@@ -285,24 +255,7 @@ async function buildSingleEntryPoint(
 
 /**
  * Generates TypeScript declarations for all entry points.
- *
- * WHY A SEPARATE TSC CALL FOR DECLARATIONS:\n * -----------------------------------------
- * For libraries with multiple entry points, declaration generation is tricky.
- *
- * Problem with Rollup's TypeScript plugin for sub-entries:
- * Each entry is built independently, and declarations are generated relative to
- * that entry's output directory. This creates mismatched declaration paths:
- *   - Entry ./browser outputs to dist/browser/
- *   - Its declarations reference types from dist/browser/ perspective
- *   - But the root entry's types reference dist/ perspective
- *   - Import resolution breaks when types don't align
- *
- * Solution: Use Rollup's TS plugin only for the root entry, then run a single
- * tsc --emitDeclarationOnly pass that generates ALL declarations in one shot.
- * This ensures consistent type resolution paths across all entry points.
- *
- * The --declarationMap flag generates .d.ts.map files that map declarations
- * back to original .ts source, enabling "Go to Definition" in IDEs.
+ * Uses a separate tsc call to ensure consistent declaration paths across all entries.
  *
  * @param projectRoot - Absolute path to the project root
  * @param outputPath - Absolute path to output directory
@@ -317,47 +270,21 @@ export function generateDeclarationsUnified(
   workspaceRoot: string,
   discovery: EntryPointDiscovery
 ): void {
-  /*
-   * Root-only libraries (single entry at src/index.ts) don't need this.
-   * Their declarations are generated by rollup-plugin-typescript during build.
-   */
-  if (discovery.category === 'root') {
-    return
-  }
+  if (discovery.category === 'root') return
 
   logger.info('Generating TypeScript declarations...')
 
-  execFileSync('npx', [
-    'tsc',
-    '--project', tsConfigPath,
-    '--emitDeclarationOnly',
-    '--declaration',
-    '--declarationMap',
-    '--outDir', outputPath
-  ], {
-    stdio: 'inherit',
-    cwd: projectRoot,
-  })
+  execFileSync(
+    'npx',
+    ['tsc', '--project', tsConfigPath, '--emitDeclarationOnly', '--declaration', '--declarationMap', '--outDir', outputPath],
+    { stdio: 'inherit', cwd: projectRoot }
+  )
 
   flattenDeclarationPaths(projectRoot, outputPath, workspaceRoot, discovery)
 }
 
 /**
- * Flattens declaration paths from nested structure to flat output.
- *
- * WHY FLATTENING IS NEEDED:
- * -------------------------
- * TypeScript's tsc outputs declarations mirroring the source directory structure
- * relative to the workspace root. For a library at libs/utils/data/:
- *
- * tsc outputs:        dist/libs/utils/data/src/browser/index.d.ts
- * We need:            dist/browser/index.d.ts
- *
- * This happens because tsc calculates paths from rootDir, and in a monorepo,
- * rootDir is often the workspace root to allow cross-project imports.
- *
- * This function copies declarations from the nested structure to the expected
- * flat output locations, then cleans up the nested directories.
+ * Flattens declaration paths from nested tsc output structure to flat output.
  *
  * @param projectRoot - Absolute path to the project root
  * @param outputPath - Absolute path to output directory
@@ -370,19 +297,12 @@ function flattenDeclarationPaths(
   workspaceRoot: string,
   discovery: EntryPointDiscovery
 ): void {
-  /*
-   * Calculate where tsc put the declarations.
-   * For libs/utils/data/, this would be dist/libs/utils/data/src/
-   */
   const nestedDeclarations = join(outputPath, relative(workspaceRoot, join(projectRoot, 'src')))
 
-  if (!existsSync(nestedDeclarations)) {
-    return
-  }
+  if (!existsSync(nestedDeclarations)) return
 
-  // Copy each entry point's declarations to its output location
   for (const entry of discovery.entryPoints) {
-    if (entry.isRoot) continue // Root declarations are in the right place
+    if (entry.isRoot) continue
 
     const srcDir = entry.srcPath
     const declSrc = join(nestedDeclarations, srcDir)
@@ -394,7 +314,6 @@ function flattenDeclarationPaths(
     }
   }
 
-  // Clean up nested directory structure
   cleanupNestedDeclarations(projectRoot, outputPath, workspaceRoot)
 }
 
@@ -405,11 +324,7 @@ function flattenDeclarationPaths(
  * @param outputPath - Absolute path to output directory
  * @param workspaceRoot - Absolute path to workspace root
  */
-function cleanupNestedDeclarations(
-  projectRoot: string,
-  outputPath: string,
-  workspaceRoot: string
-): void {
+function cleanupNestedDeclarations(projectRoot: string, outputPath: string, workspaceRoot: string): void {
   const parts = relative(workspaceRoot, projectRoot).split('/')
   const topLevel = parts[0]
 
@@ -424,34 +339,13 @@ function cleanupNestedDeclarations(
 /**
  * Builds a library with any entry point configuration.
  *
- * BUILD PROCESS OVERVIEW:
- * -----------------------
- * 1. BUILD ENTRY POINTS: Each entry (., ./browser, ./node, etc.) is built
- *    separately via Rollup. This produces:
- *    - dist/index.esm.js + dist/index.cjs.js (root entry)
- *    - dist/browser/index.esm.js + dist/browser/index.cjs.js
- *    - etc.
- *
- * 2. GENERATE DECLARATIONS: A single tsc --emitDeclarationOnly pass creates
- *    all .d.ts files. These are then flattened from tsc's nested output
- *    structure to match the JavaScript output locations.
- *
- * 3. GENERATE PACKAGE.JSON: Creates a package.json with:
- *    - \"exports\" field mapping each entry point to its files
- *    - \"types\" fields pointing to .d.ts files
- *    - \"main\" and \"module\" for backward compatibility
- *
- * This unified approach handles all library patterns:\n * - Standard: Simple libraries with src/index.ts only
- * - Platform-specific: Libraries with browser/ and node/ variants
- * - Feature-based: Libraries with multiple domain modules
- * - Complex: Deep nested structures combining the above
- *
  * @param projectRoot - Absolute path to the project root
  * @param outputPath - Absolute path to output directory
  * @param tsConfigPath - Absolute path to tsconfig file
  * @param external - External dependencies to exclude from bundle
  * @param workspaceRoot - Absolute path to workspace root
  * @param discovery - Entry point discovery result
+ * @param includeBundle - Whether CDN bundle fields should be added to package.json
  */
 export async function buildUnifiedLibrary(
   projectRoot: string,
@@ -459,33 +353,19 @@ export async function buildUnifiedLibrary(
   tsConfigPath: string,
   external: string[],
   workspaceRoot: string,
-  discovery: EntryPointDiscovery
+  discovery: EntryPointDiscovery,
+  includeBundle = false
 ): Promise<void> {
   logger.info(`Building library (${discovery.category} structure, ${discovery.entryPoints.length} entry points)...`)
 
-  /*
-   * STEP 1: Build each entry point to ESM + CJS
-   * Sequential execution ensures consistent output and clear error messages.
-   * Parallel builds could be faster but make debugging harder.
-   */
   for (const entry of discovery.entryPoints) {
     await buildSingleEntryPoint(entry, outputPath, tsConfigPath, projectRoot, external)
   }
 
-  /*
-   * STEP 2: Generate TypeScript declarations
-   * Only runs for multi-entry libraries; root-only libs get declarations from Rollup.
-   * This ensures all declaration paths are consistent across entry points.
-   */
   generateDeclarationsUnified(projectRoot, outputPath, tsConfigPath, workspaceRoot, discovery)
 
-  /*
-   * STEP 3: Generate package.json with exports map
-   * This is what enables import '@hyperfrontend/lib/browser' to work.
-   * The exports field maps subpaths to their ESM/CJS/types files.
-   */
   const srcPkg = readProjectPackageJson(projectRoot)
-  generatePackageJsonFromDiscovery(srcPkg, outputPath, discovery)
+  generatePackageJsonFromDiscovery(srcPkg, outputPath, discovery, includeBundle)
 
   logger.info('Library build complete')
 }

--- a/tools/package/src/executors/build/lib/package-json.ts
+++ b/tools/package/src/executors/build/lib/package-json.ts
@@ -90,13 +90,23 @@ export function generateExportsFromDiscovery(
  * @param srcPkg - Source package.json contents
  * @param outputPath - Absolute path to output directory
  * @param discovery - Entry point discovery result
+ * @param includeBundle - Whether to include bundle/CDN fields
  */
 export function generatePackageJsonFromDiscovery(
   srcPkg: PackageJson,
   outputPath: string,
-  discovery: EntryPointDiscovery
+  discovery: EntryPointDiscovery,
+  includeBundle = false
 ): void {
   const exports = generateExportsFromDiscovery(discovery)
+
+  // Add bundle export if bundling is enabled
+  if (includeBundle) {
+    exports['./bundle'] = {
+      import: './bundle/index.umd.min.js',
+      require: './bundle/index.umd.min.js',
+    }
+  }
 
   // If there's a root entry, keep main/module/types for backwards compatibility
   if (discovery.hasRootEntry) {
@@ -105,6 +115,11 @@ export function generatePackageJsonFromDiscovery(
       main: './index.cjs.js',
       module: './index.esm.js',
       types: './index.d.ts',
+      sideEffects: false,
+      ...(includeBundle && {
+        unpkg: './bundle/index.umd.min.js',
+        jsdelivr: './bundle/index.umd.min.js',
+      }),
       exports,
     }
     writeOutputPackageJson(outputPath, distPkg)
@@ -117,6 +132,7 @@ export function generatePackageJsonFromDiscovery(
 
     const distPkg: PackageJson = {
       ...rest,
+      sideEffects: false,
       exports,
     }
     writeOutputPackageJson(outputPath, distPkg)

--- a/tools/package/src/executors/build/lib/types.ts
+++ b/tools/package/src/executors/build/lib/types.ts
@@ -23,6 +23,10 @@ export interface BuildExecutorOptions {
   assets?: (string | AssetConfig)[]
   /** External dependencies to exclude from the bundle */
   external?: string[]
+  /** Generate self-contained UMD and IIFE bundles for CDN distribution */
+  bundle?: boolean
+  /** Global variable name for UMD/IIFE bundles (e.g., 'HyperfrontendNexus') */
+  globalName?: string
 }
 
 /**

--- a/tools/package/src/executors/build/schema.json
+++ b/tools/package/src/executors/build/schema.json
@@ -36,6 +36,15 @@
       "description": "External dependencies to exclude from the bundle.",
       "items": { "type": "string" },
       "default": []
+    },
+    "bundle": {
+      "type": "boolean",
+      "description": "Generate self-contained UMD and IIFE bundles for CDN distribution. All dependencies are inlined.",
+      "default": false
+    },
+    "globalName": {
+      "type": "string",
+      "description": "Global variable name for UMD/IIFE bundles (e.g., 'HyperfrontendNexus'). Required when bundle is true."
     }
   },
   "required": []


### PR DESCRIPTION
# PR: Bundle Support

## Description

Add UMD/IIFE bundle generation capability to the build executor, enabling CDN distribution for libraries. Implements self-contained bundles with minification support.

## Related Issue

Implements Phase 2, 3, and 5 from BUILD_SYSTEM_TODO.md

## Type of Change

✨ Feature | ♻️ Refactor | 🔧 Build/Config

## Changes Made

### Build Executor Enhancements

- Add `bundle` and `globalName` options to executor schema
- Implement `buildBundledOutput()` for UMD + IIFE generation
- Add `@rollup/plugin-terser` for minification
- Generate minified variants (`.min.js`)
- Add CDN fields (`unpkg`, `jsdelivr`) to package.json when bundling
- Add `sideEffects: false` to all generated package.json files

### lib-nexus Configuration

- Enable bundling with `bundle: true` in project.json
- Set global variable name: `HyperfrontendNexus`
- Output: `dist/libs/nexus/bundle/` with UMD and IIFE formats

### lib-network-protocol Fixes

- Fix circular dependency imports in queue creators
- Change `import { createQueue } from '../creators'` to `import { createQueue } from './create-queue'`

### Code Quality

- Remove verbose inline comments from executor files
- Preserve JSDoc documentation

## Files Changed

| File                                                     | Change                                             |
| -------------------------------------------------------- | -------------------------------------------------- |
| `package.json`                                           | Add `@rollup/plugin-terser` dependency             |
| `tools/package/src/executors/build/schema.json`          | Add `bundle`, `globalName` options                 |
| `tools/package/src/executors/build/lib/types.ts`         | Add `bundle`, `globalName` to BuildExecutorOptions |
| `tools/package/src/executors/build/lib/build-unified.ts` | Add bundle build functions, cleanup comments       |
| `tools/package/src/executors/build/lib/package-json.ts`  | Add `sideEffects`, CDN fields support              |
| `tools/package/src/executors/build/executor.ts`          | Integrate bundle build, cleanup comments           |
| `libs/nexus/project.json`                                | Add `bundle: true`, `globalName`                   |
| `libs/network-protocol/src/lib/queue/creators/*.ts`      | Fix circular imports (6 files)                     |

## Testing

```bash
# Build lib-nexus with bundles
npx nx build lib-nexus

# Verify output structure
ls -la dist/libs/nexus/bundle/
# index.umd.js, index.umd.min.js, index.iife.js, index.iife.min.js

# Build all libraries
npx nx run-many -t=build --all
```

## Output Example

```
dist/libs/nexus/
├── index.esm.js
├── index.cjs.js
├── index.d.ts
├── bundle/
│   ├── index.umd.js      (~51KB)
│   ├── index.umd.min.js  (~17KB)
│   ├── index.iife.js     (~51KB)
│   └── index.iife.min.js (~16KB)
└── package.json
```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

- lib-network-protocol does not have bundling enabled (lacks root entry point)
- Bundle output includes source maps for debugging
- Minification reduces bundle size by ~67%

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
