### PR TITLE
fix(lib-network-protocol): resolve stop/resume race condition in queue

### DIFF
--- a/libs/network-protocol/CHANGELOG.md
+++ b/libs/network-protocol/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
-## 0.0.1 (2026-02-14)
+## 0.0.1 (2026-02-15)
 
 
 ### Bug Fixes
 
 * **lib-network-protocol:** fix imports ([5f6f6a9](https://github.com/AndrewRedican/hyperfrontend/commit/5f6f6a9b29f0ad148f9ad929ae5ca06d5da82299))
+* **lib-network-protocol:** resolve stop/resume race condition in queue ([cc9d83f](https://github.com/AndrewRedican/hyperfrontend/commit/cc9d83fe014e9540c4033722b75ae868d321811a))
 * **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))

--- a/libs/network-protocol/src/lib/queue/creators/create-queue.ts
+++ b/libs/network-protocol/src/lib/queue/creators/create-queue.ts
@@ -70,6 +70,10 @@ export function createQueue<T extends Record<string, any> = any>(processMessage:
 
     isProcessing = false
     currentMsg = null
+
+    if (!shouldStop && fifoQueue.size() > 0) {
+      processQueue()
+    }
   }
 
   const result: Queue<T> = {

--- a/libs/nexus/CHANGELOG.md
+++ b/libs/nexus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
-## 0.1.0 (2026-02-14)
+## 0.1.0 (2026-02-15)
 
 
 ### Features


### PR DESCRIPTION
## Description

Fixes a race condition in the network-protocol library's queue implementation where messages could get stuck when `stop()` and `resume()` are called in quick succession while new messages are being added.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->

Fixes #

## Type of Change

🐛 Bug fix

## Changes Made

- Added a check after the `processQueue` while loop completes to re-trigger processing if messages were added during the stop/resume transition
- This ensures the queue continues processing when `shouldStop` is false and there are pending messages

## Testing

- Existing unit tests continue to pass
- The fix handles edge cases where messages are enqueued while the queue transitions between stopped and running states

## Screenshots/Videos

N/A - Internal queue logic change

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

**Root Cause:** When `stop()` is called, the `processQueue` while loop exits because `shouldStop` becomes `true`. If `resume()` is called immediately after (setting `shouldStop` back to `false`), and the `isProcessing` flag is still `true` (before it gets set to `false`), the `resume()` function's check `!isProcessing && fifoQueue.size() > 0` would fail, causing `processQueue()` not to be called. Meanwhile, `processQueue()` would then finish by setting `isProcessing = false` without restarting, leaving queued messages unprocessed.

**Fix:** After clearing `isProcessing` and `currentMsg`, we now check if there are still messages to process and if we're not in a stopped state, then recursively call `processQueue()` to handle any pending messages.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
