### PR TITLE
Fix npm authentication issue for main pipeline

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -380,11 +380,15 @@ jobs:
         if: steps.affected.outputs.has_affected == 'true'
         run: npx nx affected -t=build --base=HEAD~1 --head=HEAD
 
+      - name: Configure npm authentication
+        if: steps.affected.outputs.has_affected == 'true'
+        run: npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}" --location=user
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish affected libraries
         if: steps.affected.outputs.has_affected == 'true'
         run: npx nx affected -t=publish --base=HEAD~1 --head=HEAD
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-github-release:
     name: github-release


### PR DESCRIPTION
## Description

Fix npm publish authentication failure in CI/CD pipeline by configuring npm to use the `NPM_TOKEN` secret.

## Related Issue

Fixes publish step failing with `npm error code ENEEDAUTH`

## Type of Change

🐛 Bug fix

## Changes Made

- Added "Configure npm authentication" step in `ci-main.yml` before the publish step
- Uses `npm config set` to securely configure the registry auth token

## Testing

- The fix follows npm's standard authentication pattern for CI/CD environments
- Will be validated when the workflow runs on main branch after merge

## Screenshots/Videos

N/A - CI/CD configuration change

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

The previous workflow passed `NPM_TOKEN` as an environment variable but npm requires explicit `.npmrc` configuration to use it. The `npm config set` approach is more secure than `echo` as npm handles token escaping and file permissions internally.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
