### PR TITLE
Fix missing hugo setup from main pipeline and add additional library badges

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -382,6 +382,8 @@ jobs:
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
+        with:
+          install-hugo: 'true'
 
       - name: Check for affected libraries
         id: affected

--- a/libs/cryptography/README.md
+++ b/libs/cryptography/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/cryptography">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/cryptography?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Production-grade cryptographic primitives with isomorphic APIs for browser and Node.js environments.

--- a/libs/logging/README.md
+++ b/libs/logging/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/logging">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/logging?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Structured logging with configurable severity levels and error-resilient execution.

--- a/libs/network-protocol/README.md
+++ b/libs/network-protocol/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/network-protocol">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/network-protocol?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Production-grade network protocol for secure, real-time cross-window and cross-process communication with built-in encryption, obfuscation, routing, and message queueing.

--- a/libs/nexus/README.md
+++ b/libs/nexus/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/nexus">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/nexus?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Secure cross-window communication library for micro-frontends with contract-validated messaging, origin-based security policies, and connection lifecycle management.

--- a/libs/state-machine/README.md
+++ b/libs/state-machine/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/state-machine">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/state-machine?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Lightweight, functional state management library with Redux-inspired actions/reducers, async operation orchestration, and lifecycle-aware component abstractions for predictable application state.

--- a/libs/utils/data/README.md
+++ b/libs/utils/data/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/data-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/data-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Comprehensive data structure manipulation with circular reference handling and custom class support.

--- a/libs/utils/function/README.md
+++ b/libs/utils/function/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/function-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/function-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Higher-order function utilities for behavioral modification and composition.

--- a/libs/utils/immutable-api/README.md
+++ b/libs/utils/immutable-api/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/immutable-api-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/immutable-api-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Decorators and utilities for creating immutable, tamper-proof object APIs.

--- a/libs/utils/list/README.md
+++ b/libs/utils/list/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/list-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/list-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Purpose-built collection utilities for queue management, filtering, and iteration patterns.

--- a/libs/utils/random-generator/README.md
+++ b/libs/utils/random-generator/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/random-generator-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/random-generator-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Statistical random distributions and UUID generation for simulations, testing, and procedural content.

--- a/libs/utils/string/README.md
+++ b/libs/utils/string/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/string-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/string-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Isomorphic string encoding utilities with unified APIs for browser and Node.js environments.

--- a/libs/utils/time/README.md
+++ b/libs/utils/time/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/time-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/time-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Functional time utilities for async operations, intervals, and time normalization.

--- a/libs/utils/ui/README.md
+++ b/libs/utils/ui/README.md
@@ -24,6 +24,11 @@
   <a href="https://github.com/AndrewRedican/hyperfrontend">
     <img src="https://img.shields.io/github/stars/AndrewRedican/hyperfrontend?style=flat-square" alt="GitHub stars">
   </a>
+  <a href="https://bundlephobia.com/package/@hyperfrontend/ui-utils">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hyperfrontend/ui-utils?style=flat-square" alt="Bundle Size">
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen?style=flat-square&logo=node.js" alt="Node Version">
+  <img src="https://img.shields.io/badge/tree%20shakeable-%E2%9C%93-success?style=flat-square" alt="Tree Shakeable">
 </p>
 
 Modular DOM utilities for dynamic styling, gesture detection, element lifecycle, and color manipulation.


### PR DESCRIPTION
## Description

Added three informative badges to all 13 publishable library READMEs to improve package discoverability and help developers make informed decisions about using these libraries. The badges showcase bundle size, Node.js compatibility, and tree-shaking support.

## Related Issue

N/A - Documentation enhancement

## Type of Change

📝 Docs

## Changes Made

- Added **Bundle Size** badge (with Bundlephobia link) to all 13 publishable libraries
- Added **Node Version ≥18.0.0** badge showing minimum Node.js compatibility requirement
- Added **Tree Shakeable** badge highlighting `sideEffects: false` configuration
- Badges added to the following libraries:
  - `@hyperfrontend/nexus`
  - `@hyperfrontend/cryptography`
  - `@hyperfrontend/logging`
  - `@hyperfrontend/state-machine`
  - `@hyperfrontend/network-protocol`
  - `@hyperfrontend/function-utils`
  - `@hyperfrontend/string-utils`
  - `@hyperfrontend/data-utils`
  - `@hyperfrontend/list-utils`
  - `@hyperfrontend/time-utils`
  - `@hyperfrontend/ui-utils`
  - `@hyperfrontend/random-generator-utils`
  - `@hyperfrontend/immutable-api-utils`

## Testing

- [x] Verified badge markdown syntax is correct
- [x] Confirmed all 13 library READMEs were updated consistently
- [x] Badges positioned after GitHub stars badge and before library description

## Screenshots/Videos

The badges appear in the header section of each README, displaying:
1. Bundle size information from Bundlephobia with clickable link for detailed analysis
2. Node.js version requirement (≥18.0.0) with Node.js logo
3. Tree shakeable indicator with checkmark

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed (N/A - documentation only)
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

**Benefits:**
- **Bundle Size badge** helps developers evaluate package weight impact before installation
- **Node Version badge** clearly communicates minimum runtime requirements
- **Tree Shakeable badge** highlights that unused exports can be eliminated during bundling

These badges will trigger the first publish for all 13 libraries when merged to main, as the README changes constitute new release content.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
