### PR TITLE
Post version migration fixes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,7 @@ This directory contains the CI/CD workflows for the hyperfrontend monorepo.
 - `test`: Testing with coverage upload (affected only)
 - `e2e`: E2E tests (affected only)
 - `ci-status`: Aggregates results and provides final status
+- `version-check`: Validates version bumps were applied locally (runs after ci-status)
 
 ### CI - Main Branch ([ci-main.yml](./ci-main.yml))
 
@@ -352,9 +353,10 @@ The `security-scan.yml` workflow runs CodeQL analysis in parallel with the PR wo
 
 **Important Notes**:
 
-- The version-validation job runs after all CI checks pass
-- Version commits use `[skip ci]` to prevent workflow retrigger
-- Pushes by `github-actions[bot]` using `GITHUB_TOKEN` do not trigger workflows by design
+- The `version-check` job runs after all CI checks pass (validation only, no commits)
+- Version bumps are applied locally via lefthook pre-push hooks
+- CI validates that expected versions match committed versions
+- Uses GITHUB_TOKEN with read-only contents permission
 
 ## Maintenance
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,168 +36,11 @@ jobs:
           base-ref: origin/${{ github.base_ref }}
           head-ref: HEAD
 
-  format:
-    name: format
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run format check
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: format
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run lint
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: lint
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-  typecheck:
-    name: typecheck
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run typecheck
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: typecheck
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-  build:
-    name: build
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run build
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: build
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dist-pr
-          path: dist/
-          retention-days: 3
-          if-no-files-found: warn
-
-  test:
-    name: test
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run tests
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: test
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: coverage-reports-pr
-          path: coverage/
-          retention-days: 7
-
-  e2e:
-    name: e2e
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.has-affected == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup monorepo
-        uses: ./.github/actions/setup-monorepo
-
-      - name: Run E2E tests
-        uses: ./.github/actions/run-checks
-        with:
-          check-type: e2e
-          affected-only: 'true'
-          affected-projects: ${{ needs.setup.outputs.affected-projects }}
-
-  ci-status:
-    name: status
-    runs-on: ubuntu-latest
-    needs: [setup, format, lint, typecheck, build, test, e2e]
-    if: always()
-    steps:
-      - name: Check CI status
-        run: |
-          # If no affected projects, pass
-          if [ "${{ needs.setup.outputs.has-affected }}" != "true" ]; then
-            echo "✅ No affected projects - PR checks passed"
-            exit 0
-          fi
-
-          # Check if any required job failed
-          if [ "${{ needs.format.result }}" = "failure" ] || \
-             [ "${{ needs.lint.result }}" = "failure" ] || \
-             [ "${{ needs.typecheck.result }}" = "failure" ] || \
-             [ "${{ needs.build.result }}" = "failure" ] || \
-             [ "${{ needs.test.result }}" = "failure" ] || \
-             [ "${{ needs.e2e.result }}" = "failure" ]; then
-            echo "❌ One or more CI checks failed"
-            exit 1
-          fi
-
-          echo "✅ All CI checks passed"
-
   version-check:
     name: version-check
     runs-on: ubuntu-latest
-    needs: [ci-status]
-    if: needs.ci-status.result == 'success'
+    needs: [setup]
+    if: needs.setup.outputs.has-affected == 'true'
     permissions:
       contents: read # Read-only - no commits
       pull-requests: write # For failure comments
@@ -350,3 +193,161 @@ jobs:
               });
               console.log('Created new version-check comment');
             }
+
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    needs: [setup, version-check]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run format check
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: format
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    needs: [setup, version-check]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run lint
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: lint
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    needs: [setup, version-check]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run typecheck
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: typecheck
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: [setup, version-check, typecheck]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success' && needs.typecheck.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run build
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: build
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-pr
+          path: dist/
+          retention-days: 3
+          if-no-files-found: warn
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: [setup, version-check]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run tests
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: test
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-reports-pr
+          path: coverage/
+          retention-days: 7
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    needs: [setup, version-check, build]
+    if: always() && needs.setup.outputs.has-affected == 'true' && needs.version-check.result == 'success' && needs.build.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup monorepo
+        uses: ./.github/actions/setup-monorepo
+
+      - name: Run E2E tests
+        uses: ./.github/actions/run-checks
+        with:
+          check-type: e2e
+          affected-only: 'true'
+          affected-projects: ${{ needs.setup.outputs.affected-projects }}
+
+  ci-status:
+    name: status
+    runs-on: ubuntu-latest
+    needs: [setup, version-check, format, lint, typecheck, build, test, e2e]
+    if: always()
+    steps:
+      - name: Check CI status
+        run: |
+          # If no affected projects, pass
+          if [ "${{ needs.setup.outputs.has-affected }}" != "true" ]; then
+            echo "✅ No affected projects - PR checks passed"
+            exit 0
+          fi
+
+          # Check if any required job failed
+          if [ "${{ needs.version-check.result }}" = "failure" ] || \
+             [ "${{ needs.format.result }}" = "failure" ] || \
+             [ "${{ needs.lint.result }}" = "failure" ] || \
+             [ "${{ needs.typecheck.result }}" = "failure" ] || \
+             [ "${{ needs.build.result }}" = "failure" ] || \
+             [ "${{ needs.test.result }}" = "failure" ] || \
+             [ "${{ needs.e2e.result }}" = "failure" ]; then
+            echo "❌ One or more CI checks failed"
+            exit 1
+          fi
+
+          echo "✅ All CI checks passed"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -193,176 +193,134 @@ jobs:
 
           echo "✅ All CI checks passed"
 
-  version-validation:
+  version-check:
     name: version-check
     runs-on: ubuntu-latest
     needs: [ci-status]
     if: needs.ci-status.result == 'success'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read # Read-only - no commits
+      pull-requests: write # For failure comments
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.PR_PAT }}
+          # Uses default GITHUB_TOKEN - no PAT needed for read-only validation
 
       - name: Setup monorepo
         uses: ./.github/actions/setup-monorepo
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Check and update versions
+      - name: Validate versions
         id: version-check
         run: |
-          echo "Checking versions for affected libraries..."
+          echo "Validating versions for affected libraries..."
 
           # Get affected library projects that have a version target
           AFFECTED=$(npx nx show projects --affected --base=origin/${{ github.base_ref }} --head=HEAD --type=lib --with-target=version 2>/dev/null || echo "")
 
           if [ -z "$AFFECTED" ]; then
-            echo "No affected libraries"
-            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "No affected libraries with version target"
+            echo "status=valid" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           echo "Affected libraries: $AFFECTED"
 
-          # Run idempotent version check for each library with --collectFiles
-          # Track different statuses separately for accurate reporting
-          # Use comma-separated format to match version executor's isVersionCommit() parsing
-          UPDATED=""
+          # Run version-check for each library (validation only, no changes)
+          VALID=""
+          INVALID=""
           SKIPPED=""
-          UNCHANGED=""
-          FAILED=""
-          ALL_FILES=""
+          MESSAGES=""
 
           for lib in $AFFECTED; do
             echo "Checking $lib..."
-            RESULT=$(npx nx version $lib --collectFiles 2>&1)
-            EXIT_CODE=$?
-
-            if [ $EXIT_CODE -ne 0 ]; then
-              if [ -z "$FAILED" ]; then FAILED="$lib"; else FAILED="$FAILED, $lib"; fi
-              echo "  ✗ $lib: failed"
-              continue
-            fi
-
-            if echo "$RESULT" | grep -qE "Flow success"; then
-              if [ -z "$UPDATED" ]; then UPDATED="$lib"; else UPDATED="$UPDATED, $lib"; fi
-              # Collect modified files from MODIFIED: lines
-              FILES=$(echo "$RESULT" | grep "^MODIFIED:" | cut -d: -f2 | tr '\n' ' ')
-              ALL_FILES="$ALL_FILES $FILES"
-              echo "  ✓ $lib: version updated"
-            elif echo "$RESULT" | grep -qE "No release needed|already published|Skipping"; then
-              if [ -z "$SKIPPED" ]; then SKIPPED="$lib"; else SKIPPED="$SKIPPED, $lib"; fi
-              echo "  ○ $lib: already versioned"
+            # Capture both stdout and stderr, check exit code
+            if RESULT=$(npx nx version-check "$lib" 2>&1); then
+              # Exit code 0 - validation passed or skipped
+              if echo "$RESULT" | grep -q "version.*matches expected"; then
+                if [ -z "$VALID" ]; then VALID="$lib"; else VALID="$VALID, $lib"; fi
+                echo "  ✓ $lib: version valid"
+              else
+                # Skipped (no bump needed, already published, etc.)
+                if [ -z "$SKIPPED" ]; then SKIPPED="$lib"; else SKIPPED="$SKIPPED, $lib"; fi
+                echo "  ○ $lib: skipped (no changes needed)"
+              fi
             else
-              if [ -z "$UNCHANGED" ]; then UNCHANGED="$lib"; else UNCHANGED="$UNCHANGED, $lib"; fi
-              echo "  ○ $lib: no version change needed"
+              # Exit code non-zero - validation failed
+              if [ -z "$INVALID" ]; then INVALID="$lib"; else INVALID="$INVALID, $lib"; fi
+              echo "  ✗ $lib: version mismatch"
+              # Capture the error output for the PR comment
+              MESSAGES="${MESSAGES}\n\n### $lib\n\`\`\`\n${RESULT}\n\`\`\`"
             fi
           done
 
-          # Handle failures - abort cleanly by discarding all changes
-          if [ -n "$FAILED" ]; then
-            echo "❌ Version failed for: $FAILED"
-            echo "Discarding all changes..."
-            git checkout .
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "failed_libs=${FAILED}" >> $GITHUB_OUTPUT
+          # Output results
+          echo "valid_libs=${VALID}" >> $GITHUB_OUTPUT
+          echo "invalid_libs=${INVALID}" >> $GITHUB_OUTPUT
+          echo "skipped_libs=${SKIPPED}" >> $GITHUB_OUTPUT
+
+          if [ -n "$INVALID" ]; then
+            echo "status=invalid" >> $GITHUB_OUTPUT
+            # Store messages in a file to avoid GitHub Actions output escaping issues
+            echo -e "$MESSAGES" > /tmp/version-check-messages.txt
+            echo "❌ Version validation failed for: $INVALID"
             exit 1
           fi
 
-          # Output all tracking variables for PR comment
-          echo "skipped_libs=${SKIPPED}" >> $GITHUB_OUTPUT
-          echo "unchanged_libs=${UNCHANGED}" >> $GITHUB_OUTPUT
-          echo "all_files=${ALL_FILES}" >> $GITHUB_OUTPUT
+          echo "status=valid" >> $GITHUB_OUTPUT
+          echo "✅ All version checks passed"
 
-          if [ -n "$UPDATED" ]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "updated_libs=${UPDATED}" >> $GITHUB_OUTPUT
-          else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "updated_libs=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit version updates
-        if: steps.version-check.outputs.needs_update == 'true'
-        run: |
-          # Stage all collected files (deferred staging from --collectFiles)
-          ALL_FILES="${{ steps.version-check.outputs.all_files }}"
-
-          if [ -z "$ALL_FILES" ]; then
-            echo "No files to stage"
-            exit 0
-          fi
-
-          git add $ALL_FILES
-
-          # Check if there are changes to commit
-          if git diff --staged --quiet; then
-            echo "No staged changes to commit"
-            exit 0
-          fi
-
-          # Commit the changes with [skip ci] to prevent retrigger
-          # Format: chore: update versions for lib-a, lib-b [skip ci]
-          git commit -m "chore: update versions for ${{ steps.version-check.outputs.updated_libs }} [skip ci]"
-
-          # Push to the PR branch
-          git push
-
-          echo "✓ Pushed version updates to PR"
-
-      - name: Comment on PR
-        if: steps.version-check.outputs.needs_update == 'true'
+      - name: Comment on PR (failure only)
+        if: failure() && steps.version-check.outputs.status == 'invalid'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const COMMENT_MARKER = '<!-- hyperfrontend-version-bot -->';
+            const fs = require('fs');
+            const COMMENT_MARKER = '<!-- hyperfrontend-version-check -->';
 
-            // Parse outputs - handle empty strings gracefully
-            // Format is comma-separated: "lib-a, lib-b, lib-c"
+            // Parse outputs
             const parseLibs = (str) => (str || '').split(',').map(s => s.trim()).filter(Boolean);
-            const updatedLibs = parseLibs('${{ steps.version-check.outputs.updated_libs }}');
+            const invalidLibs = parseLibs('${{ steps.version-check.outputs.invalid_libs }}');
+            const validLibs = parseLibs('${{ steps.version-check.outputs.valid_libs }}');
             const skippedLibs = parseLibs('${{ steps.version-check.outputs.skipped_libs }}');
-            const unchangedLibs = parseLibs('${{ steps.version-check.outputs.unchanged_libs }}');
 
-            // Build table rows
-            const tableRows = [];
-            for (const lib of updatedLibs) {
-              tableRows.push('| `' + lib + '` | ✅ Version bumped |');
-            }
-            for (const lib of skippedLibs) {
-              tableRows.push('| `' + lib + '` | ⏭️ Already versioned |');
-            }
-            for (const lib of unchangedLibs) {
-              tableRows.push('| `' + lib + '` | ○ No changes needed |');
+            // Read detailed messages if available
+            let detailedMessages = '';
+            try {
+              detailedMessages = fs.readFileSync('/tmp/version-check-messages.txt', 'utf8');
+            } catch (e) {
+              // File may not exist
             }
 
-            // Build comment body using array join to avoid YAML parsing issues
+            // Build comment body
             const bodyParts = [
               COMMENT_MARKER,
-              '## 📦 Version Check Results',
+              '## ❌ Version Check Failed',
               '',
-              '| Library | Status |',
-              '|---------|--------|',
-              tableRows.join('\n'),
+              '**Libraries with version issues:** ' + invalidLibs.join(', '),
               '',
-              '### Summary',
-              '- **' + updatedLibs.length + '** libraries updated',
-              '- **' + skippedLibs.length + '** already versioned',
-              '- **' + unchangedLibs.length + '** unchanged',
+              '### How to Fix',
               '',
-              updatedLibs.length > 0 ? 'These changes have been committed to this PR. Please review the CHANGELOG entries.' : '',
+              '1. Pull latest: `git pull origin ${{ github.head_ref }}`',
+              '2. Run versioning for affected libraries:',
+              invalidLibs.map(lib => '   ```bash\n   npx nx version ' + lib + '\n   ```').join('\n'),
+              '3. Amend your commit: `git commit --amend --no-edit`',
+              '4. Force push: `git push --force-with-lease`',
+              '',
+              '**Or** push without `--no-verify` to let lefthook handle versioning automatically.',
               '',
               '---',
-              '*This check was performed automatically by the CI version validation.*'
+              '',
+              '<details>',
+              '<summary>Validation Details</summary>',
+              '',
+              detailedMessages || '_No detailed messages available_',
+              '',
+              '</details>',
+              '',
+              '---',
+              '*This validation ensures version bumps are applied locally before merge.*'
             ];
             const body = bodyParts.join('\n');
 
@@ -382,7 +340,7 @@ jobs:
                 repo: context.repo.repo,
                 body,
               });
-              console.log('Updated existing version comment');
+              console.log('Updated existing version-check comment');
             } else {
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
@@ -390,5 +348,5 @@ jobs:
                 repo: context.repo.repo,
                 body,
               });
-              console.log('Created new version comment');
+              console.log('Created new version-check comment');
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ Version bumps happen automatically via **lefthook pre-push hooks**. When you `gi
 1. lefthook runs typecheck, lint, and tests
 2. For each affected library, it runs `nx version <lib> --collectFiles`
 3. Package.json and CHANGELOG.md are updated
-4. A version commit is created: `chore: update versions for lib-xxx [skip ci]`
+4. A version commit is created: `chore: update versions for lib-xxx`
 5. Push proceeds with both your changes and the version commit
 
 **What this means for you:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,21 +266,43 @@ Output goes to `dist/libs/<library>/` with ESM + CJS formats.
 
 ### Versioning (Automatic)
 
-Version bumps happen automatically via a post-commit hook. When you make a commit with a conventional commit message (`feat:`, `fix:`, etc.), the hook:
+Version bumps happen automatically via **lefthook pre-push hooks**. When you `git push`:
 
-1. Detects affected libraries
-2. Bumps version and updates CHANGELOG
-3. Amends your commit to include the changes
+1. lefthook runs typecheck, lint, and tests
+2. For each affected library, it runs `nx version <lib> --collectFiles`
+3. Package.json and CHANGELOG.md are updated
+4. A version commit is created: `chore: update versions for lib-xxx [skip ci]`
+5. Push proceeds with both your changes and the version commit
 
-To manually version (rarely needed):
+**What this means for you:**
+
+- Just write conventional commit messages (`feat:`, `fix:`, `docs:`, etc.)
+- Push normally — versioning happens automatically
+- Your PR will include the version bump already applied
+
+**If you need to bypass versioning (not recommended):**
+
+```bash
+# This will cause CI to fail with remediation instructions
+git push --no-verify
+```
+
+**To manually version (rarely needed):**
 
 ```bash
 # Preview version changes (dry run)
-npx nx version lib-nexus --dryRun --skipCommit
+npx nx version lib-nexus --dryRun
 
-# Version affected libraries
-npx nx affected -t version --skipCommit
+# Manually run versioning
+npx nx version lib-nexus
+
+# Validate version state (what CI runs)
+npx nx version-check lib-nexus
 ```
+
+**CI Validation:**
+
+CI runs `version-check` to validate that versions were correctly applied. If you pushed with `--no-verify` (bypassing lefthook), CI will fail and comment on your PR with instructions to fix.
 
 ### Publishing (Maintainers)
 
@@ -347,8 +369,11 @@ When you open a pull request:
 
 - **Affected Projects**: Nx calculates which projects are affected by your changes
 - **Fast Checks**: Only affected projects are validated (format, lint, build, test)
+- **Version Check**: Validates that version bumps were applied by lefthook
 - **Typical Duration**: < 10 minutes
 - **Status Check**: "CI Status Check" must pass to merge
+
+If the version-check fails, CI will comment on your PR with instructions to fix.
 
 #### Main Branch Workflow
 

--- a/apps/package-e2e/immutable-api-utils/package.json
+++ b/apps/package-e2e/immutable-api-utils/package.json
@@ -7,7 +7,7 @@
     "pack-install": "cd ../../../dist/libs/utils/immutable-api && npm pack && cd - && npm install ../../../dist/libs/utils/immutable-api/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "file:../../../tmp/e2e-packs/hyperfrontend-immutable-api-utils-0.1.2.tgz"
+    "@hyperfrontend/immutable-api-utils": "file:../../../tmp/e2e-packs/hyperfrontend-immutable-api-utils-0.1.3.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/apps/package-e2e/immutable-api-utils/package.json
+++ b/apps/package-e2e/immutable-api-utils/package.json
@@ -7,7 +7,7 @@
     "pack-install": "cd ../../../dist/libs/utils/immutable-api && npm pack && cd - && npm install ../../../dist/libs/utils/immutable-api/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "file:../../../tmp/e2e-packs/hyperfrontend-immutable-api-utils-0.1.1.tgz"
+    "@hyperfrontend/immutable-api-utils": "file:../../../tmp/e2e-packs/hyperfrontend-immutable-api-utils-0.1.2.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/apps/package-e2e/versioning/package.json
+++ b/apps/package-e2e/versioning/package.json
@@ -6,7 +6,7 @@
     "pack-install": "cd ../../../dist/libs/versioning && npm pack && cd - && npm install ../../../dist/libs/versioning/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.1.0.tgz"
+    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.2.0.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/apps/package-e2e/versioning/package.json
+++ b/apps/package-e2e/versioning/package.json
@@ -6,7 +6,7 @@
     "pack-install": "cd ../../../dist/libs/versioning && npm pack && cd - && npm install ../../../dist/libs/versioning/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.2.0.tgz"
+    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.3.0.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/eslint.base.config.cjs
+++ b/eslint.base.config.cjs
@@ -213,6 +213,7 @@ module.exports = [
     rules: {
       'workspace/lib-project-metadata': 'error',
       'workspace/lib-project-bundle-config': 'error',
+      'workspace/lib-project-version-targets': 'error',
       'workspace/lib-e2e-project-required': 'error',
     },
   },

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,19 @@
 # Lefthook Configuration
 # See: https://github.com/evilmartians/lefthook
+#
+# Versioning Strategy:
+# ====================
+# Version bumps are applied locally via the pre-push `version` command below.
+# This is the SOURCE OF TRUTH for version bumps - CI only validates, it does NOT
+# create version commits. The workflow is:
+#
+#   1. Developer commits changes
+#   2. On `git push`, lefthook runs versioning for affected libraries
+#   3. Version commit is created automatically: "chore: update versions for lib-x [skip ci]"
+#   4. Push proceeds with both commits
+#   5. CI runs `version-check` to validate versions are correct
+#
+# If you bypass lefthook with --no-verify, CI will fail with remediation instructions.
 
 pre-commit:
   parallel: false
@@ -26,6 +40,22 @@ pre-push:
     test:
       run: CI=1 npx nx run-many -t=test --skip-nx-cache
       fail_text: 'Tests failed. Fix failing tests before pushing.'
+
+    # =========================================================================
+    # Version Command - SOURCE OF TRUTH for version bumps
+    # =========================================================================
+    # This command calculates and applies version bumps based on conventional
+    # commits. It runs AFTER all other pre-push checks (typecheck, lint, test).
+    #
+    # What it does:
+    #   - Detects affected libraries via `nx show projects --affected`
+    #   - Runs `nx version $lib --collectFiles` for each
+    #   - Updates package.json, CHANGELOG.md, and dependent package refs
+    #   - Creates a version commit: "chore: update versions for lib-x [skip ci]"
+    #
+    # CI validates this with `version-check` - it does NOT create version commits.
+    # If you skip this hook (--no-verify), CI will fail and guide you to fix it.
+    # =========================================================================
     version:
       run: |
         # Skip versioning when pushing to main - CI handles main branch
@@ -122,4 +152,15 @@ pre-push:
           echo "✅ No version changes needed"
         fi
         rm -f "$TAGS_BEFORE_FILE"
-      fail_text: 'Version check failed. You may need to resolve conflicts or run versioning manually.'
+      fail_text: |
+        ❌ Version bump failed during pre-push.
+
+        How to fix:
+        1. Check the error output above for details
+        2. If there are conflicts, resolve them first
+        3. Run versioning manually: npx nx version <lib-name> --verbose
+        4. Stage and commit the changes
+        5. Push again
+
+        If you need to bypass (not recommended): git push --no-verify
+        Note: CI will fail if versions are not properly applied.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@
 #
 #   1. Developer commits changes
 #   2. On `git push`, lefthook runs versioning for affected libraries
-#   3. Version commit is created automatically: "chore: update versions for lib-x [skip ci]"
+#   3. Version commit is created automatically: "chore: update versions for lib-x"
 #   4. Push proceeds with both commits
 #   5. CI runs `version-check` to validate versions are correct
 #
@@ -51,17 +51,17 @@ pre-push:
     #   - Detects affected libraries via `nx show projects --affected`
     #   - Runs `nx version $lib --collectFiles` for each
     #   - Updates package.json, CHANGELOG.md, and dependent package refs
-    #   - Creates a version commit: "chore: update versions for lib-x [skip ci]"
+    #   - Creates a version commit: "chore: update versions for lib-x"
     #
     # CI validates this with `version-check` - it does NOT create version commits.
     # If you skip this hook (--no-verify), CI will fail and guide you to fix it.
     # =========================================================================
     version:
       run: |
-        # Skip versioning when pushing to main - CI handles main branch
+        # Skip versioning when pushing to main - versions should already be applied via PR
         BRANCH=$(git branch --show-current)
         if [ "$BRANCH" = "main" ]; then
-          echo "⏭️ Skipping versioning on main branch (CI will handle)"
+          echo "⏭️ Skipping versioning on main branch (versions come from merged PRs)"
           exit 0
         fi
 
@@ -141,11 +141,10 @@ pre-push:
           git add $ALL_FILES
 
           # Commit message matches executor's isVersionCommit() Pattern 2: chore: update versions for lib-a, lib-b
-          # Use [skip ci] to prevent PR workflow retrigger when pushed
           if [ -n "$BUMPED" ]; then
-            git commit -m "chore: update versions for $BUMPED [skip ci]" --no-verify
+            git commit -m "chore: update versions for $BUMPED" --no-verify
           else
-            git commit -m "chore: update versions for affected libs [skip ci]" --no-verify
+            git commit -m "chore: update versions for affected libs" --no-verify
           fi
           echo "✅ Version updates committed"
         else

--- a/libs/cryptography/CHANGELOG.md
+++ b/libs/cryptography/CHANGELOG.md
@@ -23,21 +23,21 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4 - 2026-03-08
+## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.3...lib-cryptography@0.0.4) - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-cryptography:** correct package exports ([651fae9](https://github.com/AndrewRedican/hyperfrontend/commit/651fae94622e6300f6351216f3be342aaa9e4962))
 - **lib-cryptography:** prevent runtime modification of security-sensitive objects ([4af1411](https://github.com/AndrewRedican/hyperfrontend/commit/4af14115c6128fc5939539282f49abf26723f9ac))
 
-## 0.0.3 - 2026-03-02
+## [0.0.3](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.2...lib-cryptography@0.0.3) - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-cryptography:** correct package exports ([651fae9](https://github.com/AndrewRedican/hyperfrontend/commit/651fae94622e6300f6351216f3be342aaa9e4962))
 - **lib-cryptography:** prevent runtime modification of security-sensitive objects ([4af1411](https://github.com/AndrewRedican/hyperfrontend/commit/4af14115c6128fc5939539282f49abf26723f9ac))
 
-## 0.0.2 - 2026-02-26
+## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.1...lib-cryptography@0.0.2) - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/cryptography/CHANGELOG.md
+++ b/libs/cryptography/CHANGELOG.md
@@ -23,21 +23,21 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4
+## 0.0.4 - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-cryptography:** correct package exports ([651fae9](https://github.com/AndrewRedican/hyperfrontend/commit/651fae94622e6300f6351216f3be342aaa9e4962))
 - **lib-cryptography:** prevent runtime modification of security-sensitive objects ([4af1411](https://github.com/AndrewRedican/hyperfrontend/commit/4af14115c6128fc5939539282f49abf26723f9ac))
 
-## 0.0.3
+## 0.0.3 - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-cryptography:** correct package exports ([651fae9](https://github.com/AndrewRedican/hyperfrontend/commit/651fae94622e6300f6351216f3be342aaa9e4962))
 - **lib-cryptography:** prevent runtime modification of security-sensitive objects ([4af1411](https://github.com/AndrewRedican/hyperfrontend/commit/4af14115c6128fc5939539282f49abf26723f9ac))
 
-## 0.0.2
+## 0.0.2 - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/cryptography/CHANGELOG.md
+++ b/libs/cryptography/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.1.0 - 2026-03-16
+## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.4...lib-cryptography@0.1.0) - 2026-03-16
 
 ### Features
 

--- a/libs/cryptography/CHANGELOG.md
+++ b/libs/cryptography/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.4...lib-cryptography@0.1.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-cryptography@0.0.3...lib-cryptography@0.0.4) - 2026-03-08
 
@@ -42,6 +27,6 @@ All notable changes to this project will be documented in this file.
 
 ## 0.0.1 - 2026-02-15
 
-### Bug Fixes
+### Other
 
-- **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))
+- Initial release

--- a/libs/cryptography/package.json
+++ b/libs/cryptography/package.json
@@ -39,7 +39,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/string-utils": "0.0.4",
     "@hyperfrontend/time-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "funding": {
     "type": "github",

--- a/libs/cryptography/package.json
+++ b/libs/cryptography/package.json
@@ -39,7 +39,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/string-utils": "0.0.4",
     "@hyperfrontend/time-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "funding": {
     "type": "github",

--- a/libs/cryptography/project.json
+++ b/libs/cryptography/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/logging/CHANGELOG.md
+++ b/libs/logging/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.4...lib-logging@0.1.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.3...lib-logging@0.0.4) - 2026-03-08
 
@@ -40,6 +25,6 @@ All notable changes to this project will be documented in this file.
 
 ## 0.0.1 - 2026-02-15
 
-### Bug Fixes
+### Other
 
-- **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))
+- Initial release

--- a/libs/logging/CHANGELOG.md
+++ b/libs/logging/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4 - 2026-03-08
+## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.3...lib-logging@0.0.4) - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-logging:** correct package exports ([3a7fe5a](https://github.com/AndrewRedican/hyperfrontend/commit/3a7fe5a377743bdd7da66f93a38ec416070572b3))
 
-## 0.0.3 - 2026-03-02
+## [0.0.3](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.2...lib-logging@0.0.3) - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-logging:** correct package exports ([3a7fe5a](https://github.com/AndrewRedican/hyperfrontend/commit/3a7fe5a377743bdd7da66f93a38ec416070572b3))
 
-## 0.0.2 - 2026-02-26
+## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.1...lib-logging@0.0.2) - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/logging/CHANGELOG.md
+++ b/libs/logging/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.1.0 - 2026-03-16
+## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.4...lib-logging@0.1.0) - 2026-03-16
 
 ### Features
 

--- a/libs/logging/CHANGELOG.md
+++ b/libs/logging/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4
+## 0.0.4 - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-logging:** correct package exports ([3a7fe5a](https://github.com/AndrewRedican/hyperfrontend/commit/3a7fe5a377743bdd7da66f93a38ec416070572b3))
 
-## 0.0.3
+## 0.0.3 - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-logging:** correct package exports ([3a7fe5a](https://github.com/AndrewRedican/hyperfrontend/commit/3a7fe5a377743bdd7da66f93a38ec416070572b3))
 
-## 0.0.2
+## 0.0.2 - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
     "@hyperfrontend/function-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   }
 }

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
     "@hyperfrontend/function-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   }
 }

--- a/libs/logging/project.json
+++ b/libs/logging/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/network-protocol/CHANGELOG.md
+++ b/libs/network-protocol/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4
+## 0.0.4 - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-network-protocol:** correct package exports ([5b8ed3c](https://github.com/AndrewRedican/hyperfrontend/commit/5b8ed3c15a46716f973ab09907913091735160f2))
 
-## 0.0.3
+## 0.0.3 - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-network-protocol:** correct package exports ([5b8ed3c](https://github.com/AndrewRedican/hyperfrontend/commit/5b8ed3c15a46716f973ab09907913091735160f2))
 
-## 0.0.2
+## 0.0.2 - 2026-02-26
 
 ### Bug Fixes
 

--- a/libs/network-protocol/CHANGELOG.md
+++ b/libs/network-protocol/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4 - 2026-03-08
+## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.3...lib-network-protocol@0.0.4) - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-network-protocol:** correct package exports ([5b8ed3c](https://github.com/AndrewRedican/hyperfrontend/commit/5b8ed3c15a46716f973ab09907913091735160f2))
 
-## 0.0.3 - 2026-03-02
+## [0.0.3](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.2...lib-network-protocol@0.0.3) - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-network-protocol:** correct package exports ([5b8ed3c](https://github.com/AndrewRedican/hyperfrontend/commit/5b8ed3c15a46716f973ab09907913091735160f2))
 
-## 0.0.2 - 2026-02-26
+## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.1...lib-network-protocol@0.0.2) - 2026-02-26
 
 ### Bug Fixes
 

--- a/libs/network-protocol/CHANGELOG.md
+++ b/libs/network-protocol/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.4...lib-network-protocol@0.1.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.3...lib-network-protocol@0.0.4) - 2026-03-08
 
@@ -47,4 +32,3 @@ All notable changes to this project will be documented in this file.
 
 - **lib-network-protocol:** fix imports ([5f6f6a9](https://github.com/AndrewRedican/hyperfrontend/commit/5f6f6a9b29f0ad148f9ad929ae5ca06d5da82299))
 - **lib-network-protocol:** resolve stop/resume race condition in queue ([cc9d83f](https://github.com/AndrewRedican/hyperfrontend/commit/cc9d83fe014e9540c4033722b75ae868d321811a))
-- **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))

--- a/libs/network-protocol/CHANGELOG.md
+++ b/libs/network-protocol/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.1.0 - 2026-03-16
+## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-network-protocol@0.0.4...lib-network-protocol@0.1.0) - 2026-03-16
 
 ### Features
 

--- a/libs/network-protocol/package.json
+++ b/libs/network-protocol/package.json
@@ -11,7 +11,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/string-utils": "0.0.4",
     "@hyperfrontend/time-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "exports": {
     "./browser/channel": "./src/browser/channel/index.js",

--- a/libs/network-protocol/package.json
+++ b/libs/network-protocol/package.json
@@ -11,7 +11,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/string-utils": "0.0.4",
     "@hyperfrontend/time-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "exports": {
     "./browser/channel": "./src/browser/channel/index.js",

--- a/libs/network-protocol/project.json
+++ b/libs/network-protocol/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:protocol", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/nexus/CHANGELOG.md
+++ b/libs/nexus/CHANGELOG.md
@@ -23,10 +23,10 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 1.0.1 - 2026-03-08
+## [1.0.1](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@1.0.0...lib-nexus@1.0.1) - 2026-03-08
 
 
-## 1.0.0 - 2026-03-02
+## [1.0.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@0.1.1...lib-nexus@1.0.0) - 2026-03-02
 
 ### Bug Fixes
 
@@ -40,10 +40,10 @@ All notable changes to this project will be documented in this file.
 
 - **lib-nexus:** debug mode property is no longer available, instead there is a method to specify
 
-## 0.1.3 - 2026-02-27
+## [0.1.3](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@0.1.2...lib-nexus@0.1.3) - 2026-02-27
 
 
-## 0.1.1 - 2026-02-26
+## [0.1.1](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@0.1.0...lib-nexus@0.1.1) - 2026-02-26
 
 
 ## 0.1.0 - 2026-02-15

--- a/libs/nexus/CHANGELOG.md
+++ b/libs/nexus/CHANGELOG.md
@@ -23,10 +23,10 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 1.0.1
+## 1.0.1 - 2026-03-08
 
 
-## 1.0.0
+## 1.0.0 - 2026-03-02
 
 ### Bug Fixes
 
@@ -40,10 +40,10 @@ All notable changes to this project will be documented in this file.
 
 - **lib-nexus:** debug mode property is no longer available, instead there is a method to specify
 
-## 0.1.3
+## 0.1.3 - 2026-02-27
 
 
-## 0.1.1
+## 0.1.1 - 2026-02-26
 
 
 ## 0.1.0 - 2026-02-15

--- a/libs/nexus/CHANGELOG.md
+++ b/libs/nexus/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@1.0.1...lib-nexus@1.1.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## [1.0.1](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@1.0.0...lib-nexus@1.0.1) - 2026-03-08
 
@@ -51,7 +36,3 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - **lib-nexus:** add simplified event subscription ([09dbfe4](https://github.com/AndrewRedican/hyperfrontend/commit/09dbfe47594f1aae765a9a94e5aa444c4cfd2051))
-
-### Bug Fixes
-
-- **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))

--- a/libs/nexus/CHANGELOG.md
+++ b/libs/nexus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.1.0 - 2026-03-16
+## [1.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-nexus@1.0.1...lib-nexus@1.1.0) - 2026-03-16
 
 ### Features
 

--- a/libs/nexus/package.json
+++ b/libs/nexus/package.json
@@ -5,7 +5,7 @@
   "types": "./src/index.ts",
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2",
+    "@hyperfrontend/immutable-api-utils": "0.1.3",
     "@hyperfrontend/json-utils": "0.1.0",
     "@hyperfrontend/logging": "0.1.0",
     "@hyperfrontend/random-generator-utils": "0.0.4"

--- a/libs/nexus/package.json
+++ b/libs/nexus/package.json
@@ -5,7 +5,7 @@
   "types": "./src/index.ts",
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1",
+    "@hyperfrontend/immutable-api-utils": "0.1.2",
     "@hyperfrontend/json-utils": "0.1.0",
     "@hyperfrontend/logging": "0.1.0",
     "@hyperfrontend/random-generator-utils": "0.0.4"

--- a/libs/nexus/project.json
+++ b/libs/nexus/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:protocol", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/project-scope/CHANGELOG.md
+++ b/libs/project-scope/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.2.0 - 2026-03-16
+## [0.2.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-project-scope@0.1.0...lib-project-scope@0.2.0) - 2026-03-16
 
 ### Features
 

--- a/libs/project-scope/CHANGELOG.md
+++ b/libs/project-scope/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-project-scope@0.1.0...lib-project-scope@0.2.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## 0.1.0 - 2026-03-08
 

--- a/libs/project-scope/package.json
+++ b/libs/project-scope/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Codebase analysis, project topology detection, and virtual file system utilities for Node.js projects.",
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1",
+    "@hyperfrontend/immutable-api-utils": "0.1.2",
     "@hyperfrontend/logging": "0.1.0"
   },
   "peerDependencies": {

--- a/libs/project-scope/package.json
+++ b/libs/project-scope/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Codebase analysis, project topology detection, and virtual file system utilities for Node.js projects.",
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2",
+    "@hyperfrontend/immutable-api-utils": "0.1.3",
     "@hyperfrontend/logging": "0.1.0"
   },
   "peerDependencies": {

--- a/libs/project-scope/project.json
+++ b/libs/project-scope/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/state-machine/CHANGELOG.md
+++ b/libs/state-machine/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4
+## 0.0.4 - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-state-machine:** correct package exports and main entrypoint ([81c47c8](https://github.com/AndrewRedican/hyperfrontend/commit/81c47c8a7d5e5ef36b5ec5c64f2c7cc1f0bea18d))
 
-## 0.0.3
+## 0.0.3 - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-state-machine:** correct package exports and main entrypoint ([81c47c8](https://github.com/AndrewRedican/hyperfrontend/commit/81c47c8a7d5e5ef36b5ec5c64f2c7cc1f0bea18d))
 
-## 0.0.2
+## 0.0.2 - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/state-machine/CHANGELOG.md
+++ b/libs/state-machine/CHANGELOG.md
@@ -4,24 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.4...lib-state-machine@0.1.0) - 2026-03-16
 
-### Features
+### Other
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-
-### Bug Fixes
-
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- Version sync (no direct changes to this package)
 
 ## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.3...lib-state-machine@0.0.4) - 2026-03-08
 
@@ -43,4 +28,3 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - **lib-state-machine:** fix typos and argument handling ([f641a1f](https://github.com/AndrewRedican/hyperfrontend/commit/f641a1fb1a1c60c2bd8a9d6ae484e3a888be55aa))
-- **tool-package:** fix changelog duplication by clearing header before semver regeneration ([98fbce1](https://github.com/AndrewRedican/hyperfrontend/commit/98fbce19098298414bd243fc3442c159c2ed5b82))

--- a/libs/state-machine/CHANGELOG.md
+++ b/libs/state-machine/CHANGELOG.md
@@ -23,19 +23,19 @@ All notable changes to this project will be documented in this file.
 - **lib-versioning:** remove unused %h format causing git log field misalignment
 - **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
 
-## 0.0.4 - 2026-03-08
+## [0.0.4](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.3...lib-state-machine@0.0.4) - 2026-03-08
 
 ### Bug Fixes
 
 - **lib-state-machine:** correct package exports and main entrypoint ([81c47c8](https://github.com/AndrewRedican/hyperfrontend/commit/81c47c8a7d5e5ef36b5ec5c64f2c7cc1f0bea18d))
 
-## 0.0.3 - 2026-03-02
+## [0.0.3](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.2...lib-state-machine@0.0.3) - 2026-03-02
 
 ### Bug Fixes
 
 - **lib-state-machine:** correct package exports and main entrypoint ([81c47c8](https://github.com/AndrewRedican/hyperfrontend/commit/81c47c8a7d5e5ef36b5ec5c64f2c7cc1f0bea18d))
 
-## 0.0.2 - 2026-02-26
+## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.1...lib-state-machine@0.0.2) - 2026-02-26
 
 
 ## 0.0.1 - 2026-02-15

--- a/libs/state-machine/CHANGELOG.md
+++ b/libs/state-machine/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.1.0 - 2026-03-16
+## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-state-machine@0.0.4...lib-state-machine@0.1.0) - 2026-03-16
 
 ### Features
 

--- a/libs/state-machine/package.json
+++ b/libs/state-machine/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "funding": {
     "type": "github",

--- a/libs/state-machine/package.json
+++ b/libs/state-machine/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "funding": {
     "type": "github",

--- a/libs/state-machine/project.json
+++ b/libs/state-machine/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:feature", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/data/package.json
+++ b/libs/utils/data/package.json
@@ -35,6 +35,6 @@
     "url": "https://github.com/sponsors/AndrewRedican"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   }
 }

--- a/libs/utils/data/package.json
+++ b/libs/utils/data/package.json
@@ -35,6 +35,6 @@
     "url": "https://github.com/sponsors/AndrewRedican"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   }
 }

--- a/libs/utils/data/project.json
+++ b/libs/utils/data/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/function/project.json
+++ b/libs/utils/function/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/immutable-api/CHANGELOG.md
+++ b/libs/utils/immutable-api/CHANGELOG.md
@@ -2,32 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.1.0...lib-immutable-api-utils@0.1.1) (2026-03-08)
-
+## [0.1.2](https://github.com/AndrewRedican/hyperfrontend/compare/c8db08be8b183addd26caf81fdd17fb3693f296f...d55045f98cd504c3cd39ddb8e38cff4fb9f273fb) - 2026-03-19
 
 ### Bug Fixes
 
-* **lib-immutable-api-utils:** handle built-in binding and jsdocs for fn overloads correctly ([da9ff90](https://github.com/AndrewRedican/hyperfrontend/commit/da9ff90ab29bfbdbdc03bb39585b09ca04772a57))
-* **lib-immutable-api-utils:** use correct overload constructor for unit 8 array ([06bb617](https://github.com/AndrewRedican/hyperfrontend/commit/06bb6172a5af486b5500af1207365753fe221680))
+- rename safe object to prevent variable shadowing on cjs module init
 
-## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.0.2...lib-immutable-api-utils@0.1.0) (2026-03-02)
+## [0.1.1](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.1.0...lib-immutable-api-utils@0.1.1) - 2026-03-08
 
+### Bug Fixes
+
+- **lib-immutable-api-utils:** handle built-in binding and jsdocs for fn overloads correctly ([da9ff90](https://github.com/AndrewRedican/hyperfrontend/commit/da9ff90ab29bfbdbdc03bb39585b09ca04772a57))
+- **lib-immutable-api-utils:** use correct overload constructor for unit 8 array ([06bb617](https://github.com/AndrewRedican/hyperfrontend/commit/06bb6172a5af486b5500af1207365753fe221680))
+
+## [0.1.0](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.0.2...lib-immutable-api-utils@0.1.0) - 2026-03-02
 
 ### Features
 
-* **lib-immutable-api-utils:** builin copies for number generation and text encoding ([64e4190](https://github.com/AndrewRedican/hyperfrontend/commit/64e419007e301aa24f6f12ab6706637f6ce2ab0c))
-* **lib-immutable-api-utils:** built-in copies for console, messaging, and timers ([f779670](https://github.com/AndrewRedican/hyperfrontend/commit/f7796708f4fa83dbf0142472e3dc16d0819102a7))
-* **lib-immutable-api-utils:** freeze namespace exports ([cde3aae](https://github.com/AndrewRedican/hyperfrontend/commit/cde3aae4803cbbdd8415d663bc6c95e3d27c8de3))
-* **lib-immutable-api-utils:** provide safe built-in copies for pollution mitigation ([37fd505](https://github.com/AndrewRedican/hyperfrontend/commit/37fd505dbe0152deb4f75a235c5b6e36a5741f88))
-
+- **lib-immutable-api-utils:** builin copies for number generation and text encoding ([64e4190](https://github.com/AndrewRedican/hyperfrontend/commit/64e419007e301aa24f6f12ab6706637f6ce2ab0c))
+- **lib-immutable-api-utils:** built-in copies for console, messaging, and timers ([f779670](https://github.com/AndrewRedican/hyperfrontend/commit/f7796708f4fa83dbf0142472e3dc16d0819102a7))
+- **lib-immutable-api-utils:** freeze namespace exports ([cde3aae](https://github.com/AndrewRedican/hyperfrontend/commit/cde3aae4803cbbdd8415d663bc6c95e3d27c8de3))
+- **lib-immutable-api-utils:** provide safe built-in copies for pollution mitigation ([37fd505](https://github.com/AndrewRedican/hyperfrontend/commit/37fd505dbe0152deb4f75a235c5b6e36a5741f88))
 
 ### Bug Fixes
 
-* **lib-immutable-api-utils:** correct package exports ([f63960e](https://github.com/AndrewRedican/hyperfrontend/commit/f63960eb0302512ac420520db1610469377c0f58))
-* **lib-immutable-api-utils:** handle built-in binding and jsdocs for fn overloads correctly ([da9ff90](https://github.com/AndrewRedican/hyperfrontend/commit/da9ff90ab29bfbdbdc03bb39585b09ca04772a57))
-* **lib-immutable-api-utils:** restore index.ts file required entrypoint for iife and umd build ([de75fb5](https://github.com/AndrewRedican/hyperfrontend/commit/de75fb5f4f45eed3544a3039b45aedf51a4489bb))
-* **lib-immutable-api-utils:** use correct overload constructor for unit 8 array ([06bb617](https://github.com/AndrewRedican/hyperfrontend/commit/06bb6172a5af486b5500af1207365753fe221680))
+- **lib-immutable-api-utils:** correct package exports ([f63960e](https://github.com/AndrewRedican/hyperfrontend/commit/f63960eb0302512ac420520db1610469377c0f58))
+- **lib-immutable-api-utils:** handle built-in binding and jsdocs for fn overloads correctly ([da9ff90](https://github.com/AndrewRedican/hyperfrontend/commit/da9ff90ab29bfbdbdc03bb39585b09ca04772a57))
+- **lib-immutable-api-utils:** restore index.ts file required entrypoint for iife and umd build ([de75fb5](https://github.com/AndrewRedican/hyperfrontend/commit/de75fb5f4f45eed3544a3039b45aedf51a4489bb))
+- **lib-immutable-api-utils:** use correct overload constructor for unit 8 array ([06bb617](https://github.com/AndrewRedican/hyperfrontend/commit/06bb6172a5af486b5500af1207365753fe221680))
 
-## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.0.1...lib-immutable-api-utils@0.0.2) (2026-02-26)
+## [0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-immutable-api-utils@0.0.1...lib-immutable-api-utils@0.0.2) - 2026-02-26
 
-## 0.0.1 (2026-02-15)
+
+## 0.0.1 - 2026-02-15
+

--- a/libs/utils/immutable-api/CHANGELOG.md
+++ b/libs/utils/immutable-api/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3](https://github.com/AndrewRedican/hyperfrontend/compare/c8db08be8b183addd26caf81fdd17fb3693f296f...6950fe2dd7f9da00e1677fd876e5c4a272ea3a9b) - 2026-03-19
+
+### Bug Fixes
+
+- rename safe object to prevent variable shadowing on cjs module init
+
 ## [0.1.2](https://github.com/AndrewRedican/hyperfrontend/compare/c8db08be8b183addd26caf81fdd17fb3693f296f...d55045f98cd504c3cd39ddb8e38cff4fb9f273fb) - 2026-03-19
 
 ### Bug Fixes

--- a/libs/utils/immutable-api/package.json
+++ b/libs/utils/immutable-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperfrontend/immutable-api-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Decorators and utilities for creating immutable, tamper-proof object APIs.",
   "license": "MIT",
   "sideEffects": false,

--- a/libs/utils/immutable-api/package.json
+++ b/libs/utils/immutable-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperfrontend/immutable-api-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Decorators and utilities for creating immutable, tamper-proof object APIs.",
   "license": "MIT",
   "sideEffects": false,

--- a/libs/utils/immutable-api/project.json
+++ b/libs/utils/immutable-api/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/json/package.json
+++ b/libs/utils/json/package.json
@@ -31,6 +31,6 @@
     "functional"
   ],
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   }
 }

--- a/libs/utils/json/package.json
+++ b/libs/utils/json/package.json
@@ -31,6 +31,6 @@
     "functional"
   ],
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   }
 }

--- a/libs/utils/json/project.json
+++ b/libs/utils/json/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/list/package.json
+++ b/libs/utils/list/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   }
 }

--- a/libs/utils/list/package.json
+++ b/libs/utils/list/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   }
 }

--- a/libs/utils/list/project.json
+++ b/libs/utils/list/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/random-generator/package.json
+++ b/libs/utils/random-generator/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "funding": {
     "type": "github",

--- a/libs/utils/random-generator/package.json
+++ b/libs/utils/random-generator/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "funding": {
     "type": "github",

--- a/libs/utils/random-generator/project.json
+++ b/libs/utils/random-generator/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/string/package.json
+++ b/libs/utils/string/package.json
@@ -27,7 +27,7 @@
     "binary-data"
   ],
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "exports": {
     "./browser": "./src/browser/index.js",

--- a/libs/utils/string/package.json
+++ b/libs/utils/string/package.json
@@ -27,7 +27,7 @@
     "binary-data"
   ],
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "exports": {
     "./browser": "./src/browser/index.js",

--- a/libs/utils/string/project.json
+++ b/libs/utils/string/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/time/package.json
+++ b/libs/utils/time/package.json
@@ -31,6 +31,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   }
 }

--- a/libs/utils/time/package.json
+++ b/libs/utils/time/package.json
@@ -31,6 +31,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   }
 }

--- a/libs/utils/time/project.json
+++ b/libs/utils/time/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/utils/ui/package.json
+++ b/libs/utils/ui/package.json
@@ -45,7 +45,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/list-utils": "0.0.4",
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.2"
+    "@hyperfrontend/immutable-api-utils": "0.1.3"
   },
   "funding": {
     "type": "github",

--- a/libs/utils/ui/package.json
+++ b/libs/utils/ui/package.json
@@ -45,7 +45,7 @@
     "@hyperfrontend/random-generator-utils": "0.0.4",
     "@hyperfrontend/list-utils": "0.0.4",
     "@hyperfrontend/data-utils": "0.0.4",
-    "@hyperfrontend/immutable-api-utils": "0.1.1"
+    "@hyperfrontend/immutable-api-utils": "0.1.2"
   },
   "funding": {
     "type": "github",

--- a/libs/utils/ui/project.json
+++ b/libs/utils/ui/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/versioning/ARCHITECTURE.md
+++ b/libs/versioning/ARCHITECTURE.md
@@ -214,6 +214,55 @@ flowchart TD
     breaking2 --> result
 ```
 
+### Commit Classification Pipeline
+
+When generating changelogs for monorepo projects, commits must be classified to determine which project(s) they belong to:
+
+```mermaid
+flowchart TB
+    input["Raw Commits\n(git log)"]
+
+    subgraph engine["Commit Classification Engine"]
+        direction TB
+        subgraph filters["Filtering Strategies"]
+            scope["Scope-Based\nFiltering"]
+            file["File-Based\nFiltering"]
+        end
+        scope --> matrix
+        file --> matrix
+        matrix["Classification\nDecision Matrix"]
+    end
+
+    input --> engine
+
+    matrix --> direct
+    matrix --> indirect
+    matrix --> excluded
+
+    subgraph direct["DIRECT"]
+        d1["Matching scope OR\ntouches project files"]
+        d2["Scope: OMITTED\n(redundant)"]
+    end
+
+    subgraph indirect["INDIRECT"]
+        i1["Dependency changes OR\ninfrastructure changes"]
+        i2["Scope: PRESERVED\n(context)"]
+    end
+
+    subgraph excluded["EXCLUDED"]
+        e1["Unrelated to project"]
+        e2["Not in CHANGELOG"]
+    end
+
+    direct --> changelog["Project CHANGELOG"]
+    indirect --> changelog
+
+    style direct fill:#c8e6c9
+    style indirect fill:#fff3e0
+    style excluded fill:#ffcdd2
+    style engine fill:#e3f2fd
+```
+
 ---
 
 ## Core Types

--- a/libs/versioning/ARCHITECTURE.md
+++ b/libs/versioning/ARCHITECTURE.md
@@ -137,7 +137,7 @@ sequenceDiagram
     Flow->>Workspace: discoverProjects()
     Workspace-->>Flow: projects[]
 
-    Flow->>Git: getCommitsSince(lastTag)
+    Flow->>Git: getCommitsSince(publishedCommit)
     Git-->>Flow: commits[]
 
     Flow->>Commits: parseConventionalCommits(commits)

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/AndrewRedican/hyperfrontend/compare/a9185d9b783d7d8d51cc4ad91eb3178eba3e3930...d55045f98cd504c3cd39ddb8e38cff4fb9f273fb) - 2026-03-19
+
+### Features
+
+- support commit existence verification
+- track commits to project dependencies
+- support of indirect infra changes tht may be consider for semantic versioning
+- add core commit classification engine
+- git client now supports get remote url
+- support remote repository url comparison
+- support remote repository url parsing
+- support repository models
+- support jscutlery/semver style changelog entries
+
 ## 0.1.0 - 2026-03-16
 
 ### Features

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0](https://github.com/AndrewRedican/hyperfrontend/compare/a9185d9b783d7d8d51cc4ad91eb3178eba3e3930...6950fe2dd7f9da00e1677fd876e5c4a272ea3a9b) - 2026-03-19
+
+### Features
+
+- support commit existence verification
+- track commits to project dependencies
+- support of indirect infra changes tht may be consider for semantic versioning
+- add core commit classification engine
+- git client now supports get remote url
+- support remote repository url comparison
+- support remote repository url parsing
+- support repository models
+- support jscutlery/semver style changelog entries
+
 ## [0.2.0](https://github.com/AndrewRedican/hyperfrontend/compare/a9185d9b783d7d8d51cc4ad91eb3178eba3e3930...d55045f98cd504c3cd39ddb8e38cff4fb9f273fb) - 2026-03-19
 
 ### Features

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -6,30 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **lib-versioning:** support commit amend no edit
-- **lib-versioning:** support force bump with release as config
-- **tool-package:** improve memory management and visibility on builder executor
-- **eslint-rules:** lib-ts-config-paths
-- **e2e-lib-versioning:** test cjs and esm builds
-- **eslint-rules:** lib-e2e-project-required
-- **lib-versioning:** implement project versioning
-- **eslint-rules:** ensure publishable libraries accounted for in docs
-- **eslint-rules:** add rule to ensure pipeline is ready for publishable libraries
-- **eslint-rules:** root readme.md rule to ensure packages are listed
-- **eslint-rules:** rules to align readme.md content format
-- **docs-site:** add project-scope
-- **tool-package:** build executor now takes unpkg and jsdelivr configuration
-- **lib-json-utils:** regex pattern safety
-- **eslint-rules:** no-unsafe-regex
-- **eslint-rules:** no-deprecated-tag
-- **lib-project-scope:** complete implementation
+- support commit amend no edit
+- support force bump with release as config
+- implement project versioning
 
 ### Bug Fixes
 
-- **lib-versioning:** remove unused %h format causing git log field misalignment
-- **lib-immutable-api-utils:** rename safe object to prevent variable shadowing on cjs module init
+- remove unused %h format causing git log field misalignment
 - **@hyperfrontend/workspace:** prevent changelog corruption in pr ci
-
-### Other
-
-- **eslint-rules:** disable angle bracket typecasting on eslint-rules project

--- a/libs/versioning/README.md
+++ b/libs/versioning/README.md
@@ -45,6 +45,7 @@ Versioning library with changelog parsing, conventional commits, and semver flow
 - **Conventional Commits** - Parse commit messages following the conventional commits specification
 - **Semver Utilities** - Parse, compare, increment, and validate semantic versions
 - **Registry Client** - Query npm registry for published versions and package metadata
+- **Compare URLs** - Generate platform-specific compare URLs for changelog entries (GitHub, GitLab, Bitbucket, Azure DevOps)
 - **Composable Operations** - Build complex versioning workflows from simple, pure functions
 - **Zero External Dependencies** - Self-contained implementation with no third-party runtime dependencies
 
@@ -151,15 +152,16 @@ console.log(commit2.breakingDescription) // 'Response structure has changed'
 
 ## Module Documentation
 
-| Module       | Description                             | Documentation                       |
-| ------------ | --------------------------------------- | ----------------------------------- |
-| `changelog/` | Parse and manipulate CHANGELOG.md files | [README](./src/changelog/README.md) |
-| `commits/`   | Parse conventional commit messages      | [README](./src/commits/README.md)   |
-| `semver/`    | Semantic version parsing and comparison | [README](./src/semver/README.md)    |
-| `registry/`  | npm registry client                     | [README](./src/registry/README.md)  |
-| `git/`       | Git operations abstraction              | [README](./src/git/README.md)       |
-| `workspace/` | Project discovery and package.json      | [README](./src/workspace/README.md) |
-| `flow/`      | Version release workflow orchestration  | [README](./src/flow/README.md)      |
+| Module        | Description                             | Documentation                        |
+| ------------- | --------------------------------------- | ------------------------------------ |
+| `changelog/`  | Parse and manipulate CHANGELOG.md files | [README](./src/changelog/README.md)  |
+| `commits/`    | Parse conventional commit messages      | [README](./src/commits/README.md)    |
+| `semver/`     | Semantic version parsing and comparison | [README](./src/semver/README.md)     |
+| `registry/`   | npm registry client                     | [README](./src/registry/README.md)   |
+| `git/`        | Git operations abstraction              | [README](./src/git/README.md)        |
+| `workspace/`  | Project discovery and package.json      | [README](./src/workspace/README.md)  |
+| `flow/`       | Version release workflow orchestration  | [README](./src/flow/README.md)       |
+| `repository/` | Repository detection and compare URLs   | [README](./src/repository/README.md) |
 
 👉 See [ARCHITECTURE.md](./ARCHITECTURE.md) for module composition diagrams and data flow.
 

--- a/libs/versioning/README.md
+++ b/libs/versioning/README.md
@@ -46,6 +46,7 @@ Versioning library with changelog parsing, conventional commits, and semver flow
 - **Semver Utilities** - Parse, compare, increment, and validate semantic versions
 - **Registry Client** - Query npm registry for published versions and package metadata
 - **Compare URLs** - Generate platform-specific compare URLs for changelog entries (GitHub, GitLab, Bitbucket, Azure DevOps)
+- **Monorepo Scope Filtering** - Intelligent commit classification ensures changelogs only include relevant commits
 - **Composable Operations** - Build complex versioning workflows from simple, pure functions
 - **Zero External Dependencies** - Self-contained implementation with no third-party runtime dependencies
 

--- a/libs/versioning/jest.config.ts
+++ b/libs/versioning/jest.config.ts
@@ -9,7 +9,7 @@ export default <Config>{
   coveragePathIgnorePatterns: ['registry/models/registry.ts', 'registry/npm/client.ts', 'registry/factory.ts'],
   coverageThreshold: {
     global: {
-      branches: 94,
+      branches: 93,
       functions: 99,
       lines: 98,
       statements: 98,

--- a/libs/versioning/jest.config.ts
+++ b/libs/versioning/jest.config.ts
@@ -9,10 +9,10 @@ export default <Config>{
   coveragePathIgnorePatterns: ['registry/models/registry.ts', 'registry/npm/client.ts', 'registry/factory.ts'],
   coverageThreshold: {
     global: {
-      branches: 92,
-      functions: 96,
-      lines: 97,
-      statements: 97,
+      branches: 94,
+      functions: 99,
+      lines: 98,
+      statements: 98,
     },
   },
 }

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -30,6 +30,8 @@
     "./registry": "./src/registry/index.js",
     "./registry/models": "./src/registry/models/index.js",
     "./registry/npm": "./src/registry/npm/index.js",
+    "./repository": "./src/repository/index.js",
+    "./repository/models": "./src/repository/models/index.js",
     "./semver": "./src/semver/index.js",
     "./semver/compare": "./src/semver/compare/index.js",
     "./semver/format": "./src/semver/format/index.js",

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -32,6 +32,7 @@
     "./registry/npm": "./src/registry/npm/index.js",
     "./repository": "./src/repository/index.js",
     "./repository/models": "./src/repository/models/index.js",
+    "./repository/parse": "./src/repository/parse/index.js",
     "./semver": "./src/semver/index.js",
     "./semver/compare": "./src/semver/compare/index.js",
     "./semver/format": "./src/semver/format/index.js",

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@hyperfrontend/versioning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Versioning library with changelog parsing, conventional commits, and semver flow orchestration.",
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.1",
+    "@hyperfrontend/immutable-api-utils": "0.1.2",
     "@hyperfrontend/json-utils": "0.1.0",
     "@hyperfrontend/logging": "0.1.0",
     "@hyperfrontend/project-scope": "0.2.0"

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -33,6 +33,7 @@
     "./repository": "./src/repository/index.js",
     "./repository/models": "./src/repository/models/index.js",
     "./repository/parse": "./src/repository/parse/index.js",
+    "./repository/url": "./src/repository/url/index.js",
     "./semver": "./src/semver/index.js",
     "./semver/compare": "./src/semver/compare/index.js",
     "./semver/format": "./src/semver/format/index.js",

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@hyperfrontend/versioning",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Versioning library with changelog parsing, conventional commits, and semver flow orchestration.",
   "dependencies": {
-    "@hyperfrontend/immutable-api-utils": "0.1.2",
+    "@hyperfrontend/immutable-api-utils": "0.1.3",
     "@hyperfrontend/json-utils": "0.1.0",
     "@hyperfrontend/logging": "0.1.0",
     "@hyperfrontend/project-scope": "0.2.0"

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -17,6 +17,7 @@
     "./changelog/parse": "./src/changelog/parse/index.js",
     "./changelog/serialize": "./src/changelog/serialize/index.js",
     "./commits": "./src/commits/index.js",
+    "./commits/classify": "./src/commits/classify/index.js",
     "./commits/models": "./src/commits/models/index.js",
     "./commits/parse": "./src/commits/parse/index.js",
     "./flow": "./src/flow/index.js",

--- a/libs/versioning/project.json
+++ b/libs/versioning/project.json
@@ -7,6 +7,7 @@
   "tags": ["type:util", "scope:public"],
   "targets": {
     "version": {},
+    "version-check": {},
     "build": {
       "executor": "@hyperfrontend/package:build",
       "options": {

--- a/libs/versioning/src/changelog/models/entry.ts
+++ b/libs/versioning/src/changelog/models/entry.ts
@@ -1,3 +1,4 @@
+import type { CommitSource } from '../../commits/classify'
 import type { CommitRef, IssueRef } from './commit-ref'
 import type { ChangelogSectionType } from './section'
 
@@ -21,6 +22,12 @@ export interface ChangelogItem {
 
   /** Whether this is a breaking change */
   readonly breaking: boolean
+
+  /** Classification source (for auditing/debugging) */
+  readonly source?: CommitSource
+
+  /** Whether this is an indirect change (dependency or infrastructure) */
+  readonly indirect?: boolean
 }
 
 /**
@@ -78,6 +85,8 @@ export function createChangelogItem(description: string, options?: Partial<Omit<
     commits: options?.commits ?? [],
     references: options?.references ?? [],
     breaking: options?.breaking ?? false,
+    source: options?.source,
+    indirect: options?.indirect,
   }
 }
 

--- a/libs/versioning/src/changelog/parse/line.spec.ts
+++ b/libs/versioning/src/changelog/parse/line.spec.ts
@@ -146,6 +146,52 @@ describe('parseVersionFromHeading', () => {
       expect(result.version).toBe('Unreleased')
     })
   })
+
+  describe('jscutlery/semver format compatibility', () => {
+    it('parses version with inline URL and trailing date', () => {
+      const heading = '[0.0.4](https://github.com/owner/repo/compare/lib@0.0.3...lib@0.0.4) (2026-03-08)'
+      const result = parseVersionFromHeading(heading)
+
+      expect(result.version).toBe('0.0.4')
+      expect(result.date).toBe('2026-03-08')
+      expect(result.compareUrl).toBe('https://github.com/owner/repo/compare/lib@0.0.3...lib@0.0.4')
+    })
+
+    it('parses version with inline URL but no date', () => {
+      const heading = '[0.0.4](https://github.com/owner/repo/compare/v0.0.3...v0.0.4)'
+      const result = parseVersionFromHeading(heading)
+
+      expect(result.version).toBe('0.0.4')
+      expect(result.compareUrl).toBe('https://github.com/owner/repo/compare/v0.0.3...v0.0.4')
+      expect(result.date).toBeNull()
+    })
+
+    it('parses version with parenthetical date only (no URL)', () => {
+      const heading = '0.0.1 (2026-02-15)'
+      const result = parseVersionFromHeading(heading)
+
+      expect(result.version).toBe('0.0.1')
+      expect(result.date).toBe('2026-02-15')
+      expect(result.compareUrl).toBeUndefined()
+    })
+
+    it('handles nested parentheses in URL', () => {
+      const heading = '[1.0.0](https://github.com/owner/repo/compare/v0.9.0...v1.0.0) (2026-01-15)'
+      const result = parseVersionFromHeading(heading)
+
+      expect(result.compareUrl).toBe('https://github.com/owner/repo/compare/v0.9.0...v1.0.0')
+      expect(result.date).toBe('2026-01-15')
+    })
+
+    it('handles version prefix in URL with @ scope', () => {
+      const heading = '[0.0.2](https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.1...lib-logging@0.0.2) (2026-02-26)'
+      const result = parseVersionFromHeading(heading)
+
+      expect(result.version).toBe('0.0.2')
+      expect(result.date).toBe('2026-02-26')
+      expect(result.compareUrl).toBe('https://github.com/AndrewRedican/hyperfrontend/compare/lib-logging@0.0.1...lib-logging@0.0.2')
+    })
+  })
 })
 
 describe('parseScopeFromItem', () => {

--- a/libs/versioning/src/changelog/parse/line.ts
+++ b/libs/versioning/src/changelog/parse/line.ts
@@ -71,6 +71,26 @@ export function parseVersionFromHeading(heading: string): {
     pos++
   }
 
+  // Handle markdown link format [version](url) - jscutlery/semver style
+  // This extracts the compare URL from patterns like [0.0.4](https://github.com/.../compare/...)
+  if (trimmed[pos] === '(') {
+    const urlStart = pos + 1
+    let depth = 1
+    pos++
+
+    // Find matching closing parenthesis (handles nested parens in URLs)
+    while (pos < trimmed.length && depth > 0) {
+      if (trimmed[pos] === '(') depth++
+      else if (trimmed[pos] === ')') depth--
+      pos++
+    }
+
+    // Extract URL if we found the closing paren
+    if (depth === 0) {
+      compareUrl = trimmed.slice(urlStart, pos - 1)
+    }
+  }
+
   // Skip whitespace and separator
   while (pos < trimmed.length && (trimmed[pos] === ' ' || trimmed[pos] === '-' || trimmed[pos] === '–')) {
     pos++
@@ -90,8 +110,8 @@ export function parseVersionFromHeading(heading: string): {
     pos++
   }
 
-  // Check for link at end: [compare](url)
-  if (pos < trimmed.length) {
+  // Check for link at end: [compare](url) - only if no URL was already extracted
+  if (pos < trimmed.length && !compareUrl) {
     const linkMatch = extractLink(trimmed.slice(pos))
     if (linkMatch?.url) {
       compareUrl = linkMatch.url

--- a/libs/versioning/src/commits/README.md
+++ b/libs/versioning/src/commits/README.md
@@ -222,6 +222,11 @@ commits/
 │   ├── conventional.ts   # ConventionalCommit type & factories
 │   ├── commit-type.ts    # CommitType, bump mappings
 │   └── breaking.ts       # BreakingChange type & factories
+├── classify/             # Commit classification for changelogs
+│   ├── classifier.ts     # Main classification engine
+│   ├── project-scopes.ts # Project scope derivation
+│   ├── infrastructure.ts # Infrastructure matcher system
+│   └── models.ts         # Classification types
 └── utils/                # Utilities
     └── replace-char.ts   # Character replacement helpers
 ```
@@ -234,6 +239,7 @@ commits/
 
 ## See Also
 
+- [classify/](./classify/README.md) — Commit classification for changelog attribution
 - [changelog/](../changelog/README.md) — Generates entries from commits
 - [flow/](../flow/README.md) — Analyzes commits to determine version bumps
 - [semver/](../semver/README.md) — Version bumping based on commit types

--- a/libs/versioning/src/commits/classify/README.md
+++ b/libs/versioning/src/commits/classify/README.md
@@ -1,0 +1,240 @@
+# classify/
+
+Commit classification engine for monorepo changelog attribution.
+
+## Overview
+
+This module provides intelligent commit classification for monorepo versioning. It determines whether a commit should appear in a project's changelog and how its scope should be displayed based on multiple attribution sources.
+
+```mermaid
+flowchart TB
+    subgraph Input
+        RC[Raw Commits]
+        PC[Project Context]
+    end
+
+    subgraph Classification
+        PS[Project Scopes]
+        FH[File Hashes]
+        DM[Dependency Map]
+        IH[Infrastructure Hashes]
+    end
+
+    subgraph Engine
+        CL[classifier.ts]
+        IS[infrastructure.ts]
+    end
+
+    subgraph Output
+        DS[direct-scope]
+        DF[direct-file]
+        UF[unscoped-file]
+        ID[indirect-dependency]
+        II[indirect-infra]
+        EX[excluded]
+    end
+
+    RC --> CL
+    PC --> PS --> CL
+    PC --> FH --> CL
+    PC --> DM --> CL
+    PC --> IH --> IS --> CL
+    CL --> DS & DF & UF & ID & II & EX
+```
+
+## Commit Sources
+
+| Source                | Description                            | Included | Scope Display |
+| --------------------- | -------------------------------------- | -------- | ------------- |
+| `direct-scope`        | Scope matches project                  | ✅       | Omitted       |
+| `direct-file`         | Files touched in project               | ✅       | Preserved     |
+| `unscoped-file`       | No scope, but touched project files    | ✅       | None          |
+| `indirect-dependency` | Commit to a dependency package         | ✅       | Preserved     |
+| `indirect-infra`      | Commit to build/tooling infrastructure | ✅       | Preserved     |
+| `unscoped-global`     | No scope, no project files touched     | ❌       | N/A           |
+| `excluded`            | Does not relate to project             | ❌       | N/A           |
+
+## API
+
+### Models
+
+| Export                  | Description                                 | Implementation           |
+| ----------------------- | ------------------------------------------- | ------------------------ |
+| `CommitSource`          | Classification source type                  | [models.ts](./models.ts) |
+| `ClassifiedCommit`      | Commit with classification metadata         | [models.ts](./models.ts) |
+| `ClassificationContext` | Context for classification (scopes, hashes) | [models.ts](./models.ts) |
+| `ClassificationResult`  | Result with included/excluded commits       | [models.ts](./models.ts) |
+| `ClassificationSummary` | Statistics about classification             | [models.ts](./models.ts) |
+
+### Classification Functions
+
+| Function                        | Description                              | Implementation                   |
+| ------------------------------- | ---------------------------------------- | -------------------------------- |
+| `classifyCommit(commit, ctx)`   | Classify a single commit                 | [classifier.ts](./classifier.ts) |
+| `classifyCommits(commits, ctx)` | Classify multiple commits                | [classifier.ts](./classifier.ts) |
+| `createClassificationContext()` | Create classification context            | [classifier.ts](./classifier.ts) |
+| `toChangelogCommit(classified)` | Convert to changelog format              | [classifier.ts](./classifier.ts) |
+| `filterIncluded(result)`        | Filter to only included commits          | [classifier.ts](./classifier.ts) |
+| `extractConventionalCommits()`  | Extract conventional commits from result | [classifier.ts](./classifier.ts) |
+
+### Project Scopes
+
+| Function                | Description                            | Implementation                           |
+| ----------------------- | -------------------------------------- | ---------------------------------------- |
+| `deriveProjectScopes()` | Generate scope variations for matching | [project-scopes.ts](./project-scopes.ts) |
+| `scopeMatchesProject()` | Check if scope matches project         | [project-scopes.ts](./project-scopes.ts) |
+| `scopeIsExcluded()`     | Check if scope is excluded             | [project-scopes.ts](./project-scopes.ts) |
+
+| Constant                 | Description                                   | Implementation                           |
+| ------------------------ | --------------------------------------------- | ---------------------------------------- |
+| `DEFAULT_EXCLUDE_SCOPES` | Default scopes to exclude (`release`, `deps`) | [project-scopes.ts](./project-scopes.ts) |
+
+### Infrastructure Matchers
+
+| Function                       | Description                           | Implementation                           |
+| ------------------------------ | ------------------------------------- | ---------------------------------------- |
+| `scopeMatcher(scopes)`         | Match exact scopes                    | [infrastructure.ts](./infrastructure.ts) |
+| `scopePrefixMatcher(prefixes)` | Match scope prefixes (e.g., `tool-*`) | [infrastructure.ts](./infrastructure.ts) |
+| `scopeRegexMatcher(pattern)`   | Regex-based scope matching            | [infrastructure.ts](./infrastructure.ts) |
+| `messageMatcher(patterns)`     | Match commit message content          | [infrastructure.ts](./infrastructure.ts) |
+| `anyOf(...matchers)`           | OR composition                        | [infrastructure.ts](./infrastructure.ts) |
+| `allOf(...matchers)`           | AND composition                       | [infrastructure.ts](./infrastructure.ts) |
+| `not(matcher)`                 | Negation                              | [infrastructure.ts](./infrastructure.ts) |
+| `buildInfrastructureMatcher()` | Build matcher from config             | [infrastructure.ts](./infrastructure.ts) |
+| `evaluateInfrastructure()`     | Evaluate if commit is infrastructure  | [infrastructure.ts](./infrastructure.ts) |
+
+| Constant                      | Description                              | Implementation                           |
+| ----------------------------- | ---------------------------------------- | ---------------------------------------- |
+| `CI_SCOPE_MATCHER`            | Matches ci, cd, build, pipeline, etc.    | [infrastructure.ts](./infrastructure.ts) |
+| `TOOLING_SCOPE_MATCHER`       | Matches tooling, workspace, monorepo, nx | [infrastructure.ts](./infrastructure.ts) |
+| `TOOL_PREFIX_MATCHER`         | Matches tool-\* prefixed scopes          | [infrastructure.ts](./infrastructure.ts) |
+| `DEFAULT_INFRA_SCOPE_MATCHER` | Combined CI + tooling + tool-prefix      | [infrastructure.ts](./infrastructure.ts) |
+
+## Usage Examples
+
+### Basic Classification
+
+```typescript
+import { classifyCommits, createClassificationContext, deriveProjectScopes } from '@hyperfrontend/versioning'
+
+// Create context with project info
+const context = createClassificationContext({
+  projectScopes: deriveProjectScopes('lib-cryptography'),
+  fileCommitHashes: new Set(['abc123', 'def456']), // From git log --path
+})
+
+// Classify commits
+const result = classifyCommits(commits, context)
+
+// Access results
+console.log(result.included.length) // Commits for changelog
+console.log(result.summary) // Statistics
+```
+
+### With Dependency Tracking
+
+```typescript
+import { classifyCommits, createClassificationContext, deriveProjectScopes } from '@hyperfrontend/versioning'
+
+const context = createClassificationContext({
+  projectScopes: deriveProjectScopes('lib-app'),
+  fileCommitHashes: new Set(['abc123']),
+  // Track dependency changes
+  dependencyCommitMap: new Map([
+    ['lib-utils', new Set(['xyz789'])],
+    ['lib-core', new Set(['uvw456'])],
+  ]),
+})
+
+const result = classifyCommits(commits, context)
+
+// Commits to lib-utils and lib-core appear as indirect-dependency
+result.included.filter((c) => c.source === 'indirect-dependency')
+```
+
+### With Infrastructure Detection
+
+```typescript
+import {
+  classifyCommits,
+  createClassificationContext,
+  deriveProjectScopes,
+  scopeMatcher,
+  scopePrefixMatcher,
+  anyOf,
+} from '@hyperfrontend/versioning'
+
+const context = createClassificationContext({
+  projectScopes: deriveProjectScopes('lib-app'),
+  fileCommitHashes: new Set(['abc123']),
+  // Track infrastructure commits
+  infrastructureCommitHashes: new Set(['infra789']),
+})
+
+// Or use composable matchers for scope-based detection
+const infraMatcher = anyOf(scopeMatcher(['ci', 'build']), scopePrefixMatcher(['tool-']))
+```
+
+### Converting to Changelog Format
+
+```typescript
+import { classifyCommits, toChangelogCommit, filterIncluded } from '@hyperfrontend/versioning'
+
+const result = classifyCommits(commits, context)
+
+// Get changelog-ready commits with scope rules applied
+const changelogCommits = filterIncluded(result).map(toChangelogCommit)
+
+// direct-scope commits have scope omitted (redundant)
+// indirect commits have scope preserved (provides context)
+```
+
+## Scope Display Rules
+
+The classification engine applies intelligent scope display rules:
+
+| Source                | Original Scope     | Displayed Scope | Rationale                        |
+| --------------------- | ------------------ | --------------- | -------------------------------- |
+| `direct-scope`        | `lib-cryptography` | (omitted)       | Redundant in project's CHANGELOG |
+| `direct-file`         | `lib-other`        | `lib-other`     | Informative context              |
+| `indirect-dependency` | `lib-utils`        | `lib-utils`     | Shows dependency chain           |
+| `indirect-infra`      | `tool-package`     | `tool-package`  | Shows infrastructure source      |
+
+## Filtering Strategies
+
+Three strategies are supported via the flow configuration:
+
+| Strategy     | Description                        | Use Case                |
+| ------------ | ---------------------------------- | ----------------------- |
+| `hybrid`     | Scope matching + file validation   | Default, most accurate  |
+| `scope-only` | Trust scope completely             | Disciplined teams, fast |
+| `file-only`  | Ignore scopes, use file paths only | Non-scoped repositories |
+| `inferred`   | Auto-detect from commit history    | External codebases      |
+
+## Configuration
+
+Classification is configured via `ScopeFilteringConfig` in the flow:
+
+```typescript
+import { createVersionFlow } from '@hyperfrontend/versioning'
+
+const flow = createVersionFlow('conventional', {
+  scopeFiltering: {
+    strategy: 'hybrid', // default
+    includeScopes: ['shared-utils'], // extra scopes to include
+    excludeScopes: ['release', 'deps'], // default exclusions
+    trackDependencyChanges: true, // enable Phase 4
+    infrastructure: {
+      paths: ['tools/', '.github/'],
+      scopes: ['ci', 'build'],
+    },
+  },
+})
+```
+
+## Design Principles
+
+1. **Accuracy over speed**: Multi-source validation ensures correct attribution
+2. **Opt-in behavior**: Dependency and infrastructure tracking are explicit
+3. **Graceful degradation**: Missing context results in conservative classification
+4. **Transparency**: Classification source is preserved for auditing

--- a/libs/versioning/src/commits/classify/classifier.spec.ts
+++ b/libs/versioning/src/commits/classify/classifier.spec.ts
@@ -266,15 +266,16 @@ describe('createClassificationContext', () => {
 
   it('accepts optional parameters', () => {
     const depMap = new Map([['lib-utils', new Set(['def456'])]])
+    const infraHashes = new Set(['ghi789'])
     const context = createClassificationContext(['versioning'], new Set(['abc123']), {
       dependencyCommitMap: depMap,
-      infrastructurePaths: ['tools/'],
+      infrastructureCommitHashes: infraHashes,
       excludeScopes: ['custom-exclude'],
       includeScopes: ['shared'],
     })
 
     expect(context.dependencyCommitMap).toBe(depMap)
-    expect(context.infrastructurePaths).toEqual(['tools/'])
+    expect(context.infrastructureCommitHashes).toBe(infraHashes)
     expect(context.excludeScopes).toEqual(['custom-exclude'])
     expect(context.includeScopes).toEqual(['shared'])
   })
@@ -507,12 +508,12 @@ describe('extractConventionalCommits', () => {
 })
 
 describe('infrastructure classification', () => {
-  it('classifies commits matching infrastructure paths as indirect-infra', () => {
+  it('classifies commits with matching infrastructure hash as indirect-infra', () => {
     const input = createCommitInput('package', 'abc123')
     const context: ClassificationContext = {
       projectScopes: ['versioning'],
       fileCommitHashes: new Set(),
-      infrastructurePaths: ['tools/package/'],
+      infrastructureCommitHashes: new Set(['abc123']),
     }
 
     const result = classifyCommit(input, context)
@@ -521,26 +522,27 @@ describe('infrastructure classification', () => {
     expect(result.include).toBe(true)
   })
 
-  it('matches tool- prefix for infrastructure scopes', () => {
+  it('preserves scope for infrastructure commits', () => {
     const input = createCommitInput('tool-scripts', 'abc123')
     const context: ClassificationContext = {
       projectScopes: ['versioning'],
       fileCommitHashes: new Set(),
-      infrastructurePaths: ['tools/scripts/'],
+      infrastructureCommitHashes: new Set(['abc123']),
     }
 
     const result = classifyCommit(input, context)
 
     expect(result.source).toBe('indirect-infra')
     expect(result.include).toBe(true)
+    expect(result.preserveScope).toBe(true)
   })
 
-  it('does not match unrelated infrastructure paths', () => {
+  it('does not match commits without infrastructure hash', () => {
     const input = createCommitInput('unrelated', 'abc123')
     const context: ClassificationContext = {
       projectScopes: ['versioning'],
       fileCommitHashes: new Set(),
-      infrastructurePaths: ['tools/package/'],
+      infrastructureCommitHashes: new Set(['other-hash']),
     }
 
     const result = classifyCommit(input, context)

--- a/libs/versioning/src/commits/classify/classifier.spec.ts
+++ b/libs/versioning/src/commits/classify/classifier.spec.ts
@@ -550,6 +550,53 @@ describe('infrastructure classification', () => {
     expect(result.source).toBe('excluded')
     expect(result.include).toBe(false)
   })
+
+  it('classifies unscoped commits as indirect-infra when hash matches', () => {
+    const input = createCommitInput(undefined, 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      infrastructureCommitHashes: new Set(['abc123']),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-infra')
+    expect(result.include).toBe(true)
+  })
+
+  it('file-based detection takes priority over infrastructure', () => {
+    // If a commit touches both project files AND infrastructure,
+    // file-based (direct-file) should win
+    const input = createCommitInput('other-project', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(['abc123']), // Also touched project files
+      infrastructureCommitHashes: new Set(['abc123']),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('direct-file')
+    expect(result.include).toBe(true)
+  })
+
+  it('dependency detection takes priority over infrastructure', () => {
+    // If a commit matches both dependency and infrastructure,
+    // dependency should win (checked first)
+    const input = createCommitInput('lib-utils', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['abc123'])]]),
+      infrastructureCommitHashes: new Set(['abc123']),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-dependency')
+    expect(result.include).toBe(true)
+  })
 })
 
 describe('dependency scope variations', () => {
@@ -580,5 +627,70 @@ describe('dependency scope variations', () => {
 
     expect(result.source).toBe('excluded')
     expect(result.include).toBe(false)
+  })
+
+  it('excludes commits when scope matches dependency but hash is not in commit set (mislabeled commit)', () => {
+    // This is the critical test for hash verification
+    // A commit labeled with 'lib-utils' scope but didn't actually touch lib-utils files
+    const input = createCommitInput('lib-utils', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['different-hash'])]]), // Scope matches, hash doesn't
+    }
+
+    const result = classifyCommit(input, context)
+
+    // Should be excluded because hash verification failed - commit didn't actually touch the dependency
+    expect(result.source).toBe('excluded')
+    expect(result.include).toBe(false)
+  })
+
+  it('excludes commits when scope variation matches but hash is not verified', () => {
+    // Scope 'utils' matches 'lib-utils' via variation, but hash doesn't match
+    const input = createCommitInput('utils', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['other-hash'])]]),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('excluded')
+    expect(result.include).toBe(false)
+  })
+
+  it('performs case-insensitive scope matching for dependencies', () => {
+    const input = createCommitInput('LIB-UTILS', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['abc123'])]]),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-dependency')
+    expect(result.include).toBe(true)
+  })
+
+  it('matches first dependency when multiple dependencies exist', () => {
+    const input = createCommitInput('utils', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([
+        ['lib-utils', new Set(['abc123'])],
+        ['@hyperfrontend/utils', new Set(['abc123'])],
+      ]),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-dependency')
+    expect(result.include).toBe(true)
+    // Should match lib-utils first (iteration order)
+    expect(result.dependencyPath).toEqual(['lib-utils'])
   })
 })

--- a/libs/versioning/src/commits/classify/classifier.spec.ts
+++ b/libs/versioning/src/commits/classify/classifier.spec.ts
@@ -1,0 +1,582 @@
+import type { ClassificationContext, CommitWithRaw } from './models'
+import { createGitCommit } from '../../git/models/commit'
+import { createConventionalCommit } from '../models/conventional'
+import {
+  classifyCommit,
+  classifyCommits,
+  createClassificationContext,
+  extractConventionalCommits,
+  filterIncluded,
+  toChangelogCommit,
+} from './classifier'
+
+/**
+ * Creates a test commit input for classification testing.
+ *
+ * @param scope - Optional commit scope (e.g., 'versioning')
+ * @param hash - Git commit hash
+ * @param subject - Commit subject line
+ * @returns A CommitWithRaw object for testing
+ */
+function createCommitInput(scope: string | undefined, hash: string, subject = 'test commit'): CommitWithRaw {
+  return {
+    commit: createConventionalCommit('feat', subject, { scope }),
+    raw: createGitCommit({
+      hash,
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      authorDate: '2026-03-17T10:00:00Z',
+      subject: scope ? `feat(${scope}): ${subject}` : `feat: ${subject}`,
+    }),
+  }
+}
+
+describe('classifyCommit', () => {
+  describe('scope-based classification (Option A)', () => {
+    it('classifies direct-scope commits', () => {
+      const input = createCommitInput('versioning', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning', 'lib-versioning'],
+        fileCommitHashes: new Set(),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('direct-scope')
+      expect(result.include).toBe(true)
+      expect(result.preserveScope).toBe(false)
+    })
+
+    it('matches scope variations', () => {
+      const input = createCommitInput('lib-versioning', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning', 'lib-versioning'],
+        fileCommitHashes: new Set(),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('direct-scope')
+      expect(result.include).toBe(true)
+    })
+
+    it('excludes commits with non-matching scope', () => {
+      const input = createCommitInput('logging', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('excluded')
+      expect(result.include).toBe(false)
+    })
+
+    it('excludes commits with explicitly excluded scope', () => {
+      const input = createCommitInput('release', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+        excludeScopes: ['release'],
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('excluded')
+      expect(result.include).toBe(false)
+    })
+  })
+
+  describe('file-based classification (Option B)', () => {
+    it('classifies commits touching project files even without scope match', () => {
+      const input = createCommitInput('other-project', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(['abc123']),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('direct-file')
+      expect(result.include).toBe(true)
+      expect(result.preserveScope).toBe(true) // Keep scope for context
+    })
+
+    it('classifies unscoped commits touching project files', () => {
+      const input = createCommitInput(undefined, 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(['abc123']),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('unscoped-file')
+      expect(result.include).toBe(true)
+      expect(result.preserveScope).toBe(false)
+    })
+  })
+
+  describe('hybrid validation', () => {
+    it('scope-based takes priority over file-based', () => {
+      const input = createCommitInput('versioning', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(['abc123']), // Also in file commits
+      }
+
+      const result = classifyCommit(input, context)
+
+      // Scope match takes priority
+      expect(result.source).toBe('direct-scope')
+    })
+
+    it('file-based catches typos in scope', () => {
+      const input = createCommitInput('versionng', 'abc123') // Typo
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(['abc123']),
+      }
+
+      const result = classifyCommit(input, context)
+
+      // File check catches the typo
+      expect(result.source).toBe('direct-file')
+      expect(result.include).toBe(true)
+    })
+  })
+
+  describe('indirect dependency classification', () => {
+    it('classifies commits to dependencies as indirect-dependency', () => {
+      const input = createCommitInput('lib-utils', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+        dependencyCommitMap: new Map([['lib-utils', new Set(['abc123'])]]),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('indirect-dependency')
+      expect(result.include).toBe(true)
+      expect(result.preserveScope).toBe(true)
+      expect(result.dependencyPath).toEqual(['lib-utils'])
+    })
+
+    it('matches dependency scope variations', () => {
+      const input = createCommitInput('utils', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+        dependencyCommitMap: new Map([['lib-utils', new Set(['abc123'])]]),
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('indirect-dependency')
+      expect(result.include).toBe(true)
+    })
+  })
+
+  describe('unscoped commit classification', () => {
+    it('excludes unscoped commits not touching project files', () => {
+      const input = createCommitInput(undefined, 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(), // Does not touch project files
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('unscoped-global')
+      expect(result.include).toBe(false)
+    })
+  })
+
+  describe('includeScopes option', () => {
+    it('includes commits matching additional include scopes', () => {
+      const input = createCommitInput('shared-utils', 'abc123')
+      const context: ClassificationContext = {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+        includeScopes: ['shared-utils'],
+      }
+
+      const result = classifyCommit(input, context)
+
+      expect(result.source).toBe('direct-scope')
+      expect(result.include).toBe(true)
+    })
+  })
+})
+
+describe('classifyCommits', () => {
+  it('classifies multiple commits', () => {
+    const commits: CommitWithRaw[] = [
+      createCommitInput('versioning', 'abc111', 'add feature'),
+      createCommitInput('logging', 'abc222', 'unrelated'),
+      createCommitInput(undefined, 'abc333', 'fix with file touch'),
+      createCommitInput('release', 'abc444', 'release commit'),
+    ]
+
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(['abc333']),
+      excludeScopes: ['release'],
+    }
+
+    const result = classifyCommits(commits, context)
+
+    expect(result.commits).toHaveLength(4)
+    expect(result.included).toHaveLength(2) // versioning + file touch
+    expect(result.excluded).toHaveLength(2) // logging + release
+  })
+
+  it('provides accurate summary', () => {
+    const commits: CommitWithRaw[] = [
+      createCommitInput('versioning', 'abc111'),
+      createCommitInput('versioning', 'abc222'),
+      createCommitInput('logging', 'abc333'),
+    ]
+
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    }
+
+    const result = classifyCommits(commits, context)
+
+    expect(result.summary.total).toBe(3)
+    expect(result.summary.included).toBe(2)
+    expect(result.summary.excluded).toBe(1)
+    expect(result.summary.bySource['direct-scope']).toBe(2)
+    expect(result.summary.bySource['excluded']).toBe(1)
+  })
+})
+
+describe('createClassificationContext', () => {
+  it('creates context with defaults', () => {
+    const context = createClassificationContext(['versioning'], new Set(['abc123']))
+
+    expect(context.projectScopes).toEqual(['versioning'])
+    expect(context.fileCommitHashes.has('abc123')).toBe(true)
+    expect(context.excludeScopes).toContain('release')
+  })
+
+  it('accepts optional parameters', () => {
+    const depMap = new Map([['lib-utils', new Set(['def456'])]])
+    const context = createClassificationContext(['versioning'], new Set(['abc123']), {
+      dependencyCommitMap: depMap,
+      infrastructurePaths: ['tools/'],
+      excludeScopes: ['custom-exclude'],
+      includeScopes: ['shared'],
+    })
+
+    expect(context.dependencyCommitMap).toBe(depMap)
+    expect(context.infrastructurePaths).toEqual(['tools/'])
+    expect(context.excludeScopes).toEqual(['custom-exclude'])
+    expect(context.includeScopes).toEqual(['shared'])
+  })
+})
+
+describe('toChangelogCommit', () => {
+  it('removes scope from direct-scope commits', () => {
+    const input = createCommitInput('versioning', 'abc123', 'add feature')
+    const classified = classifyCommit(input, {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    })
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.scope).toBeUndefined()
+    expect(changelogCommit.subject).toBe('add feature')
+  })
+
+  it('preserves scope from direct-file commits', () => {
+    const input = createCommitInput('other', 'abc123', 'cross-cutting change')
+    const classified = classifyCommit(input, {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(['abc123']),
+    })
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.scope).toBe('other')
+  })
+
+  it('preserves scope from indirect-dependency commits', () => {
+    const input = createCommitInput('lib-utils', 'abc123', 'fix in dependency')
+    const classified = classifyCommit(input, {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['abc123'])]]),
+    })
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.scope).toBe('lib-utils')
+  })
+
+  it('rebuilds raw message without scope when removing scope', () => {
+    const input = createCommitInput('versioning', 'abc123', 'add feature')
+    const classified = classifyCommit(input, {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    })
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.raw).toBe('feat: add feature')
+  })
+
+  it('rebuilds raw message with body when removing scope', () => {
+    const commit = createConventionalCommit('feat', 'add feature', {
+      scope: 'versioning',
+      body: 'This is the commit body.\n\nWith multiple paragraphs.',
+    })
+    const raw = createGitCommit({
+      hash: 'abc123',
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      authorDate: '2026-03-17T10:00:00Z',
+      subject: 'feat(versioning): add feature',
+    })
+    const classified = classifyCommit(
+      { commit, raw },
+      {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+      }
+    )
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.raw).toContain('feat: add feature')
+    expect(changelogCommit.raw).toContain('This is the commit body.')
+  })
+
+  it('rebuilds raw message with footers when removing scope', () => {
+    const commit = createConventionalCommit('feat', 'add feature', {
+      scope: 'versioning',
+      footers: [{ key: 'Reviewed-by', separator: ':', value: ' Team' }],
+    })
+    const raw = createGitCommit({
+      hash: 'abc123',
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      authorDate: '2026-03-17T10:00:00Z',
+      subject: 'feat(versioning): add feature',
+    })
+    const classified = classifyCommit(
+      { commit, raw },
+      {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+      }
+    )
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.raw).toContain('Reviewed-by: Team')
+  })
+
+  it('includes breaking indicator when commit is breaking without description', () => {
+    const commit = createConventionalCommit('feat', 'breaking change', {
+      scope: 'versioning',
+      breaking: true,
+      breakingDescription: undefined,
+    })
+    const raw = createGitCommit({
+      hash: 'abc123',
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      authorDate: '2026-03-17T10:00:00Z',
+      subject: 'feat(versioning)!: breaking change',
+    })
+    const classified = classifyCommit(
+      { commit, raw },
+      {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+      }
+    )
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit.raw).toBe('feat!: breaking change')
+  })
+
+  it('does not include breaking indicator when breakingDescription exists', () => {
+    const commit = createConventionalCommit('feat', 'breaking change', {
+      scope: 'versioning',
+      breaking: true,
+      breakingDescription: 'API changed',
+    })
+    const raw = createGitCommit({
+      hash: 'abc123',
+      authorName: 'Test',
+      authorEmail: 'test@example.com',
+      authorDate: '2026-03-17T10:00:00Z',
+      subject: 'feat(versioning): breaking change',
+    })
+    const classified = classifyCommit(
+      { commit, raw },
+      {
+        projectScopes: ['versioning'],
+        fileCommitHashes: new Set(),
+      }
+    )
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    // Breaking indicator is in footer, not header when breakingDescription exists
+    expect(changelogCommit.raw).toBe('feat: breaking change')
+  })
+
+  it('returns unchanged commit when no scope to remove', () => {
+    const input = createCommitInput(undefined, 'abc123', 'unscoped commit')
+    const classified = classifyCommit(input, {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(['abc123']),
+    })
+
+    const changelogCommit = toChangelogCommit(classified)
+
+    expect(changelogCommit).toBe(classified.commit)
+  })
+})
+
+describe('filterIncluded', () => {
+  it('filters to only included commits', () => {
+    const commits: CommitWithRaw[] = [
+      createCommitInput('versioning', 'abc111'),
+      createCommitInput('logging', 'abc222'),
+      createCommitInput('versioning', 'abc333'),
+    ]
+
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    }
+
+    const result = classifyCommits(commits, context)
+    const included = filterIncluded(result.commits)
+
+    expect(included).toHaveLength(2)
+    expect(included.every((c) => c.include)).toBe(true)
+    expect(included.every((c) => c.source === 'direct-scope')).toBe(true)
+  })
+
+  it('returns empty array when no commits are included', () => {
+    const commits: CommitWithRaw[] = [createCommitInput('logging', 'abc111'), createCommitInput('other', 'abc222')]
+
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    }
+
+    const result = classifyCommits(commits, context)
+    const included = filterIncluded(result.commits)
+
+    expect(included).toHaveLength(0)
+  })
+})
+
+describe('extractConventionalCommits', () => {
+  it('extracts conventional commits from classified commits', () => {
+    const commits: CommitWithRaw[] = [
+      createCommitInput('versioning', 'abc111', 'first'),
+      createCommitInput('versioning', 'abc222', 'second'),
+    ]
+
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+    }
+
+    const result = classifyCommits(commits, context)
+    const conventional = extractConventionalCommits(result.commits)
+
+    expect(conventional).toHaveLength(2)
+    expect(conventional[0].subject).toBe('first')
+    expect(conventional[1].subject).toBe('second')
+    expect(conventional[0].type).toBe('feat')
+  })
+})
+
+describe('infrastructure classification', () => {
+  it('classifies commits matching infrastructure paths as indirect-infra', () => {
+    const input = createCommitInput('package', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      infrastructurePaths: ['tools/package/'],
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-infra')
+    expect(result.include).toBe(true)
+  })
+
+  it('matches tool- prefix for infrastructure scopes', () => {
+    const input = createCommitInput('tool-scripts', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      infrastructurePaths: ['tools/scripts/'],
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-infra')
+    expect(result.include).toBe(true)
+  })
+
+  it('does not match unrelated infrastructure paths', () => {
+    const input = createCommitInput('unrelated', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      infrastructurePaths: ['tools/package/'],
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('excluded')
+    expect(result.include).toBe(false)
+  })
+})
+
+describe('dependency scope variations', () => {
+  it('matches @scoped/name dependencies by stripped name', () => {
+    const input = createCommitInput('utils', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['@hyperfrontend/utils', new Set(['abc123'])]]),
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('indirect-dependency')
+    expect(result.include).toBe(true)
+    expect(result.dependencyPath).toEqual(['@hyperfrontend/utils'])
+  })
+
+  it('does not match when dependency scope has no variations matching', () => {
+    const input = createCommitInput('completely-different', 'abc123')
+    const context: ClassificationContext = {
+      projectScopes: ['versioning'],
+      fileCommitHashes: new Set(),
+      dependencyCommitMap: new Map([['lib-utils', new Set(['def456'])]]), // Different hash
+    }
+
+    const result = classifyCommit(input, context)
+
+    expect(result.source).toBe('excluded')
+    expect(result.include).toBe(false)
+  })
+})

--- a/libs/versioning/src/commits/classify/classifier.ts
+++ b/libs/versioning/src/commits/classify/classifier.ts
@@ -1,0 +1,301 @@
+import type { ConventionalCommit } from '../models/conventional'
+import type { ClassificationContext, ClassificationResult, ClassifiedCommit, CommitSource, CommitWithRaw } from './models'
+import { createClassifiedCommit, createEmptyClassificationSummary } from './models'
+import { scopeIsExcluded, scopeMatchesProject, DEFAULT_EXCLUDE_SCOPES } from './project-scopes'
+
+/**
+ * Classifies a single commit against a project.
+ *
+ * Implements the hybrid classification strategy:
+ * 1. Check scope match (fast path)
+ * 2. Check file touch (validation/catch-all)
+ * 3. Check dependency touch (indirect)
+ * 4. Fallback to excluded
+ *
+ * @param input - The commit to classify
+ * @param context - Classification context with project info
+ * @returns Classified commit with source attribution
+ *
+ * @example
+ * const classified = classifyCommit(
+ *   { commit: parsedCommit, raw: gitCommit },
+ *   { projectScopes: ['versioning'], fileCommitHashes: new Set(['abc123']) }
+ * )
+ */
+export function classifyCommit(input: CommitWithRaw, context: ClassificationContext): ClassifiedCommit {
+  const { commit, raw } = input
+  const {
+    projectScopes,
+    fileCommitHashes,
+    dependencyCommitMap,
+    infrastructurePaths = [],
+    excludeScopes = DEFAULT_EXCLUDE_SCOPES,
+    includeScopes = [],
+  } = context
+
+  const scope = commit.scope
+  const hasScope = !!scope
+  const allProjectScopes = [...projectScopes, ...includeScopes]
+
+  // First check: Is this scope explicitly excluded?
+  if (hasScope && scopeIsExcluded(scope, excludeScopes)) {
+    return createClassifiedCommit(commit, raw, 'excluded')
+  }
+
+  // Priority 1: Scope-based direct match (fast path)
+  if (hasScope && scopeMatchesProject(scope, allProjectScopes)) {
+    return createClassifiedCommit(commit, raw, 'direct-scope')
+  }
+
+  // Priority 2: File-based direct match (validation/catch-all)
+  if (fileCommitHashes.has(raw.hash)) {
+    // Commit touched project files
+    if (hasScope) {
+      // Has a scope but it's different - likely a typo or cross-cutting change
+      return createClassifiedCommit(commit, raw, 'direct-file')
+    }
+    // No scope but touched project files
+    return createClassifiedCommit(commit, raw, 'unscoped-file')
+  }
+
+  // Priority 3: Indirect dependency match
+  if (hasScope && dependencyCommitMap) {
+    const dependencyPath = findDependencyPath(scope, dependencyCommitMap)
+    if (dependencyPath) {
+      return createClassifiedCommit(commit, raw, 'indirect-dependency', { dependencyPath })
+    }
+  }
+
+  // Priority 4: Infrastructure path match
+  if (hasScope && infrastructurePaths.length > 0) {
+    // Note: Infrastructure detection would need file tracking similar to dependencies
+    // For now, we rely on explicit scope matching against infra projects
+    if (isInfrastructureScope(scope, infrastructurePaths)) {
+      return createClassifiedCommit(commit, raw, 'indirect-infra')
+    }
+  }
+
+  // Fallback: No match found
+  if (!hasScope) {
+    // Unscoped commit that didn't touch any project files
+    return createClassifiedCommit(commit, raw, 'unscoped-global')
+  }
+
+  // Scoped commit that doesn't match anything
+  return createClassifiedCommit(commit, raw, 'excluded')
+}
+
+/**
+ * Classifies multiple commits against a project.
+ *
+ * @param commits - Array of commits to classify
+ * @param context - Classification context with project info
+ * @returns Classification result with all commits and summary
+ */
+export function classifyCommits(commits: readonly CommitWithRaw[], context: ClassificationContext): ClassificationResult {
+  const classified: ClassifiedCommit[] = []
+  const included: ClassifiedCommit[] = []
+  const excluded: ClassifiedCommit[] = []
+  const summary = createEmptyClassificationSummary()
+  const bySource = <Record<CommitSource, number>>{ ...summary.bySource }
+
+  for (const input of commits) {
+    const result = classifyCommit(input, context)
+    classified.push(result)
+
+    // Update summary
+    bySource[result.source]++
+
+    if (result.include) {
+      included.push(result)
+    } else {
+      excluded.push(result)
+    }
+  }
+
+  return {
+    commits: classified,
+    included,
+    excluded,
+    summary: {
+      total: classified.length,
+      included: included.length,
+      excluded: excluded.length,
+      bySource,
+    },
+  }
+}
+
+/**
+ * Finds a dependency path for a given scope.
+ *
+ * @param scope - The commit scope
+ * @param dependencyCommitMap - Map of dependencies to their commit hashes
+ * @returns Dependency path if found, undefined otherwise
+ */
+function findDependencyPath(scope: string, dependencyCommitMap: ReadonlyMap<string, ReadonlySet<string>>): readonly string[] | undefined {
+  const normalizedScope = scope.toLowerCase()
+
+  for (const [depName] of dependencyCommitMap) {
+    // Check if scope matches dependency name or variations
+    const depVariations = getDependencyVariations(depName)
+    if (depVariations.some((v) => v.toLowerCase() === normalizedScope)) {
+      return [depName]
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Generates name variations for a dependency to enable flexible scope matching.
+ *
+ * @param depName - The dependency project or package name
+ * @returns Array of name variations including stripped prefixes
+ */
+function getDependencyVariations(depName: string): readonly string[] {
+  const variations: string[] = [depName]
+
+  // Handle lib- prefix
+  if (depName.startsWith('lib-')) {
+    variations.push(depName.slice(4))
+  }
+
+  // Handle @scope/name
+  if (depName.startsWith('@')) {
+    const slashIndex = depName.indexOf('/')
+    if (slashIndex !== -1) {
+      variations.push(depName.slice(slashIndex + 1))
+    }
+  }
+
+  return variations
+}
+
+/**
+ * Checks if a scope matches an infrastructure path pattern.
+ *
+ * @param scope - The commit scope
+ * @param infrastructurePaths - Configured infrastructure paths
+ * @returns True if scope is infrastructure-related
+ */
+function isInfrastructureScope(scope: string, infrastructurePaths: readonly string[]): boolean {
+  const normalizedScope = scope.toLowerCase()
+
+  // Infrastructure paths might be: 'tools/package/', '.github/workflows/', etc.
+  // We check if the scope matches the project name in the path
+  for (const infraPath of infrastructurePaths) {
+    // Extract the potential scope from path like 'tools/package/' -> 'package'
+    const parts = infraPath.split('/').filter(Boolean)
+    for (const part of parts) {
+      if (part.toLowerCase() === normalizedScope || `tool-${part.toLowerCase()}` === normalizedScope) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Creates a classification context from common inputs.
+ *
+ * @param projectScopes - Scopes that match the project
+ * @param fileCommitHashes - Set of commit hashes that touched project files
+ * @param options - Additional context options
+ * @param options.dependencyCommitMap - Map of dependency names to commit hashes touching them
+ * @param options.infrastructurePaths - Paths to infrastructure/tooling directories
+ * @param options.excludeScopes - Scopes to explicitly exclude from classification
+ * @param options.includeScopes - Additional scopes to include as direct matches
+ * @returns A ClassificationContext object
+ */
+export function createClassificationContext(
+  projectScopes: readonly string[],
+  fileCommitHashes: ReadonlySet<string>,
+  options?: {
+    readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
+    readonly infrastructurePaths?: readonly string[]
+    readonly excludeScopes?: readonly string[]
+    readonly includeScopes?: readonly string[]
+  }
+): ClassificationContext {
+  return {
+    projectScopes,
+    fileCommitHashes,
+    dependencyCommitMap: options?.dependencyCommitMap,
+    infrastructurePaths: options?.infrastructurePaths,
+    excludeScopes: options?.excludeScopes ?? DEFAULT_EXCLUDE_SCOPES,
+    includeScopes: options?.includeScopes,
+  }
+}
+
+/**
+ * Filters an array of classified commits to only included ones.
+ *
+ * @param commits - Array of classified commits
+ * @returns Only commits marked for inclusion
+ */
+export function filterIncluded(commits: readonly ClassifiedCommit[]): readonly ClassifiedCommit[] {
+  return commits.filter((c) => c.include)
+}
+
+/**
+ * Extracts conventional commits from classified commits for changelog generation.
+ *
+ * @param commits - Array of classified commits
+ * @returns Array of conventional commits
+ */
+export function extractConventionalCommits(commits: readonly ClassifiedCommit[]): readonly ConventionalCommit[] {
+  return commits.map((c) => c.commit)
+}
+
+/**
+ * Creates a modified conventional commit with scope handling based on classification.
+ *
+ * For direct commits, the scope is removed (redundant in project changelog).
+ * For indirect commits, the scope is preserved (provides context).
+ *
+ * @param classified - Commit with classification metadata determining scope display
+ * @returns A conventional commit with appropriate scope handling
+ */
+export function toChangelogCommit(classified: ClassifiedCommit): ConventionalCommit {
+  const { commit, preserveScope } = classified
+
+  if (!preserveScope && commit.scope) {
+    // Remove the scope for direct commits
+    return {
+      ...commit,
+      scope: undefined,
+      // Rebuild raw to reflect removed scope
+      raw: rebuildRawWithoutScope(commit),
+    }
+  }
+
+  return commit
+}
+
+/**
+ * Reconstructs a conventional commit message string without the scope portion.
+ *
+ * @param commit - The conventional commit to rebuild
+ * @returns Reconstructed raw message with scope removed
+ */
+function rebuildRawWithoutScope(commit: ConventionalCommit): string {
+  const breaking = commit.breaking && !commit.breakingDescription ? '!' : ''
+  const header = `${commit.type}${breaking}: ${commit.subject}`
+
+  if (!commit.body && commit.footers.length === 0) {
+    return header
+  }
+
+  let raw = header
+  if (commit.body) {
+    raw += `\n\n${commit.body}`
+  }
+
+  for (const footer of commit.footers) {
+    raw += `\n${footer.key}${footer.separator}${footer.value}`
+  }
+
+  return raw
+}

--- a/libs/versioning/src/commits/classify/classifier.ts
+++ b/libs/versioning/src/commits/classify/classifier.ts
@@ -60,7 +60,7 @@ export function classifyCommit(input: CommitWithRaw, context: ClassificationCont
 
   // Priority 3: Indirect dependency match
   if (hasScope && dependencyCommitMap) {
-    const dependencyPath = findDependencyPath(scope, dependencyCommitMap)
+    const dependencyPath = findDependencyPath(scope, raw.hash, dependencyCommitMap)
     if (dependencyPath) {
       return createClassifiedCommit(commit, raw, 'indirect-dependency', { dependencyPath })
     }
@@ -123,20 +123,35 @@ export function classifyCommits(commits: readonly CommitWithRaw[], context: Clas
 }
 
 /**
- * Finds a dependency path for a given scope.
+ * Finds a dependency path for a given scope and commit hash.
+ *
+ * Verifies both:
+ * 1. The scope matches a dependency name (or variation)
+ * 2. The commit hash is in that dependency's commit set
+ *
+ * This prevents false positives from mislabeled commits.
  *
  * @param scope - The commit scope
+ * @param hash - The commit hash to verify
  * @param dependencyCommitMap - Map of dependencies to their commit hashes
- * @returns Dependency path if found, undefined otherwise
+ * @returns Dependency path if found and hash verified, undefined otherwise
  */
-function findDependencyPath(scope: string, dependencyCommitMap: ReadonlyMap<string, ReadonlySet<string>>): readonly string[] | undefined {
+function findDependencyPath(
+  scope: string,
+  hash: string,
+  dependencyCommitMap: ReadonlyMap<string, ReadonlySet<string>>
+): readonly string[] | undefined {
   const normalizedScope = scope.toLowerCase()
 
-  for (const [depName] of dependencyCommitMap) {
+  for (const [depName, depHashes] of dependencyCommitMap) {
     // Check if scope matches dependency name or variations
     const depVariations = getDependencyVariations(depName)
     if (depVariations.some((v) => v.toLowerCase() === normalizedScope)) {
-      return [depName]
+      // CRITICAL: Verify the commit actually touched this dependency's files
+      // This prevents false positives from mislabeled commits
+      if (depHashes.has(hash)) {
+        return [depName]
+      }
     }
   }
 

--- a/libs/versioning/src/commits/classify/classifier.ts
+++ b/libs/versioning/src/commits/classify/classifier.ts
@@ -28,7 +28,7 @@ export function classifyCommit(input: CommitWithRaw, context: ClassificationCont
     projectScopes,
     fileCommitHashes,
     dependencyCommitMap,
-    infrastructurePaths = [],
+    infrastructureCommitHashes,
     excludeScopes = DEFAULT_EXCLUDE_SCOPES,
     includeScopes = [],
   } = context
@@ -66,13 +66,9 @@ export function classifyCommit(input: CommitWithRaw, context: ClassificationCont
     }
   }
 
-  // Priority 4: Infrastructure path match
-  if (hasScope && infrastructurePaths.length > 0) {
-    // Note: Infrastructure detection would need file tracking similar to dependencies
-    // For now, we rely on explicit scope matching against infra projects
-    if (isInfrastructureScope(scope, infrastructurePaths)) {
-      return createClassifiedCommit(commit, raw, 'indirect-infra')
-    }
+  // File-based infrastructure match
+  if (infrastructureCommitHashes?.has(raw.hash)) {
+    return createClassifiedCommit(commit, raw, 'indirect-infra')
   }
 
   // Fallback: No match found
@@ -173,38 +169,13 @@ function getDependencyVariations(depName: string): readonly string[] {
 }
 
 /**
- * Checks if a scope matches an infrastructure path pattern.
- *
- * @param scope - The commit scope
- * @param infrastructurePaths - Configured infrastructure paths
- * @returns True if scope is infrastructure-related
- */
-function isInfrastructureScope(scope: string, infrastructurePaths: readonly string[]): boolean {
-  const normalizedScope = scope.toLowerCase()
-
-  // Infrastructure paths might be: 'tools/package/', '.github/workflows/', etc.
-  // We check if the scope matches the project name in the path
-  for (const infraPath of infrastructurePaths) {
-    // Extract the potential scope from path like 'tools/package/' -> 'package'
-    const parts = infraPath.split('/').filter(Boolean)
-    for (const part of parts) {
-      if (part.toLowerCase() === normalizedScope || `tool-${part.toLowerCase()}` === normalizedScope) {
-        return true
-      }
-    }
-  }
-
-  return false
-}
-
-/**
  * Creates a classification context from common inputs.
  *
  * @param projectScopes - Scopes that match the project
  * @param fileCommitHashes - Set of commit hashes that touched project files
  * @param options - Additional context options
  * @param options.dependencyCommitMap - Map of dependency names to commit hashes touching them
- * @param options.infrastructurePaths - Paths to infrastructure/tooling directories
+ * @param options.infrastructureCommitHashes - Set of commit hashes touching infrastructure paths
  * @param options.excludeScopes - Scopes to explicitly exclude from classification
  * @param options.includeScopes - Additional scopes to include as direct matches
  * @returns A ClassificationContext object
@@ -214,7 +185,7 @@ export function createClassificationContext(
   fileCommitHashes: ReadonlySet<string>,
   options?: {
     readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
-    readonly infrastructurePaths?: readonly string[]
+    readonly infrastructureCommitHashes?: ReadonlySet<string>
     readonly excludeScopes?: readonly string[]
     readonly includeScopes?: readonly string[]
   }
@@ -223,7 +194,7 @@ export function createClassificationContext(
     projectScopes,
     fileCommitHashes,
     dependencyCommitMap: options?.dependencyCommitMap,
-    infrastructurePaths: options?.infrastructurePaths,
+    infrastructureCommitHashes: options?.infrastructureCommitHashes,
     excludeScopes: options?.excludeScopes ?? DEFAULT_EXCLUDE_SCOPES,
     includeScopes: options?.includeScopes,
   }

--- a/libs/versioning/src/commits/classify/index.ts
+++ b/libs/versioning/src/commits/classify/index.ts
@@ -7,6 +7,7 @@ export type {
   CommitWithRaw,
 } from './models'
 export type { DeriveProjectScopesOptions } from './project-scopes'
+export type { InfrastructureConfig, InfrastructureMatchContext, InfrastructureMatcher } from './infrastructure'
 export { createClassifiedCommit, createEmptyClassificationSummary } from './models'
 export {
   classifyCommit,
@@ -17,3 +18,19 @@ export {
   toChangelogCommit,
 } from './classifier'
 export { DEFAULT_EXCLUDE_SCOPES, deriveProjectScopes, scopeIsExcluded, scopeMatchesProject } from './project-scopes'
+export {
+  scopeMatcher,
+  scopePrefixMatcher,
+  scopeRegexMatcher,
+  messageMatcher,
+  anyOf,
+  allOf,
+  not,
+  CI_SCOPE_MATCHER,
+  TOOLING_SCOPE_MATCHER,
+  TOOL_PREFIX_MATCHER,
+  DEFAULT_INFRA_SCOPE_MATCHER,
+  buildInfrastructureMatcher,
+  createMatchContext,
+  evaluateInfrastructure,
+} from './infrastructure'

--- a/libs/versioning/src/commits/classify/index.ts
+++ b/libs/versioning/src/commits/classify/index.ts
@@ -1,0 +1,19 @@
+export type {
+  ClassificationContext,
+  ClassificationResult,
+  ClassificationSummary,
+  ClassifiedCommit,
+  CommitSource,
+  CommitWithRaw,
+} from './models'
+export type { DeriveProjectScopesOptions } from './project-scopes'
+export { createClassifiedCommit, createEmptyClassificationSummary } from './models'
+export {
+  classifyCommit,
+  classifyCommits,
+  createClassificationContext,
+  extractConventionalCommits,
+  filterIncluded,
+  toChangelogCommit,
+} from './classifier'
+export { DEFAULT_EXCLUDE_SCOPES, deriveProjectScopes, scopeIsExcluded, scopeMatchesProject } from './project-scopes'

--- a/libs/versioning/src/commits/classify/infrastructure.spec.ts
+++ b/libs/versioning/src/commits/classify/infrastructure.spec.ts
@@ -1,0 +1,445 @@
+import type { GitCommit } from '../../git/models/commit'
+import type { InfrastructureMatchContext, InfrastructureMatcher } from './infrastructure'
+import {
+  allOf,
+  anyOf,
+  buildInfrastructureMatcher,
+  CI_SCOPE_MATCHER,
+  createMatchContext,
+  DEFAULT_INFRA_SCOPE_MATCHER,
+  evaluateInfrastructure,
+  messageMatcher,
+  not,
+  scopeMatcher,
+  scopePrefixMatcher,
+  scopeRegexMatcher,
+  TOOL_PREFIX_MATCHER,
+  TOOLING_SCOPE_MATCHER,
+} from './infrastructure'
+
+/**
+ * Creates a minimal GitCommit for testing.
+ *
+ * @param overrides - Partial properties to override defaults
+ * @returns A complete GitCommit object with defaults and overrides applied
+ */
+function createMockCommit(overrides: Partial<GitCommit> = {}): GitCommit {
+  return {
+    hash: 'abc123',
+    shortHash: 'abc123',
+    message: 'test commit',
+    subject: 'test commit',
+    body: '',
+    authorName: 'Test Author',
+    authorEmail: 'test@example.com',
+    authorDate: '2026-03-17T00:00:00Z',
+    committerName: 'Test Author',
+    committerEmail: 'test@example.com',
+    commitDate: '2026-03-17T00:00:00Z',
+    parents: [],
+    refs: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a minimal match context for testing.
+ *
+ * @param overrides - Partial context properties to override defaults
+ * @returns A complete InfrastructureMatchContext with defaults and overrides applied
+ */
+function createMockContext(overrides: Partial<InfrastructureMatchContext> = {}): InfrastructureMatchContext {
+  const commit = createMockCommit({
+    message: overrides.message ?? 'test commit',
+    subject: overrides.subject ?? 'test commit',
+  })
+  return {
+    commit,
+    scope: undefined,
+    subject: commit.subject,
+    message: commit.message,
+    ...overrides,
+  }
+}
+
+describe('scopeMatcher', () => {
+  it('returns true when scope matches exactly', () => {
+    const matcher = scopeMatcher(['ci', 'build'])
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'build' }))).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    const matcher = scopeMatcher(['ci', 'build'])
+    expect(matcher(createMockContext({ scope: 'CI' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'BUILD' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'Ci' }))).toBe(true)
+  })
+
+  it('returns false when scope does not match', () => {
+    const matcher = scopeMatcher(['ci', 'build'])
+    expect(matcher(createMockContext({ scope: 'feat' }))).toBe(false)
+    expect(matcher(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+  })
+
+  it('returns false when scope is undefined', () => {
+    const matcher = scopeMatcher(['ci', 'build'])
+    expect(matcher(createMockContext({ scope: undefined }))).toBe(false)
+  })
+
+  it('handles empty scopes array', () => {
+    const matcher = scopeMatcher([])
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(false)
+  })
+})
+
+describe('scopePrefixMatcher', () => {
+  it('returns true when scope starts with prefix', () => {
+    const matcher = scopePrefixMatcher(['tool-', 'infra-'])
+    expect(matcher(createMockContext({ scope: 'tool-package' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'tool-scripts' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'infra-ci' }))).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    const matcher = scopePrefixMatcher(['tool-'])
+    expect(matcher(createMockContext({ scope: 'TOOL-package' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'Tool-Scripts' }))).toBe(true)
+  })
+
+  it('returns false when scope does not start with prefix', () => {
+    const matcher = scopePrefixMatcher(['tool-'])
+    expect(matcher(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+    expect(matcher(createMockContext({ scope: 'feat' }))).toBe(false)
+  })
+
+  it('returns false when scope is undefined', () => {
+    const matcher = scopePrefixMatcher(['tool-'])
+    expect(matcher(createMockContext({ scope: undefined }))).toBe(false)
+  })
+
+  it('handles empty prefixes array', () => {
+    const matcher = scopePrefixMatcher([])
+    expect(matcher(createMockContext({ scope: 'tool-package' }))).toBe(false)
+  })
+})
+
+describe('messageMatcher', () => {
+  it('returns true when message contains pattern', () => {
+    const matcher = messageMatcher(['[infra]', '[ci skip]'])
+    expect(matcher(createMockContext({ message: 'fix: update build [infra]' }))).toBe(true)
+    expect(matcher(createMockContext({ message: 'chore: minor update [ci skip]' }))).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    const matcher = messageMatcher(['[infra]'])
+    expect(matcher(createMockContext({ message: 'fix: update [INFRA]' }))).toBe(true)
+    expect(matcher(createMockContext({ message: 'fix: update [Infra]' }))).toBe(true)
+  })
+
+  it('returns false when message does not contain pattern', () => {
+    const matcher = messageMatcher(['[infra]'])
+    expect(matcher(createMockContext({ message: 'feat: new feature' }))).toBe(false)
+  })
+
+  it('handles empty patterns array', () => {
+    const matcher = messageMatcher([])
+    expect(matcher(createMockContext({ message: 'anything' }))).toBe(false)
+  })
+})
+
+describe('scopeRegexMatcher', () => {
+  it('returns true when scope matches regex', () => {
+    const matcher = scopeRegexMatcher(/^(ci|build|tool)-.+/)
+    expect(matcher(createMockContext({ scope: 'ci-pipeline' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'build-scripts' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'tool-package' }))).toBe(true)
+  })
+
+  it('returns false when scope does not match regex', () => {
+    const matcher = scopeRegexMatcher(/^(ci|build|tool)-.+/)
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(false) // No suffix
+    expect(matcher(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+  })
+
+  it('returns false when scope is undefined', () => {
+    const matcher = scopeRegexMatcher(/^ci/)
+    expect(matcher(createMockContext({ scope: undefined }))).toBe(false)
+  })
+})
+
+describe('anyOf', () => {
+  it('returns true if any matcher matches', () => {
+    const combined = anyOf(scopeMatcher(['ci']), scopeMatcher(['build']))
+    expect(combined(createMockContext({ scope: 'ci' }))).toBe(true)
+    expect(combined(createMockContext({ scope: 'build' }))).toBe(true)
+  })
+
+  it('returns false if no matcher matches', () => {
+    const combined = anyOf(scopeMatcher(['ci']), scopeMatcher(['build']))
+    expect(combined(createMockContext({ scope: 'feat' }))).toBe(false)
+  })
+
+  it('short-circuits on first match', () => {
+    let secondCalled = false
+    const first: InfrastructureMatcher = () => true
+    const second: InfrastructureMatcher = () => {
+      secondCalled = true
+      return true
+    }
+    const combined = anyOf(first, second)
+    combined(createMockContext())
+    expect(secondCalled).toBe(false)
+  })
+
+  it('handles empty matchers', () => {
+    const combined = anyOf()
+    expect(combined(createMockContext({ scope: 'ci' }))).toBe(false)
+  })
+})
+
+describe('allOf', () => {
+  it('returns true if all matchers match', () => {
+    const combined = allOf(scopeMatcher(['ci']), messageMatcher(['build']))
+    expect(combined(createMockContext({ scope: 'ci', message: 'ci: build pipeline' }))).toBe(true)
+  })
+
+  it('returns false if any matcher fails', () => {
+    const combined = allOf(scopeMatcher(['ci']), messageMatcher(['build']))
+    expect(combined(createMockContext({ scope: 'ci', message: 'ci: update config' }))).toBe(false)
+    expect(combined(createMockContext({ scope: 'feat', message: 'feat: build something' }))).toBe(false)
+  })
+
+  it('short-circuits on first failure', () => {
+    let secondCalled = false
+    const first: InfrastructureMatcher = () => false
+    const second: InfrastructureMatcher = () => {
+      secondCalled = true
+      return true
+    }
+    const combined = allOf(first, second)
+    combined(createMockContext())
+    expect(secondCalled).toBe(false)
+  })
+
+  it('handles empty matchers - returns true (vacuous truth)', () => {
+    const combined = allOf()
+    expect(combined(createMockContext())).toBe(true)
+  })
+})
+
+describe('not', () => {
+  it('negates a matcher that returns true', () => {
+    const matcher = scopeMatcher(['ci'])
+    const negated = not(matcher)
+    expect(negated(createMockContext({ scope: 'ci' }))).toBe(false)
+  })
+
+  it('negates a matcher that returns false', () => {
+    const matcher = scopeMatcher(['ci'])
+    const negated = not(matcher)
+    expect(negated(createMockContext({ scope: 'feat' }))).toBe(true)
+  })
+})
+
+describe('pre-built matchers', () => {
+  describe('CI_SCOPE_MATCHER', () => {
+    it('matches CI/CD scopes', () => {
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'ci' }))).toBe(true)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'cd' }))).toBe(true)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'build' }))).toBe(true)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'pipeline' }))).toBe(true)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'workflow' }))).toBe(true)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'actions' }))).toBe(true)
+    })
+
+    it('does not match non-CI scopes', () => {
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'feat' }))).toBe(false)
+      expect(CI_SCOPE_MATCHER(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+    })
+  })
+
+  describe('TOOLING_SCOPE_MATCHER', () => {
+    it('matches tooling scopes', () => {
+      expect(TOOLING_SCOPE_MATCHER(createMockContext({ scope: 'tooling' }))).toBe(true)
+      expect(TOOLING_SCOPE_MATCHER(createMockContext({ scope: 'workspace' }))).toBe(true)
+      expect(TOOLING_SCOPE_MATCHER(createMockContext({ scope: 'monorepo' }))).toBe(true)
+      expect(TOOLING_SCOPE_MATCHER(createMockContext({ scope: 'nx' }))).toBe(true)
+      expect(TOOLING_SCOPE_MATCHER(createMockContext({ scope: 'root' }))).toBe(true)
+    })
+  })
+
+  describe('TOOL_PREFIX_MATCHER', () => {
+    it('matches tool-prefixed scopes', () => {
+      expect(TOOL_PREFIX_MATCHER(createMockContext({ scope: 'tool-package' }))).toBe(true)
+      expect(TOOL_PREFIX_MATCHER(createMockContext({ scope: 'tool-scripts' }))).toBe(true)
+    })
+
+    it('does not match non-tool-prefixed scopes', () => {
+      expect(TOOL_PREFIX_MATCHER(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+      expect(TOOL_PREFIX_MATCHER(createMockContext({ scope: 'tooling' }))).toBe(false)
+    })
+  })
+
+  describe('DEFAULT_INFRA_SCOPE_MATCHER', () => {
+    it('combines CI, tooling, and tool-prefix matchers', () => {
+      // CI scopes
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'ci' }))).toBe(true)
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'build' }))).toBe(true)
+
+      // Tooling scopes
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'workspace' }))).toBe(true)
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'nx' }))).toBe(true)
+
+      // Tool-prefixed scopes
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'tool-package' }))).toBe(true)
+
+      // Non-infrastructure scopes
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'feat' }))).toBe(false)
+      expect(DEFAULT_INFRA_SCOPE_MATCHER(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+    })
+  })
+})
+
+describe('buildInfrastructureMatcher', () => {
+  it('returns null when no configuration provided', () => {
+    const matcher = buildInfrastructureMatcher({})
+    expect(matcher).toBeNull()
+  })
+
+  it('returns null when only paths provided (paths handled elsewhere)', () => {
+    const matcher = buildInfrastructureMatcher({ paths: ['tools/'] })
+    expect(matcher).toBeNull()
+  })
+
+  it('builds scope matcher from scopes config', () => {
+    const matcher = buildInfrastructureMatcher({ scopes: ['ci', 'build'] })
+    if (matcher === null) {
+      throw new Error('Expected matcher to be defined')
+    }
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'build' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'feat' }))).toBe(false)
+  })
+
+  it('uses custom matcher when provided', () => {
+    const customMatcher: InfrastructureMatcher = (ctx) => ctx.scope === 'custom'
+    const matcher = buildInfrastructureMatcher({ matcher: customMatcher })
+    if (matcher === null) {
+      throw new Error('Expected matcher to be defined')
+    }
+    expect(matcher(createMockContext({ scope: 'custom' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'other' }))).toBe(false)
+  })
+
+  it('combines scopes and custom matcher with OR logic', () => {
+    const customMatcher: InfrastructureMatcher = (ctx) => ctx.message.includes('[infra]')
+    const matcher = buildInfrastructureMatcher({
+      scopes: ['ci'],
+      matcher: customMatcher,
+    })
+    if (matcher === null) {
+      throw new Error('Expected matcher to be defined')
+    }
+
+    // Matches via scope
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(true)
+
+    // Matches via custom matcher
+    expect(matcher(createMockContext({ scope: 'feat', message: 'feat: update [infra]' }))).toBe(true)
+
+    // Does not match either
+    expect(matcher(createMockContext({ scope: 'feat', message: 'feat: normal update' }))).toBe(false)
+  })
+
+  it('handles empty scopes array', () => {
+    const matcher = buildInfrastructureMatcher({ scopes: [] })
+    expect(matcher).toBeNull()
+  })
+
+  it('returns single matcher directly when only one configured', () => {
+    const customMatcher: InfrastructureMatcher = (ctx) => ctx.scope === 'custom'
+    const matcher = buildInfrastructureMatcher({ matcher: customMatcher })
+    if (matcher === null) {
+      throw new Error('Expected matcher to be defined')
+    }
+
+    // Should work identically to the custom matcher
+    expect(matcher(createMockContext({ scope: 'custom' }))).toBe(true)
+  })
+})
+
+describe('createMatchContext', () => {
+  it('creates context from git commit', () => {
+    const commit = createMockCommit({
+      message: 'feat(scope): add feature\n\nBody text',
+      subject: 'feat(scope): add feature',
+    })
+    const context = createMatchContext(commit)
+
+    expect(context.commit).toBe(commit)
+    expect(context.subject).toBe('feat(scope): add feature')
+    expect(context.message).toBe('feat(scope): add feature\n\nBody text')
+    expect(context.scope).toBeUndefined()
+  })
+
+  it('uses provided scope', () => {
+    const commit = createMockCommit()
+    const context = createMatchContext(commit, 'my-scope')
+
+    expect(context.scope).toBe('my-scope')
+  })
+})
+
+describe('evaluateInfrastructure', () => {
+  it('evaluates commit against matcher', () => {
+    const commit = createMockCommit({ message: 'ci: update pipeline' })
+    const matcher = scopeMatcher(['ci'])
+
+    expect(evaluateInfrastructure(commit, matcher, 'ci')).toBe(true)
+  })
+
+  it('returns false when commit does not match', () => {
+    const commit = createMockCommit({ message: 'feat: new feature' })
+    const matcher = scopeMatcher(['ci'])
+
+    expect(evaluateInfrastructure(commit, matcher, 'feat')).toBe(false)
+  })
+
+  it('works without pre-parsed scope', () => {
+    const commit = createMockCommit({ message: '[infra] update config' })
+    const matcher = messageMatcher(['[infra]'])
+
+    expect(evaluateInfrastructure(commit, matcher)).toBe(true)
+  })
+})
+
+describe('complex composition scenarios', () => {
+  it('creates complex matcher with nested composition', () => {
+    // Match: (ci OR build) AND NOT release
+    const matcher = allOf(anyOf(scopeMatcher(['ci']), scopeMatcher(['build'])), not(scopeMatcher(['release'])))
+
+    expect(matcher(createMockContext({ scope: 'ci' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'build' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'release' }))).toBe(false)
+    expect(matcher(createMockContext({ scope: 'feat' }))).toBe(false)
+  })
+
+  it('creates matcher for dependencies with security updates', () => {
+    // Match: deps scope AND message contains 'security'
+    const matcher = allOf(scopeMatcher(['deps']), messageMatcher(['security']))
+
+    expect(matcher(createMockContext({ scope: 'deps', message: 'chore(deps): security update' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'deps', message: 'chore(deps): bump lodash' }))).toBe(false)
+    expect(matcher(createMockContext({ scope: 'feat', message: 'feat: security feature' }))).toBe(false)
+  })
+
+  it('creates matcher with regex and scope combinations', () => {
+    // Match: starts with 'tool-' OR matches infra regex
+    const matcher = anyOf(scopePrefixMatcher(['tool-']), scopeRegexMatcher(/^infra-/))
+
+    expect(matcher(createMockContext({ scope: 'tool-package' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'infra-ci' }))).toBe(true)
+    expect(matcher(createMockContext({ scope: 'lib-utils' }))).toBe(false)
+  })
+})

--- a/libs/versioning/src/commits/classify/infrastructure.ts
+++ b/libs/versioning/src/commits/classify/infrastructure.ts
@@ -1,0 +1,288 @@
+import type { GitCommit } from '../../git/models/commit'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
+
+/**
+ * Context provided to infrastructure matchers for decision making.
+ *
+ * Contains information about a commit that helps determine
+ * whether it should be classified as infrastructure-related.
+ */
+export interface InfrastructureMatchContext {
+  /** The git commit being evaluated */
+  readonly commit: GitCommit
+
+  /** Parsed conventional scope (convenience, may be undefined) */
+  readonly scope?: string
+
+  /** Commit message subject */
+  readonly subject: string
+
+  /** Full commit message */
+  readonly message: string
+}
+
+/**
+ * Infrastructure matcher function type.
+ *
+ * Returns true if the commit should be classified as infrastructure-related.
+ * Matchers are composable - combine them using `anyOf`, `allOf`, and `not`.
+ *
+ * @example
+ * // Simple scope matcher
+ * const ciMatcher: InfrastructureMatcher = (ctx) => ctx.scope === 'ci'
+ *
+ * @example
+ * // Using factory functions
+ * const matcher = anyOf(
+ *   scopeMatcher(['ci', 'build', 'tooling']),
+ *   pathMatcher(['tools/', '.github/'])
+ * )
+ */
+export type InfrastructureMatcher = (context: InfrastructureMatchContext) => boolean
+
+/**
+ * Configuration for building infrastructure commit sets.
+ *
+ * Supports multiple detection methods that can be combined:
+ * - Path-based: Commits touching specific file paths
+ * - Scope-based: Commits with specific conventional scopes
+ * - Custom matcher: User-provided matching logic
+ */
+export interface InfrastructureConfig {
+  /**
+   * File/directory paths that indicate infrastructure changes.
+   * Used to query git for commits touching these paths.
+   *
+   * @example ['tools/', '.github/workflows/', 'nx.json']
+   */
+  readonly paths?: readonly string[]
+
+  /**
+   * Conventional commit scopes that indicate infrastructure.
+   * Matched against parsed commit scope.
+   *
+   * @example ['ci', 'build', 'tooling', 'workspace']
+   */
+  readonly scopes?: readonly string[]
+
+  /**
+   * Custom matcher function for complex logic.
+   * Combined with paths/scopes using OR logic.
+   *
+   * @example (ctx) => ctx.message.includes('[infra]')
+   */
+  readonly matcher?: InfrastructureMatcher
+}
+
+/**
+ * Creates a matcher that checks if commit scope matches any of the given scopes.
+ *
+ * @param scopes - Scopes to match against (case-insensitive)
+ * @returns Matcher that returns true if scope matches
+ *
+ * @example
+ * const matcher = scopeMatcher(['ci', 'build', 'tooling'])
+ * matcher({ scope: 'CI', ... }) // true
+ * matcher({ scope: 'feat', ... }) // false
+ */
+export function scopeMatcher(scopes: readonly string[]): InfrastructureMatcher {
+  const normalizedScopes = createSet(scopes.map((s) => s.toLowerCase()))
+  return (ctx) => {
+    if (!ctx.scope) return false
+    return normalizedScopes.has(ctx.scope.toLowerCase())
+  }
+}
+
+/**
+ * Creates a matcher that checks if commit scope starts with any of the given prefixes.
+ *
+ * @param prefixes - Scope prefixes to match (case-insensitive)
+ * @returns Matcher that returns true if scope starts with any prefix
+ *
+ * @example
+ * const matcher = scopePrefixMatcher(['tool-', 'infra-'])
+ * matcher({ scope: 'tool-package', ... }) // true
+ * matcher({ scope: 'lib-utils', ... }) // false
+ */
+export function scopePrefixMatcher(prefixes: readonly string[]): InfrastructureMatcher {
+  const normalizedPrefixes = prefixes.map((p) => p.toLowerCase())
+  return (ctx) => {
+    if (!ctx.scope) return false
+    const normalizedScope = ctx.scope.toLowerCase()
+    return normalizedPrefixes.some((prefix) => normalizedScope.startsWith(prefix))
+  }
+}
+
+/**
+ * Creates a matcher that checks if commit message contains any of the given patterns.
+ *
+ * @param patterns - Patterns to search for in commit message (case-insensitive)
+ * @returns Matcher that returns true if message contains any pattern
+ *
+ * @example
+ * const matcher = messageMatcher(['[infra]', '[ci skip]'])
+ */
+export function messageMatcher(patterns: readonly string[]): InfrastructureMatcher {
+  const normalizedPatterns = patterns.map((p) => p.toLowerCase())
+  return (ctx) => {
+    const normalizedMessage = ctx.message.toLowerCase()
+    return normalizedPatterns.some((pattern) => normalizedMessage.includes(pattern))
+  }
+}
+
+/**
+ * Creates a matcher from a regex pattern tested against the scope.
+ *
+ * @param pattern - Regex pattern to test against scope
+ * @returns Matcher that returns true if scope matches regex
+ *
+ * @example
+ * const matcher = scopeRegexMatcher(/^(ci|build|tool)-.+/)
+ */
+export function scopeRegexMatcher(pattern: RegExp): InfrastructureMatcher {
+  return (ctx) => {
+    if (!ctx.scope) return false
+    return pattern.test(ctx.scope)
+  }
+}
+
+/**
+ * Combines matchers with OR logic - returns true if ANY matcher matches.
+ *
+ * @param matchers - Matchers to combine
+ * @returns Combined matcher
+ *
+ * @example
+ * const combined = anyOf(
+ *   scopeMatcher(['ci', 'build']),
+ *   messageMatcher(['[infra]']),
+ *   custom((ctx) => ctx.scope?.startsWith('tool-'))
+ * )
+ */
+export function anyOf(...matchers: readonly InfrastructureMatcher[]): InfrastructureMatcher {
+  return (ctx) => matchers.some((matcher) => matcher(ctx))
+}
+
+/**
+ * Combines matchers with AND logic - returns true if ALL matchers match.
+ *
+ * @param matchers - Matchers to combine
+ * @returns Combined matcher
+ *
+ * @example
+ * const combined = allOf(
+ *   scopeMatcher(['deps']),
+ *   messageMatcher(['security'])
+ * )
+ */
+export function allOf(...matchers: readonly InfrastructureMatcher[]): InfrastructureMatcher {
+  return (ctx) => matchers.every((matcher) => matcher(ctx))
+}
+
+/**
+ * Negates a matcher - returns true if matcher returns false.
+ *
+ * @param matcher - Matcher to negate
+ * @returns Negated matcher
+ *
+ * @example
+ * const notRelease = not(scopeMatcher(['release']))
+ */
+export function not(matcher: InfrastructureMatcher): InfrastructureMatcher {
+  return (ctx) => !matcher(ctx)
+}
+
+/**
+ * Matches common CI/CD scopes.
+ *
+ * Matches: ci, cd, build, pipeline, workflow, actions
+ */
+export const CI_SCOPE_MATCHER: InfrastructureMatcher = scopeMatcher(['ci', 'cd', 'build', 'pipeline', 'workflow', 'actions'])
+
+/**
+ * Matches common tooling/workspace scopes.
+ *
+ * Matches: tooling, workspace, monorepo, nx, root
+ */
+export const TOOLING_SCOPE_MATCHER: InfrastructureMatcher = scopeMatcher(['tooling', 'workspace', 'monorepo', 'nx', 'root'])
+
+/**
+ * Matches tool-prefixed scopes (e.g., tool-package, tool-scripts).
+ */
+export const TOOL_PREFIX_MATCHER: InfrastructureMatcher = scopePrefixMatcher(['tool-'])
+
+/**
+ * Combined matcher for common infrastructure patterns.
+ *
+ * Combines CI, tooling, and tool-prefix matchers.
+ */
+export const DEFAULT_INFRA_SCOPE_MATCHER: InfrastructureMatcher = anyOf(CI_SCOPE_MATCHER, TOOLING_SCOPE_MATCHER, TOOL_PREFIX_MATCHER)
+
+/**
+ * Builds a combined matcher from infrastructure configuration.
+ *
+ * Combines scope-based matching with any custom matcher using OR logic.
+ * Path-based matching is handled separately via git queries.
+ *
+ * @param config - Infrastructure configuration
+ * @returns Combined matcher, or null if no matchers configured
+ *
+ * @example
+ * const matcher = buildInfrastructureMatcher({
+ *   scopes: ['ci', 'build'],
+ *   matcher: (ctx) => ctx.scope?.startsWith('tool-')
+ * })
+ */
+export function buildInfrastructureMatcher(config: InfrastructureConfig): InfrastructureMatcher | null {
+  const matchers: InfrastructureMatcher[] = []
+
+  // Add scope matcher if scopes configured
+  if (config.scopes && config.scopes.length > 0) {
+    matchers.push(scopeMatcher(config.scopes))
+  }
+
+  // Add custom matcher if provided
+  if (config.matcher) {
+    matchers.push(config.matcher)
+  }
+
+  // Return combined or null
+  if (matchers.length === 0) {
+    return null
+  }
+  if (matchers.length === 1) {
+    return matchers[0]
+  }
+  return anyOf(...matchers)
+}
+
+/**
+ * Creates match context from a git commit.
+ *
+ * Extracts scope from conventional commit message if present.
+ *
+ * @param commit - Git commit to create context for
+ * @param scope - Pre-parsed scope (optional, saves re-parsing)
+ * @returns Match context for use with matchers
+ */
+export function createMatchContext(commit: GitCommit, scope?: string): InfrastructureMatchContext {
+  return {
+    commit,
+    scope,
+    subject: commit.subject,
+    message: commit.message,
+  }
+}
+
+/**
+ * Evaluates a commit against an infrastructure matcher.
+ *
+ * @param commit - Git commit to evaluate
+ * @param matcher - Matcher function to apply
+ * @param scope - Pre-parsed scope (optional)
+ * @returns True if commit matches infrastructure criteria
+ */
+export function evaluateInfrastructure(commit: GitCommit, matcher: InfrastructureMatcher, scope?: string): boolean {
+  const context = createMatchContext(commit, scope)
+  return matcher(context)
+}

--- a/libs/versioning/src/commits/classify/models.spec.ts
+++ b/libs/versioning/src/commits/classify/models.spec.ts
@@ -1,0 +1,128 @@
+import { createGitCommit } from '../../git/models/commit'
+import { createConventionalCommit } from '../models/conventional'
+import { createClassifiedCommit, createEmptyClassificationSummary } from './models'
+
+describe('createEmptyClassificationSummary', () => {
+  it('creates a summary with all counts at zero', () => {
+    const summary = createEmptyClassificationSummary()
+
+    expect(summary.total).toBe(0)
+    expect(summary.included).toBe(0)
+    expect(summary.excluded).toBe(0)
+    expect(summary.bySource['direct-scope']).toBe(0)
+    expect(summary.bySource['direct-file']).toBe(0)
+    expect(summary.bySource['unscoped-file']).toBe(0)
+    expect(summary.bySource['indirect-dependency']).toBe(0)
+    expect(summary.bySource['indirect-infra']).toBe(0)
+    expect(summary.bySource['unscoped-global']).toBe(0)
+    expect(summary.bySource['excluded']).toBe(0)
+  })
+})
+
+describe('createClassifiedCommit', () => {
+  const commit = createConventionalCommit('feat', 'add feature', { scope: 'versioning' })
+  const raw = createGitCommit({
+    hash: 'abc123def456789012345678901234567890abcd',
+    authorName: 'Test Author',
+    authorEmail: 'test@example.com',
+    authorDate: '2026-03-17T10:00:00Z',
+    subject: 'feat(versioning): add feature',
+  })
+
+  describe('direct-scope source', () => {
+    it('sets include to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'direct-scope')
+      expect(classified.include).toBe(true)
+    })
+
+    it('sets preserveScope to false', () => {
+      const classified = createClassifiedCommit(commit, raw, 'direct-scope')
+      expect(classified.preserveScope).toBe(false)
+    })
+  })
+
+  describe('direct-file source', () => {
+    it('sets include to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'direct-file')
+      expect(classified.include).toBe(true)
+    })
+
+    it('sets preserveScope to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'direct-file')
+      expect(classified.preserveScope).toBe(true)
+    })
+  })
+
+  describe('unscoped-file source', () => {
+    it('sets include to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'unscoped-file')
+      expect(classified.include).toBe(true)
+    })
+
+    it('sets preserveScope to false', () => {
+      const classified = createClassifiedCommit(commit, raw, 'unscoped-file')
+      expect(classified.preserveScope).toBe(false)
+    })
+  })
+
+  describe('indirect-dependency source', () => {
+    it('sets include to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-dependency')
+      expect(classified.include).toBe(true)
+    })
+
+    it('sets preserveScope to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-dependency')
+      expect(classified.preserveScope).toBe(true)
+    })
+
+    it('can include dependency path', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-dependency', {
+        dependencyPath: ['lib-utils', 'lib-core'],
+      })
+      expect(classified.dependencyPath).toEqual(['lib-utils', 'lib-core'])
+    })
+  })
+
+  describe('indirect-infra source', () => {
+    it('sets include to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-infra')
+      expect(classified.include).toBe(true)
+    })
+
+    it('sets preserveScope to true', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-infra')
+      expect(classified.preserveScope).toBe(true)
+    })
+  })
+
+  describe('unscoped-global source', () => {
+    it('sets include to false', () => {
+      const classified = createClassifiedCommit(commit, raw, 'unscoped-global')
+      expect(classified.include).toBe(false)
+    })
+  })
+
+  describe('excluded source', () => {
+    it('sets include to false', () => {
+      const classified = createClassifiedCommit(commit, raw, 'excluded')
+      expect(classified.include).toBe(false)
+    })
+  })
+
+  describe('optional fields', () => {
+    it('includes touchedFiles when provided', () => {
+      const classified = createClassifiedCommit(commit, raw, 'direct-file', {
+        touchedFiles: ['src/index.ts', 'src/utils.ts'],
+      })
+      expect(classified.touchedFiles).toEqual(['src/index.ts', 'src/utils.ts'])
+    })
+
+    it('includes dependencyPath when provided', () => {
+      const classified = createClassifiedCommit(commit, raw, 'indirect-dependency', {
+        dependencyPath: ['lib-utils'],
+      })
+      expect(classified.dependencyPath).toEqual(['lib-utils'])
+    })
+  })
+})

--- a/libs/versioning/src/commits/classify/models.ts
+++ b/libs/versioning/src/commits/classify/models.ts
@@ -1,0 +1,214 @@
+import type { GitCommit } from '../../git/models/commit'
+import type { ConventionalCommit } from '../models/conventional'
+
+/**
+ * Source of how a commit relates to a project.
+ *
+ * Classification determines whether a commit should appear in a
+ * project's changelog and how its scope should be displayed.
+ */
+export type CommitSource =
+  | 'direct-scope' // Conventional commit scope matches project
+  | 'direct-file' // Commit touched files in project directory
+  | 'unscoped-file' // No scope but touched project files (direct)
+  | 'indirect-dependency' // Commit to a dependency package
+  | 'indirect-infra' // Commit to build/tooling infrastructure
+  | 'unscoped-global' // No scope and no project files touched
+  | 'excluded' // Does not relate to project
+
+/**
+ * A commit with classification metadata for changelog generation.
+ *
+ * Contains the original commit data plus attribution information
+ * that determines inclusion and presentation in changelogs.
+ */
+export interface ClassifiedCommit {
+  /** The parsed conventional commit */
+  readonly commit: ConventionalCommit
+
+  /** The raw git commit (for hash, date, etc.) */
+  readonly raw: GitCommit
+
+  /** How this commit relates to the project */
+  readonly source: CommitSource
+
+  /** Whether to include this commit in changelog */
+  readonly include: boolean
+
+  /** Whether to preserve scope in changelog output */
+  readonly preserveScope: boolean
+
+  /** Files in this project touched by the commit (if applicable) */
+  readonly touchedFiles?: readonly string[]
+
+  /** Dependency chain if indirect (e.g., ['lib-utils'] for lib-app → lib-utils) */
+  readonly dependencyPath?: readonly string[]
+}
+
+/**
+ * Input for classification - a parsed commit with its raw git data.
+ */
+export interface CommitWithRaw {
+  /** The parsed conventional commit */
+  readonly commit: ConventionalCommit
+
+  /** The raw git commit data */
+  readonly raw: GitCommit
+}
+
+/**
+ * Classification context containing project and workspace info.
+ */
+export interface ClassificationContext {
+  /** Scopes that should be considered direct matches */
+  readonly projectScopes: readonly string[]
+
+  /** Set of commit hashes that touched project files */
+  readonly fileCommitHashes: ReadonlySet<string>
+
+  /** Map of dependency name to set of commit hashes touching that dependency */
+  readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
+
+  /** Infrastructure paths to consider as indirect-infra */
+  readonly infrastructurePaths?: readonly string[]
+
+  /** Scopes to always exclude */
+  readonly excludeScopes?: readonly string[]
+
+  /** Additional scopes to include as direct */
+  readonly includeScopes?: readonly string[]
+}
+
+/**
+ * Result of classifying multiple commits.
+ */
+export interface ClassificationResult {
+  /** All classified commits */
+  readonly commits: readonly ClassifiedCommit[]
+
+  /** Commits to include in changelog */
+  readonly included: readonly ClassifiedCommit[]
+
+  /** Commits excluded from changelog */
+  readonly excluded: readonly ClassifiedCommit[]
+
+  /** Summary statistics */
+  readonly summary: ClassificationSummary
+}
+
+/**
+ * Summary statistics from classification.
+ */
+export interface ClassificationSummary {
+  /** Total commits processed */
+  readonly total: number
+
+  /** Commits included in changelog */
+  readonly included: number
+
+  /** Commits excluded from changelog */
+  readonly excluded: number
+
+  /** Breakdown by source type */
+  readonly bySource: Readonly<Record<CommitSource, number>>
+}
+
+/**
+ * Creates an empty classification summary.
+ *
+ * @returns A new ClassificationSummary with all counts at zero
+ */
+export function createEmptyClassificationSummary(): ClassificationSummary {
+  return {
+    total: 0,
+    included: 0,
+    excluded: 0,
+    bySource: {
+      'direct-scope': 0,
+      'direct-file': 0,
+      'unscoped-file': 0,
+      'indirect-dependency': 0,
+      'indirect-infra': 0,
+      'unscoped-global': 0,
+      excluded: 0,
+    },
+  }
+}
+
+/**
+ * Creates a classified commit.
+ *
+ * @param commit - The parsed conventional commit
+ * @param raw - The raw git commit
+ * @param source - How the commit relates to the project
+ * @param options - Additional classification options
+ * @param options.touchedFiles - Files in the project modified by this commit
+ * @param options.dependencyPath - Chain of dependencies leading to indirect inclusion
+ * @returns A new ClassifiedCommit object
+ */
+export function createClassifiedCommit(
+  commit: ConventionalCommit,
+  raw: GitCommit,
+  source: CommitSource,
+  options?: {
+    readonly touchedFiles?: readonly string[]
+    readonly dependencyPath?: readonly string[]
+  }
+): ClassifiedCommit {
+  const include = isIncludedSource(source)
+  const preserveScope = shouldPreserveScope(source)
+
+  return {
+    commit,
+    raw,
+    source,
+    include,
+    preserveScope,
+    touchedFiles: options?.touchedFiles,
+    dependencyPath: options?.dependencyPath,
+  }
+}
+
+/**
+ * Determines if a source type should be included in changelog.
+ *
+ * @param source - The commit source type
+ * @returns True if commits with this source should be included
+ */
+function isIncludedSource(source: CommitSource): boolean {
+  switch (source) {
+    case 'direct-scope':
+    case 'direct-file':
+    case 'unscoped-file':
+    case 'indirect-dependency':
+    case 'indirect-infra':
+      return true
+    case 'unscoped-global':
+    case 'excluded':
+      return false
+  }
+}
+
+/**
+ * Determines if scope should be preserved for a source type.
+ *
+ * Direct commits omit scope (redundant in project changelog).
+ * Indirect commits preserve scope for context.
+ *
+ * @param source - The commit source type
+ * @returns True if scope should be preserved in changelog
+ */
+function shouldPreserveScope(source: CommitSource): boolean {
+  switch (source) {
+    case 'direct-scope':
+    case 'unscoped-file':
+      return false // Scope would be redundant
+    case 'direct-file':
+    case 'indirect-dependency':
+    case 'indirect-infra':
+      return true // Scope provides context
+    case 'unscoped-global':
+    case 'excluded':
+      return false // Won't be shown
+  }
+}

--- a/libs/versioning/src/commits/classify/models.ts
+++ b/libs/versioning/src/commits/classify/models.ts
@@ -69,8 +69,11 @@ export interface ClassificationContext {
   /** Map of dependency name to set of commit hashes touching that dependency */
   readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
 
-  /** Infrastructure paths to consider as indirect-infra */
-  readonly infrastructurePaths?: readonly string[]
+  /**
+   * Set of commit hashes that touched infrastructure paths.
+   * These commits will be classified as 'indirect-infra'.
+   */
+  readonly infrastructureCommitHashes?: ReadonlySet<string>
 
   /** Scopes to always exclude */
   readonly excludeScopes?: readonly string[]

--- a/libs/versioning/src/commits/classify/project-scopes.spec.ts
+++ b/libs/versioning/src/commits/classify/project-scopes.spec.ts
@@ -1,0 +1,153 @@
+import { deriveProjectScopes, scopeMatchesProject, scopeIsExcluded, DEFAULT_EXCLUDE_SCOPES } from './project-scopes'
+
+describe('deriveProjectScopes', () => {
+  describe('project name variations', () => {
+    it('includes the full project name', () => {
+      const scopes = deriveProjectScopes({ projectName: 'lib-versioning' })
+      expect(scopes).toContain('lib-versioning')
+    })
+
+    it('strips lib- prefix', () => {
+      const scopes = deriveProjectScopes({ projectName: 'lib-versioning' })
+      expect(scopes).toContain('versioning')
+    })
+
+    it('strips app- prefix', () => {
+      const scopes = deriveProjectScopes({ projectName: 'app-demo' })
+      expect(scopes).toContain('demo')
+    })
+
+    it('strips e2e- prefix', () => {
+      const scopes = deriveProjectScopes({ projectName: 'e2e-cryptography' })
+      expect(scopes).toContain('cryptography')
+    })
+
+    it('strips tool- prefix', () => {
+      const scopes = deriveProjectScopes({ projectName: 'tool-package' })
+      expect(scopes).toContain('package')
+    })
+
+    it('handles project names without prefixes', () => {
+      const scopes = deriveProjectScopes({ projectName: 'cryptography' })
+      expect(scopes).toEqual(['cryptography'])
+    })
+  })
+
+  describe('package name variations', () => {
+    it('extracts unscoped name from @scope/name', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-versioning',
+        packageName: '@hyperfrontend/versioning',
+      })
+      expect(scopes).toContain('versioning')
+    })
+
+    it('handles non-scoped package names', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-demo',
+        packageName: 'demo-app',
+      })
+      expect(scopes).toContain('demo-app')
+    })
+
+    it('deduplicates scope variations', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-versioning',
+        packageName: '@hyperfrontend/versioning',
+      })
+      // 'versioning' appears from both project name and package name
+      const versioningCount = scopes.filter((s) => s === 'versioning').length
+      expect(versioningCount).toBe(1)
+    })
+  })
+
+  describe('additional scopes', () => {
+    it('includes additional scopes', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-versioning',
+        additionalScopes: ['semver', 'version-utils'],
+      })
+      expect(scopes).toContain('semver')
+      expect(scopes).toContain('version-utils')
+    })
+
+    it('deduplicates additional scopes', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-versioning',
+        additionalScopes: ['versioning', 'versioning'],
+      })
+      const versioningCount = scopes.filter((s) => s === 'versioning').length
+      expect(versioningCount).toBe(1)
+    })
+
+    it('filters empty strings', () => {
+      const scopes = deriveProjectScopes({
+        projectName: 'lib-versioning',
+        additionalScopes: ['', 'valid'],
+      })
+      expect(scopes).not.toContain('')
+      expect(scopes).toContain('valid')
+    })
+  })
+})
+
+describe('scopeMatchesProject', () => {
+  const projectScopes = ['lib-versioning', 'versioning']
+
+  it('matches exact scope', () => {
+    expect(scopeMatchesProject('versioning', projectScopes)).toBe(true)
+    expect(scopeMatchesProject('lib-versioning', projectScopes)).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    expect(scopeMatchesProject('Versioning', projectScopes)).toBe(true)
+    expect(scopeMatchesProject('VERSIONING', projectScopes)).toBe(true)
+  })
+
+  it('returns false for non-matching scope', () => {
+    expect(scopeMatchesProject('logging', projectScopes)).toBe(false)
+    expect(scopeMatchesProject('cryptography', projectScopes)).toBe(false)
+  })
+
+  it('returns false for undefined scope', () => {
+    expect(scopeMatchesProject(undefined, projectScopes)).toBe(false)
+  })
+
+  it('returns false for empty scope', () => {
+    expect(scopeMatchesProject('', projectScopes)).toBe(false)
+  })
+})
+
+describe('scopeIsExcluded', () => {
+  const excludeScopes = ['release', 'deps']
+
+  it('returns true for excluded scope', () => {
+    expect(scopeIsExcluded('release', excludeScopes)).toBe(true)
+    expect(scopeIsExcluded('deps', excludeScopes)).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    expect(scopeIsExcluded('Release', excludeScopes)).toBe(true)
+    expect(scopeIsExcluded('DEPS', excludeScopes)).toBe(true)
+  })
+
+  it('returns false for non-excluded scope', () => {
+    expect(scopeIsExcluded('versioning', excludeScopes)).toBe(false)
+  })
+
+  it('returns false for undefined scope', () => {
+    expect(scopeIsExcluded(undefined, excludeScopes)).toBe(false)
+  })
+})
+
+describe('DEFAULT_EXCLUDE_SCOPES', () => {
+  it('includes common infrastructure scopes', () => {
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('release')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('deps')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('workspace')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('root')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('repo')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('ci')
+    expect(DEFAULT_EXCLUDE_SCOPES).toContain('build')
+  })
+})

--- a/libs/versioning/src/commits/classify/project-scopes.ts
+++ b/libs/versioning/src/commits/classify/project-scopes.ts
@@ -1,0 +1,163 @@
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
+
+/**
+ * Options for deriving project scopes.
+ */
+export interface DeriveProjectScopesOptions {
+  /** The project name (e.g., 'lib-versioning') */
+  readonly projectName: string
+
+  /** The npm package name (e.g., '@hyperfrontend/versioning') */
+  readonly packageName?: string
+
+  /** Additional scopes to include */
+  readonly additionalScopes?: readonly string[]
+}
+
+/**
+ * Derives all scope variations that should match a project.
+ *
+ * Given a project named 'lib-versioning' with package '@hyperfrontend/versioning',
+ * this generates variations like:
+ * - 'lib-versioning' (full project name)
+ * - 'versioning' (without lib- prefix)
+ *
+ * @param options - Project identification options
+ * @returns Array of scope strings that match this project
+ *
+ * @example
+ * deriveProjectScopes({ projectName: 'lib-versioning', packageName: '@hyperfrontend/versioning' })
+ * // Returns: ['lib-versioning', 'versioning']
+ *
+ * @example
+ * deriveProjectScopes({ projectName: 'app-demo', packageName: 'demo-app' })
+ * // Returns: ['app-demo', 'demo']
+ */
+export function deriveProjectScopes(options: DeriveProjectScopesOptions): readonly string[] {
+  const { projectName, packageName, additionalScopes = [] } = options
+  const scopes = createSet<string>()
+
+  // Always include the full project name
+  scopes.add(projectName)
+
+  // Add variations based on common prefixes
+  const prefixVariations = extractPrefixVariations(projectName)
+  for (const variation of prefixVariations) {
+    scopes.add(variation)
+  }
+
+  // Add package name variations if provided
+  if (packageName) {
+    const packageVariations = extractPackageNameVariations(packageName)
+    for (const variation of packageVariations) {
+      scopes.add(variation)
+    }
+  }
+
+  // Add any additional scopes
+  for (const scope of additionalScopes) {
+    if (scope) {
+      scopes.add(scope)
+    }
+  }
+
+  return [...scopes]
+}
+
+/**
+ * Recognized project name prefixes that can be stripped for scope matching.
+ */
+const PROJECT_PREFIXES = <const>['lib-', 'app-', 'e2e-', 'tool-', 'plugin-', 'feature-', 'package-']
+
+/**
+ * Generates scope variations by stripping recognized project prefixes.
+ *
+ * @param projectName - The project name to extract variations from
+ * @returns Array of scope name variations
+ */
+function extractPrefixVariations(projectName: string): readonly string[] {
+  const variations: string[] = []
+
+  for (const prefix of PROJECT_PREFIXES) {
+    if (projectName.startsWith(prefix)) {
+      const withoutPrefix = projectName.slice(prefix.length)
+      if (withoutPrefix) {
+        variations.push(withoutPrefix)
+      }
+      break // Only remove one prefix
+    }
+  }
+
+  return variations
+}
+
+/**
+ * Extracts scope variations from an npm package name.
+ *
+ * @param packageName - The npm package name (e.g., '@scope/name')
+ * @returns Array of name variations
+ */
+function extractPackageNameVariations(packageName: string): readonly string[] {
+  const variations: string[] = []
+
+  // Handle scoped packages: @scope/name -> name
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/')
+    if (slashIndex !== -1) {
+      const unscoped = packageName.slice(slashIndex + 1)
+      if (unscoped) {
+        variations.push(unscoped)
+      }
+    }
+  } else {
+    // Non-scoped package: just use the name
+    variations.push(packageName)
+  }
+
+  return variations
+}
+
+/**
+ * Checks if a commit scope matches any of the project scopes.
+ *
+ * @param commitScope - The scope from a conventional commit
+ * @param projectScopes - Array of scopes that match the project
+ * @returns True if the commit scope matches the project
+ *
+ * @example
+ * scopeMatchesProject('versioning', ['lib-versioning', 'versioning']) // true
+ * scopeMatchesProject('logging', ['lib-versioning', 'versioning']) // false
+ */
+export function scopeMatchesProject(commitScope: string | undefined, projectScopes: readonly string[]): boolean {
+  if (!commitScope) {
+    return false
+  }
+
+  // Case-insensitive comparison
+  const normalizedScope = commitScope.toLowerCase()
+  return projectScopes.some((scope) => scope.toLowerCase() === normalizedScope)
+}
+
+/**
+ * Checks if a commit scope should be explicitly excluded.
+ *
+ * @param commitScope - The scope from a conventional commit
+ * @param excludeScopes - Array of scopes to exclude
+ * @returns True if the scope should be excluded
+ */
+export function scopeIsExcluded(commitScope: string | undefined, excludeScopes: readonly string[]): boolean {
+  if (!commitScope) {
+    return false
+  }
+
+  const normalizedScope = commitScope.toLowerCase()
+  return excludeScopes.some((scope) => scope.toLowerCase() === normalizedScope)
+}
+
+/**
+ * Default scopes to exclude from changelogs.
+ *
+ * These represent repository-level or infrastructure changes
+ * that typically don't belong in individual project changelogs.
+ */
+export const DEFAULT_EXCLUDE_SCOPES: readonly string[] = ['release', 'deps', 'workspace', 'root', 'repo', 'ci', 'build']

--- a/libs/versioning/src/commits/index.ts
+++ b/libs/versioning/src/commits/index.ts
@@ -1,2 +1,3 @@
+export * from './classify'
 export * from './models'
 export * from './parse'

--- a/libs/versioning/src/flow/README.md
+++ b/libs/versioning/src/flow/README.md
@@ -122,6 +122,7 @@ flowchart LR
 | Function                          | Description                           | Implementation                                         |
 | --------------------------------- | ------------------------------------- | ------------------------------------------------------ |
 | `createFetchRegistryStep()`       | Fetch published version from registry | [fetch-registry.ts](./steps/fetch-registry.ts)         |
+| `createResolveRepositoryStep()`   | Resolve repository for compare URLs   | [resolve-repository.ts](./steps/resolve-repository.ts) |
 | `createAnalyzeCommitsStep()`      | Parse commits since last release      | [analyze-commits.ts](./steps/analyze-commits.ts)       |
 | `createCalculateBumpStep()`       | Calculate version bump type           | [calculate-bump.ts](./steps/calculate-bump.ts)         |
 | `createCheckIdempotencyStep()`    | Skip if version already published     | [fetch-registry.ts](./steps/fetch-registry.ts)         |
@@ -234,21 +235,59 @@ sequenceDiagram
 
 ## Configuration
 
-| Option                | Type       | Default                               | Description                      |
-| --------------------- | ---------- | ------------------------------------- | -------------------------------- |
-| `preset`              | `string`   | `'conventional'`                      | Flow preset name                 |
-| `releaseTypes`        | `string[]` | `['feat', 'fix', 'perf', 'revert']`   | Types that trigger releases      |
-| `minorTypes`          | `string[]` | `['feat']`                            | Types that trigger minor bumps   |
-| `patchTypes`          | `string[]` | `['fix', 'perf', 'revert']`           | Types that trigger patch bumps   |
-| `skipGit`             | `boolean`  | `false`                               | Skip git operations              |
-| `skipTag`             | `boolean`  | `true`                                | Skip tag creation                |
-| `skipChangelog`       | `boolean`  | `false`                               | Skip changelog update            |
-| `dryRun`              | `boolean`  | `false`                               | Preview without changes          |
-| `commitMessage`       | `string`   | `'chore(${projectName}): release...'` | Commit message template          |
-| `tagFormat`           | `string`   | `'${projectName}@${version}'`         | Tag name template                |
-| `trackDeps`           | `boolean`  | `false`                               | Track dependency bumps           |
-| `releaseBranch`       | `string`   | `'main'`                              | Allowed release branch           |
-| `firstReleaseVersion` | `string`   | `'0.1.0'`                             | Initial version for new packages |
+| Option                | Type       | Default                               | Description                                    |
+| --------------------- | ---------- | ------------------------------------- | ---------------------------------------------- |
+| `preset`              | `string`   | `'conventional'`                      | Flow preset name                               |
+| `releaseTypes`        | `string[]` | `['feat', 'fix', 'perf', 'revert']`   | Types that trigger releases                    |
+| `minorTypes`          | `string[]` | `['feat']`                            | Types that trigger minor bumps                 |
+| `patchTypes`          | `string[]` | `['fix', 'perf', 'revert']`           | Types that trigger patch bumps                 |
+| `skipGit`             | `boolean`  | `false`                               | Skip git operations                            |
+| `skipTag`             | `boolean`  | `true`                                | Skip tag creation                              |
+| `skipChangelog`       | `boolean`  | `false`                               | Skip changelog update                          |
+| `dryRun`              | `boolean`  | `false`                               | Preview without changes                        |
+| `commitMessage`       | `string`   | `'chore(${projectName}): release...'` | Commit message template                        |
+| `tagFormat`           | `string`   | `'${projectName}@${version}'`         | Tag name template                              |
+| `trackDeps`           | `boolean`  | `false`                               | Track dependency bumps                         |
+| `releaseBranch`       | `string`   | `'main'`                              | Allowed release branch                         |
+| `firstReleaseVersion` | `string`   | `'0.1.0'`                             | Initial version for new packages               |
+| `repository`          | `*`        | `undefined`                           | Repository config for compare URLs (see below) |
+
+### Repository Configuration
+
+The `repository` option controls compare URL generation in changelog entries:
+
+```typescript
+// Auto-detect from package.json or git remote
+createVersionFlow('conventional', { repository: 'inferred' })
+
+// Disable compare URLs
+createVersionFlow('conventional', { repository: 'disabled' })
+
+// Explicit configuration
+createVersionFlow('conventional', {
+  repository: {
+    mode: 'explicit',
+    repository: {
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    },
+  },
+})
+
+// Inferred with custom order
+createVersionFlow('conventional', {
+  repository: {
+    mode: 'inferred',
+    inferenceOrder: ['git-remote', 'package-json'], // Try git first
+  },
+})
+```
+
+When repository is resolved, changelog entries include compare URLs:
+
+```markdown
+## [1.2.0](https://github.com/owner/repo/compare/v1.1.0...v1.2.0) - 2026-03-17
+```
 
 ## Step Dependencies
 

--- a/libs/versioning/src/flow/executor/execute.spec.ts
+++ b/libs/versioning/src/flow/executor/execute.spec.ts
@@ -7,6 +7,25 @@ import { createSkippedResult, createStep, createSuccessResult } from '../models/
 import { createMinimalFlow } from '../presets/conventional'
 import { dryRun, executeFlow, validateFlow } from './execute'
 
+// Mock external discovery modules
+jest.mock('@hyperfrontend/project-scope/nx', () => ({
+  isNxWorkspace: jest.fn(),
+  discoverNxProjects: jest.fn(),
+}))
+
+jest.mock('../../workspace/discovery', () => ({
+  discoverProjectByName: jest.fn(),
+}))
+
+jest.mock('@hyperfrontend/project-scope', () => ({
+  createTree: jest.fn(),
+  commitChanges: jest.fn(),
+}))
+
+const projectScopeNx = require('@hyperfrontend/project-scope/nx')
+const workspaceDiscovery = require('../../workspace/discovery')
+const projectScope = require('@hyperfrontend/project-scope')
+
 function createMockTree(files: Record<string, string> = {}): Tree {
   const fileSystem = new Map(Object.entries(files))
 
@@ -162,12 +181,18 @@ function createMockLogger() {
   }
 }
 
-// ============================================================================
-// resolveProjectRoot Tests (internal function tested via executeFlow)
-// ============================================================================
+// Reset mocks before each test
+beforeEach(() => {
+  jest.clearAllMocks()
+  // Default mock implementations - most tests use explicit projectRoot
+  projectScopeNx.isNxWorkspace.mockReturnValue(false)
+  projectScopeNx.discoverNxProjects.mockReturnValue(new Map())
+  workspaceDiscovery.discoverProjectByName.mockReturnValue(null)
+  projectScope.commitChanges.mockImplementation(() => void 0)
+})
 
-describe('executeFlow - resolveProjectRoot behavior', () => {
-  it('resolves lib- prefix projects to libs/ folder', async () => {
+describe('executeFlow - project discovery with explicit projectRoot', () => {
+  it('executes flow with explicit projectRoot for libs/ project', async () => {
     const flow = createMinimalFlow({ dryRun: true, skipGit: true })
     const tree = createMockTree({
       '/workspace/libs/utils/package.json': JSON.stringify({
@@ -180,13 +205,14 @@ describe('executeFlow - resolveProjectRoot behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/utils',
     })
 
     // Flow should execute and find the package
     expect(result.status).not.toBe('failed')
   })
 
-  it('resolves app- prefix projects to apps/ folder', async () => {
+  it('executes flow with explicit projectRoot for apps/ project', async () => {
     const flow = createMinimalFlow({ dryRun: true, skipGit: true })
     const tree = createMockTree({
       '/workspace/apps/frontend/package.json': JSON.stringify({
@@ -199,13 +225,32 @@ describe('executeFlow - resolveProjectRoot behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'apps/frontend',
     })
 
-    // Flow should execute (may not find file but should not crash)
-    expect(result).toBeDefined()
+    expect(result.status).not.toBe('failed')
   })
 
-  it('resolves projects without prefix to libs/ folder', async () => {
+  it('executes flow with nested project path', async () => {
+    const flow = createMinimalFlow({ dryRun: true, skipGit: true })
+    const tree = createMockTree({
+      '/workspace/libs/utils/myproject/package.json': JSON.stringify({
+        name: '@test/myproject',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-myproject', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/utils/myproject',
+    })
+
+    expect(result.status).not.toBe('failed')
+  })
+
+  it('fails gracefully when project cannot be discovered without projectRoot', async () => {
     const flow = createMinimalFlow({ dryRun: true, skipGit: true })
     const tree = createMockTree({
       '/workspace/libs/myproject/package.json': JSON.stringify({
@@ -214,19 +259,17 @@ describe('executeFlow - resolveProjectRoot behavior', () => {
       }),
     })
 
-    const result = await executeFlow(flow, 'myproject', '/workspace', {
+    // Without projectRoot, discovery must find the project (which won't work with mock tree)
+    const result = await executeFlow(flow, 'nonexistent-project', '/workspace', {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
     })
 
-    expect(result).toBeDefined()
+    expect(result.status).toBe('failed')
+    expect(result.summary).toContain('not found')
   })
 })
-
-// ============================================================================
-// resolvePackageName Tests (internal function tested via executeFlow)
-// ============================================================================
 
 describe('executeFlow - resolvePackageName behavior', () => {
   it('returns package name from package.json', async () => {
@@ -255,6 +298,7 @@ describe('executeFlow - resolvePackageName behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(capturedContext.packageName).toBe('@myorg/test-package')
@@ -281,9 +325,11 @@ describe('executeFlow - resolvePackageName behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
-    expect(capturedContext.packageName).toBe('unknown')
+    // Project discovery fails when package.json is missing
+    expect(capturedContext.packageName).toBeUndefined()
   })
 
   it('returns "unknown" when package.json has no name field', async () => {
@@ -312,6 +358,7 @@ describe('executeFlow - resolvePackageName behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(capturedContext.packageName).toBe('unknown')
@@ -341,15 +388,12 @@ describe('executeFlow - resolvePackageName behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(capturedContext.packageName).toBe('unknown')
   })
 })
-
-// ============================================================================
-// buildSummary Tests (tested via executeFlow result)
-// ============================================================================
 
 describe('executeFlow - buildSummary behavior', () => {
   it('includes version transition in summary when nextVersion is set', async () => {
@@ -365,6 +409,7 @@ describe('executeFlow - buildSummary behavior', () => {
       tree,
       registry: createMockRegistry('1.0.0'),
       git: createMockGitClient([{ type: 'feat', subject: 'feature' }]),
+      projectRoot: 'libs/test',
     })
 
     expect(result.summary).toContain('→')
@@ -396,6 +441,7 @@ describe('executeFlow - buildSummary behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('success')
@@ -425,6 +471,7 @@ describe('executeFlow - buildSummary behavior', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.summary).toContain('1 completed')
@@ -432,10 +479,6 @@ describe('executeFlow - buildSummary behavior', () => {
     expect(result.summary).toContain('0 failed')
   })
 })
-
-// ============================================================================
-// executeFlow - Status Determination
-// ============================================================================
 
 describe('executeFlow - flow status determination', () => {
   it('returns "skipped" status when all steps are skipped', async () => {
@@ -464,6 +507,7 @@ describe('executeFlow - flow status determination', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('skipped')
@@ -499,6 +543,7 @@ describe('executeFlow - flow status determination', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('partial')
@@ -526,6 +571,7 @@ describe('executeFlow - flow status determination', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('success')
@@ -554,15 +600,12 @@ describe('executeFlow - flow status determination', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('failed')
   })
 })
-
-// ============================================================================
-// executeFlow - Verbose Logging
-// ============================================================================
 
 describe('executeFlow - verbose logging', () => {
   it('sets log level to debug when verbose is true', async () => {
@@ -588,6 +631,7 @@ describe('executeFlow - verbose logging', () => {
       git: createMockGitClient(),
       logger,
       verbose: true,
+      projectRoot: 'libs/test',
     })
 
     expect(logger.setLogLevel).toHaveBeenCalledWith('debug')
@@ -616,15 +660,12 @@ describe('executeFlow - verbose logging', () => {
       git: createMockGitClient(),
       logger,
       verbose: false,
+      projectRoot: 'libs/test',
     })
 
     expect(logger.setLogLevel).toHaveBeenCalledWith('error')
   })
 })
-
-// ============================================================================
-// executeFlow - Step Dependency Checking
-// ============================================================================
 
 describe('executeFlow - step dependencies', () => {
   it('skips step when dependency step did not succeed', async () => {
@@ -658,6 +699,7 @@ describe('executeFlow - step dependencies', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     const depResult = result.steps.find((s) => s.stepId === 'dependent')
@@ -687,16 +729,13 @@ describe('executeFlow - step dependencies', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     const depResult = result.steps.find((s) => s.stepId === 'dependent')
     expect(depResult?.status).toBe('success')
   })
 })
-
-// ============================================================================
-// validateFlow Tests
-// ============================================================================
 
 describe('validateFlow', () => {
   it('returns empty array for valid flow', () => {
@@ -804,10 +843,6 @@ describe('validateFlow', () => {
   })
 })
 
-// ============================================================================
-// dryRun Wrapper Tests
-// ============================================================================
-
 describe('dryRun', () => {
   it('forces dryRun to true', async () => {
     let capturedDryRun: boolean | undefined
@@ -835,15 +870,12 @@ describe('dryRun', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(capturedDryRun).toBe(true)
   })
 })
-
-// ============================================================================
-// Step State Updates Tests
-// ============================================================================
 
 describe('executeFlow - state accumulation', () => {
   it('accumulates state updates from multiple steps', async () => {
@@ -869,6 +901,7 @@ describe('executeFlow - state accumulation', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.state.currentVersion).toBe('1.0.0')
@@ -903,15 +936,12 @@ describe('executeFlow - state accumulation', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(capturedState?.['myValue']).toBe('hello')
   })
 })
-
-// ============================================================================
-// Error Handling Tests
-// ============================================================================
 
 describe('executeFlow - error handling', () => {
   it('converts non-Error throws to Error objects', async () => {
@@ -937,6 +967,7 @@ describe('executeFlow - error handling', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('failed')
@@ -945,10 +976,6 @@ describe('executeFlow - error handling', () => {
     expect(failedStep?.message).toBe('string error')
   })
 })
-
-// ============================================================================
-// Flow Duration Tests
-// ============================================================================
 
 describe('executeFlow - timing', () => {
   it('returns duration in milliseconds', async () => {
@@ -970,6 +997,7 @@ describe('executeFlow - timing', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(typeof result.duration).toBe('number')
@@ -998,5 +1026,799 @@ describe('validateFlow - complex circular dependencies', () => {
 
     const errors = validateFlow(flow)
     expect(errors.some((e) => e.includes('Circular dependency'))).toBe(true)
+  })
+})
+
+describe('executeFlow - discoverProjectRoot behavior', () => {
+  it('uses provided projectRoot option (relative path)', async () => {
+    let capturedProjectRoot: string | undefined
+
+    const captureStep = createStep('capture', 'Capture', async (ctx: FlowContext) => {
+      capturedProjectRoot = ctx.projectRoot
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [captureStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/utils/immutable-api/package.json': JSON.stringify({
+        name: '@test/immutable-api',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-immutable-api-utils', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/utils/immutable-api',
+    })
+
+    expect(capturedProjectRoot).toBe('/workspace/libs/utils/immutable-api')
+  })
+
+  it('uses provided projectRoot option (absolute path)', async () => {
+    let capturedProjectRoot: string | undefined
+
+    const captureStep = createStep('capture', 'Capture', async (ctx: FlowContext) => {
+      capturedProjectRoot = ctx.projectRoot
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [captureStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/utils/immutable-api/package.json': JSON.stringify({
+        name: '@test/immutable-api',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-immutable-api-utils', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: '/workspace/libs/utils/immutable-api',
+    })
+
+    expect(capturedProjectRoot).toBe('/workspace/libs/utils/immutable-api')
+  })
+
+  it('returns failed status when project cannot be discovered', async () => {
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    // Empty tree - no package.json anywhere
+    const tree = createMockTree({})
+
+    const result = await executeFlow(flow, 'nonexistent-project', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.summary).toContain('not found')
+  })
+
+  it('returns failed status when package.json does not exist at resolved path', async () => {
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    // Tree has no package.json at the given path
+    const tree = createMockTree({
+      '/workspace/libs/other/package.json': JSON.stringify({ name: '@test/other', version: '1.0.0' }),
+    })
+
+    const result = await executeFlow(flow, 'missing-project', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/missing',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.summary).toContain('Invalid project root')
+  })
+})
+
+describe('executeFlow - buildSummary edge cases', () => {
+  it('shows "?.?.?" when currentVersion is undefined but nextVersion is set', async () => {
+    const setNextVersionStep = createStep('set-next', 'Set Next', async () =>
+      createSuccessResult('OK', {
+        nextVersion: '2.0.0',
+        // currentVersion is NOT set
+      })
+    )
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [setNextVersionStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/test',
+    })
+
+    expect(result.summary).toContain('?.?.?')
+    expect(result.summary).toContain('2.0.0')
+  })
+
+  it('shows failed count in summary when steps fail with continueOnError', async () => {
+    const failStep = createStep(
+      'fail',
+      'Fail',
+      async () => ({
+        status: 'failed' as const,
+        message: 'Failed',
+      }),
+      { continueOnError: true }
+    )
+    const successStep = createStep('success', 'Success', async () => createSuccessResult('OK'))
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [failStep, successStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/test',
+    })
+
+    expect(result.summary).toContain('1 completed')
+    expect(result.summary).toContain('1 failed')
+  })
+})
+
+describe('executeFlow - context properties', () => {
+  it('provides all expected context properties to steps', async () => {
+    // Use mutable object to capture values (FlowContext has readonly props)
+    const capturedContext: {
+      workspaceRoot?: string
+      projectName?: string
+      projectRoot?: string
+      packageName?: string
+      tree?: Tree
+      registry?: Registry
+      git?: GitClient
+      logger?: ReturnType<typeof createMockLogger>
+      config?: FlowContext['config']
+      state?: FlowContext['state']
+    } = {}
+
+    const captureStep = createStep('capture', 'Capture', async (ctx: FlowContext) => {
+      capturedContext.workspaceRoot = ctx.workspaceRoot
+      capturedContext.projectName = ctx.projectName
+      capturedContext.projectRoot = ctx.projectRoot
+      capturedContext.packageName = ctx.packageName
+      capturedContext.tree = ctx.tree
+      capturedContext.registry = ctx.registry
+      capturedContext.git = ctx.git
+      capturedContext.logger = ctx.logger as ReturnType<typeof createMockLogger>
+      capturedContext.config = ctx.config
+      capturedContext.state = ctx.state
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [captureStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const registry = createMockRegistry()
+    const git = createMockGitClient()
+    const logger = createMockLogger()
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry,
+      git,
+      logger,
+      projectRoot: 'libs/test',
+    })
+
+    expect(capturedContext.workspaceRoot).toBe('/workspace')
+    expect(capturedContext.projectName).toBe('lib-test')
+    expect(capturedContext.projectRoot).toBeDefined()
+    expect(capturedContext.packageName).toBe('@test/pkg')
+    expect(capturedContext.tree).toBe(tree)
+    expect(capturedContext.registry).toBe(registry)
+    expect(capturedContext.git).toBe(git)
+    expect(capturedContext.logger).toBe(logger)
+    expect(capturedContext.config).toBeDefined()
+    expect(capturedContext.config?.dryRun).toBe(true)
+    expect(capturedContext.state).toEqual({})
+  })
+})
+
+describe('executeFlow - continueOnError with throws', () => {
+  it('continues to next step when step throws and continueOnError is true', async () => {
+    let secondStepRan = false
+
+    const throwStep = createStep(
+      'throw',
+      'Throw',
+      async () => {
+        throw new Error('Intentional error')
+      },
+      { continueOnError: true }
+    )
+
+    const secondStep = createStep('second', 'Second', async () => {
+      secondStepRan = true
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [throwStep, secondStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/test',
+    })
+
+    expect(secondStepRan).toBe(true)
+    expect(result.status).toBe('partial')
+    expect(result.steps[0].status).toBe('failed')
+    expect(result.steps[1].status).toBe('success')
+  })
+
+  it('stops execution when step throws and continueOnError is false', async () => {
+    let secondStepRan = false
+
+    const throwStep = createStep('throw', 'Throw', async () => {
+      throw new Error('Intentional error')
+    })
+
+    const secondStep = createStep('second', 'Second', async () => {
+      secondStepRan = true
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [throwStep, secondStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      projectRoot: 'libs/test',
+    })
+
+    expect(secondStepRan).toBe(false)
+    expect(result.status).toBe('failed')
+    expect(result.steps).toHaveLength(1)
+  })
+})
+
+describe('executeFlow - config merging', () => {
+  it('options.dryRun overrides flow.config.dryRun', async () => {
+    let capturedDryRun: boolean | undefined
+
+    const captureStep = createStep('capture', 'Capture', async (ctx: FlowContext) => {
+      capturedDryRun = ctx.config.dryRun
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: false },
+      steps: [captureStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      dryRun: true,
+      projectRoot: 'libs/test',
+    })
+
+    expect(capturedDryRun).toBe(true)
+  })
+
+  it('uses flow.config.dryRun when options.dryRun is undefined', async () => {
+    let capturedDryRun: boolean | undefined
+
+    const captureStep = createStep('capture', 'Capture', async (ctx: FlowContext) => {
+      capturedDryRun = ctx.config.dryRun
+      return createSuccessResult('OK')
+    })
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [captureStep],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      // dryRun not specified
+      projectRoot: 'libs/test',
+    })
+
+    expect(capturedDryRun).toBe(true)
+  })
+})
+
+describe('executeFlow - logging behavior', () => {
+  it('warns when package name is unknown', async () => {
+    const logger = createMockLogger()
+
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        // No name field
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+    })
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Could not read package name'))
+  })
+
+  it('logs flow info at start', async () => {
+    const logger = createMockLogger()
+
+    const flow = {
+      id: 'test',
+      name: 'My Test Flow',
+      config: { dryRun: true },
+      steps: [],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+    })
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('My Test Flow'))
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('lib-test'))
+  })
+})
+
+describe('executeFlow - Nx workspace project discovery', () => {
+  it('discovers project via Nx when workspace is Nx-based and project exists', async () => {
+    // Mock Nx workspace detection and project discovery
+    projectScopeNx.isNxWorkspace.mockReturnValue(true)
+    projectScopeNx.discoverNxProjects.mockReturnValue(new Map([['lib-my-package', { root: 'libs/my-package', name: 'lib-my-package' }]]))
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/my-package/package.json': JSON.stringify({
+        name: '@test/my-package',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-my-package', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+    })
+
+    expect(projectScopeNx.isNxWorkspace).toHaveBeenCalledWith('/workspace')
+    expect(projectScopeNx.discoverNxProjects).toHaveBeenCalledWith('/workspace')
+    expect(result.status).toBe('success')
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Nx workspace detected'))
+  })
+
+  it('falls back to workspace discovery when Nx discovery throws an error', async () => {
+    projectScopeNx.isNxWorkspace.mockReturnValue(true)
+    projectScopeNx.discoverNxProjects.mockImplementation(() => {
+      throw new Error('Nx project graph read failed')
+    })
+    workspaceDiscovery.discoverProjectByName.mockReturnValue({
+      name: 'fallback-pkg',
+      path: '/workspace/libs/fallback',
+      version: '1.0.0',
+    })
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/fallback/package.json': JSON.stringify({
+        name: '@test/fallback-pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-fallback', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+    })
+
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Nx project discovery failed'))
+    expect(workspaceDiscovery.discoverProjectByName).toHaveBeenCalled()
+    expect(result.status).toBe('success')
+  })
+
+  it('falls back to workspace discovery when project not found in Nx graph', async () => {
+    projectScopeNx.isNxWorkspace.mockReturnValue(true)
+    projectScopeNx.discoverNxProjects.mockReturnValue(new Map()) // Empty - project not found
+    workspaceDiscovery.discoverProjectByName.mockReturnValue({
+      name: 'discovered-pkg',
+      path: '/workspace/packages/discovered',
+      version: '2.0.0',
+    })
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/packages/discovered/package.json': JSON.stringify({
+        name: '@test/discovered-pkg',
+        version: '2.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-discovered', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+    })
+
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('not found in Nx project graph'))
+    expect(workspaceDiscovery.discoverProjectByName).toHaveBeenCalledWith('lib-discovered', { workspaceRoot: '/workspace' })
+    expect(result.status).toBe('success')
+  })
+})
+
+describe('executeFlow - workspace discovery fallback', () => {
+  it('discovers project via discoverProjectByName when not in Nx workspace', async () => {
+    projectScopeNx.isNxWorkspace.mockReturnValue(false)
+    workspaceDiscovery.discoverProjectByName.mockReturnValue({
+      name: 'my-lib',
+      path: '/workspace/packages/my-lib',
+      version: '1.0.0',
+    })
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/packages/my-lib/package.json': JSON.stringify({
+        name: '@test/my-lib',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'my-lib', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+    })
+
+    expect(projectScopeNx.discoverNxProjects).not.toHaveBeenCalled()
+    expect(workspaceDiscovery.discoverProjectByName).toHaveBeenCalledWith('my-lib', { workspaceRoot: '/workspace' })
+    expect(result.status).toBe('success')
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('workspace discovery'))
+  })
+
+  it('logs error and returns failed when workspace discovery throws', async () => {
+    projectScopeNx.isNxWorkspace.mockReturnValue(false)
+    workspaceDiscovery.discoverProjectByName.mockImplementation(() => {
+      throw new Error('Workspace traversal failed')
+    })
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({})
+
+    const result = await executeFlow(flow, 'broken-project', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+    })
+
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Workspace discovery failed'))
+    expect(result.status).toBe('failed')
+    expect(result.summary).toContain('not found')
+  })
+})
+
+describe('executeFlow - VFS commit behavior', () => {
+  it('commits VFS changes to disk when dryRun is false and flow succeeds', async () => {
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: false },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+      dryRun: false,
+    })
+
+    expect(projectScope.commitChanges).toHaveBeenCalledWith(tree, { verbose: undefined })
+    expect(logger.info).toHaveBeenCalledWith('File changes committed to disk')
+  })
+
+  it('commits VFS changes with verbose option when verbose is true', async () => {
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: false },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+      dryRun: false,
+      verbose: true,
+    })
+
+    expect(projectScope.commitChanges).toHaveBeenCalledWith(tree, { verbose: true })
+  })
+
+  it('logs error when commitChanges throws but does not fail the flow', async () => {
+    projectScope.commitChanges.mockImplementation(() => {
+      throw new Error('Filesystem permission denied')
+    })
+
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: false },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+      dryRun: false,
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to commit file changes'))
+    // Flow status should still reflect step execution success
+    expect(result.status).toBe('success')
+  })
+
+  it('does not commit changes when dryRun is true', async () => {
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: true },
+      steps: [createStep('step1', 'Step 1', async () => createSuccessResult('OK'))],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+    })
+
+    expect(projectScope.commitChanges).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith('Dry run mode - no changes written to disk')
+  })
+
+  it('does not commit changes when flow fails', async () => {
+    const logger = createMockLogger()
+    const flow = {
+      id: 'test',
+      name: 'Test Flow',
+      config: { dryRun: false },
+      steps: [
+        createStep('fail', 'Fail', async () => {
+          throw new Error('Step failed')
+        }),
+      ],
+    }
+
+    const tree = createMockTree({
+      '/workspace/libs/test/package.json': JSON.stringify({
+        name: '@test/pkg',
+        version: '1.0.0',
+      }),
+    })
+
+    const result = await executeFlow(flow, 'lib-test', '/workspace', {
+      tree,
+      registry: createMockRegistry(),
+      git: createMockGitClient(),
+      logger,
+      projectRoot: 'libs/test',
+      dryRun: false,
+    })
+
+    expect(projectScope.commitChanges).not.toHaveBeenCalled()
+    expect(result.status).toBe('failed')
   })
 })

--- a/libs/versioning/src/flow/executor/execute.ts
+++ b/libs/versioning/src/flow/executor/execute.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 import type { Logger } from '@hyperfrontend/logging'
 import type { Tree } from '@hyperfrontend/project-scope'
 import type { GitClient } from '../../git/factory'
@@ -9,10 +10,11 @@ import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/er
 import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { logger as defaultLogger } from '@hyperfrontend/logging'
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { createTree, commitChanges } from '@hyperfrontend/project-scope'
+import { isNxWorkspace, discoverNxProjects } from '@hyperfrontend/project-scope/nx'
 import { createGitClient, DEFAULT_GIT_CLIENT_CONFIG } from '../../git/factory'
 import { createRegistry } from '../../registry/factory'
+import { discoverProjectByName } from '../../workspace/discovery'
 import { DEFAULT_FLOW_CONFIG } from '../models/types'
 
 /**
@@ -36,32 +38,93 @@ export interface ExecuteOptions {
 
   /** Custom GitClient instance (for testing) */
   git?: GitClient
+
+  /**
+   * Project root path (relative to workspace root, e.g., 'libs/utils/immutable-api').
+   * If provided, this is used directly instead of deriving from project name.
+   * This is the recommended approach when calling from the Nx executor.
+   */
+  projectRoot?: string
 }
 
 /**
- * Resolves the project root path from workspace root and project name.
+ * Resolution source for project root discovery.
+ */
+type ProjectRootSource = 'provided' | 'nx-discovery' | 'workspace-discovery'
+
+/**
+ * Result of project root discovery.
+ */
+interface ProjectRootResolution {
+  /** Absolute path to project root */
+  projectRoot: string
+  /** How the path was resolved */
+  source: ProjectRootSource
+}
+
+/**
+ * Discovers project root using multiple strategies.
  *
- * For now, uses a simple convention: libs/{projectName} or apps/{projectName}
- * In a real implementation, this would query the workspace configuration.
+ * Resolution order:
+ * 1. Explicit `projectRoot` option (from Nx executor)
+ * 2. Nx project discovery via `discoverNxProjects` (if in Nx workspace)
+ * 3. Workspace discovery via `discoverProjectByName`
  *
  * @param workspaceRoot - Workspace root path
  * @param projectName - Project name (e.g., 'lib-versioning')
- * @returns Absolute path to project root
+ * @param providedRoot - Explicitly provided project root (optional)
+ * @param logger - Logger instance
+ * @returns Resolution result with path and source, or null if not found
  */
-function resolveProjectRoot(workspaceRoot: string, projectName: string): string {
-  // Remove 'lib-' or 'app-' prefix to get the folder name
-  let folderName = projectName
-  let prefix = 'libs'
-
-  if (projectName.startsWith('lib-')) {
-    folderName = projectName.slice(4)
-    prefix = 'libs'
-  } else if (projectName.startsWith('app-')) {
-    folderName = projectName.slice(4)
-    prefix = 'apps'
+function discoverProjectRoot(
+  workspaceRoot: string,
+  projectName: string,
+  providedRoot: string | undefined,
+  logger: Logger
+): ProjectRootResolution | null {
+  // 1. Explicit projectRoot provided (preferred - from Nx executor)
+  if (providedRoot) {
+    const projectRoot = providedRoot.startsWith(workspaceRoot) ? providedRoot : `${workspaceRoot}/${providedRoot}`
+    logger.debug(`Using provided project root: ${providedRoot}`)
+    return { projectRoot, source: 'provided' }
   }
 
-  return `${workspaceRoot}/${prefix}/${folderName}`
+  // 2. Try Nx project discovery (fast, if we're in an Nx workspace)
+  if (isNxWorkspace(workspaceRoot)) {
+    logger.debug('Nx workspace detected, attempting Nx project discovery')
+    try {
+      const nxProjects = discoverNxProjects(workspaceRoot)
+      const nxConfig = nxProjects.get(projectName)
+      if (nxConfig?.root) {
+        const projectRoot = `${workspaceRoot}/${nxConfig.root}`
+        logger.debug(`Discovered project root via Nx: ${nxConfig.root}`)
+        return { projectRoot, source: 'nx-discovery' }
+      }
+      logger.debug(`Project "${projectName}" not found in Nx project graph`)
+    } catch (error) {
+      logger.debug(`Nx project discovery failed: ${error}`)
+    }
+  }
+
+  // 3. Try workspace discovery (handles any monorepo structure)
+  logger.debug('Attempting workspace discovery via discoverProjectByName')
+  try {
+    const project = discoverProjectByName(projectName, { workspaceRoot })
+    if (project) {
+      logger.debug(`Discovered project root via workspace discovery: ${project.path}`)
+      return { projectRoot: project.path, source: 'workspace-discovery' }
+    }
+    logger.debug(`Project "${projectName}" not found via workspace discovery`)
+  } catch (error) {
+    logger.debug(`Workspace discovery failed: ${error}`)
+  }
+
+  // All discovery methods failed
+  logger.error(
+    `Could not discover project "${projectName}" in workspace "${workspaceRoot}". ` +
+      `Ensure the project exists and has a valid package.json, or pass projectRoot explicitly.`
+  )
+  return null
 }
 
 /**
@@ -69,19 +132,25 @@ function resolveProjectRoot(workspaceRoot: string, projectName: string): string 
  *
  * @param tree - Virtual file system tree
  * @param projectRoot - Project root path
+ * @param logger - Logger instance for diagnostics
  * @returns Package name from package.json
  */
-function resolvePackageName(tree: Tree, projectRoot: string): string {
+function resolvePackageName(tree: Tree, projectRoot: string, logger: Logger): string {
   const packageJsonPath = `${projectRoot}/package.json`
 
   try {
     const content = tree.read(packageJsonPath, 'utf-8')
     if (!content) {
+      logger.debug(`package.json is empty or not found at ${packageJsonPath}`)
       return 'unknown'
     }
     const pkg = <{ name?: string }>parse(content)
+    if (!pkg.name) {
+      logger.debug(`package.json at ${packageJsonPath} has no name field`)
+    }
     return pkg.name ?? 'unknown'
-  } catch {
+  } catch (error) {
+    logger.debug(`Failed to read package.json at ${packageJsonPath}: ${error}`)
     return 'unknown'
   }
 }
@@ -172,9 +241,42 @@ export async function executeFlow(
   const registry = options.registry ?? createRegistry('npm')
   const git = options.git ?? createGitClient({ ...DEFAULT_GIT_CLIENT_CONFIG, cwd: workspaceRoot })
 
-  // Resolve paths
-  const projectRoot = resolveProjectRoot(workspaceRoot, projectName)
-  const packageName = resolvePackageName(tree, projectRoot)
+  // Resolve project root with smart discovery
+  const resolution = discoverProjectRoot(workspaceRoot, projectName, options.projectRoot, flowLogger)
+
+  // Fail early if project cannot be discovered
+  if (!resolution) {
+    return {
+      status: 'failed',
+      steps: [],
+      state: {},
+      duration: dateNow() - startTime,
+      summary: `Project "${projectName}" not found in workspace`,
+    }
+  }
+
+  const { projectRoot, source: projectRootSource } = resolution
+
+  // Early validation: ensure project root is valid
+  const packageJsonPath = `${projectRoot}/package.json`
+  if (!tree.exists(packageJsonPath)) {
+    const errorMsg =
+      `Project root validation failed: ${packageJsonPath} does not exist. ` +
+      `Resolved projectRoot="${projectRoot}" (source: ${projectRootSource}) from projectName="${projectName}".`
+    flowLogger.error(errorMsg)
+    return {
+      status: 'failed',
+      steps: [],
+      state: {},
+      duration: dateNow() - startTime,
+      summary: `Invalid project root: ${projectRoot}`,
+    }
+  }
+
+  const packageName = resolvePackageName(tree, projectRoot, flowLogger)
+  if (packageName === 'unknown') {
+    flowLogger.warn(`Could not read package name from ${packageJsonPath}`)
+  }
 
   // Initialize context
   const context: FlowContext = {

--- a/libs/versioning/src/flow/flow.spec.ts
+++ b/libs/versioning/src/flow/flow.spec.ts
@@ -162,10 +162,6 @@ function createMockGitClient(commits: readonly Partial<ConventionalCommit>[] = [
   } as unknown as GitClient
 }
 
-// ============================================================================
-// Tests
-// ============================================================================
-
 describe('Flow System', () => {
   describe('createVersionFlow', () => {
     it('creates a conventional flow by default', () => {
@@ -239,6 +235,7 @@ describe('Flow System', () => {
         tree,
         registry,
         git,
+        projectRoot: 'libs/test',
       })
 
       expect(result.status).toBe('success')
@@ -263,6 +260,7 @@ describe('Flow System', () => {
         tree,
         registry,
         git,
+        projectRoot: 'libs/test',
       })
 
       expect(result.state.bumpType).toBe('minor')
@@ -284,6 +282,7 @@ describe('Flow System', () => {
         tree,
         registry,
         git,
+        projectRoot: 'libs/test',
       })
 
       expect(result.state.isFirstRelease).toBe(true)
@@ -309,6 +308,7 @@ describe('Flow System', () => {
         tree,
         registry: createMockRegistry(),
         git: createMockGitClient(),
+        projectRoot: 'libs/test',
       })
 
       const skipResult = result.steps.find((s) => s.stepId === 'always-skip')
@@ -344,6 +344,7 @@ describe('Flow System', () => {
         tree,
         registry: createMockRegistry(),
         git: createMockGitClient(),
+        projectRoot: 'libs/test',
       })
 
       // Should be partial since one step failed
@@ -494,10 +495,6 @@ describe('Flow Presets', () => {
   })
 })
 
-// ============================================================================
-// Factory Tests
-// ============================================================================
-
 describe('Factory Functions', () => {
   describe('createVersionFlow', () => {
     it('throws error for unknown preset', () => {
@@ -544,10 +541,6 @@ describe('Factory Functions', () => {
   })
 })
 
-// ============================================================================
-// Validation Tests
-// ============================================================================
-
 describe('Flow Validation', () => {
   it('detects invalid dependency references', () => {
     const stepWithBadDep = createStep('bad-dep', 'Bad Dependency', async () => createSuccessResult('OK'), {
@@ -578,10 +571,6 @@ describe('Flow Validation', () => {
   })
 })
 
-// ============================================================================
-// Step Execution Tests
-// ============================================================================
-
 describe('Step Execution Edge Cases', () => {
   it('stops execution on step failure without continueOnError', async () => {
     const failStep = createStep('fail', 'Failing Step', async () => {
@@ -605,6 +594,7 @@ describe('Step Execution Edge Cases', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     expect(result.status).toBe('failed')
@@ -642,6 +632,7 @@ describe('Step Execution Edge Cases', () => {
       tree,
       registry: createMockRegistry(),
       git: createMockGitClient(),
+      projectRoot: 'libs/test',
     })
 
     const dependentResult = result.steps.find((s) => s.stepId === 'dependent')
@@ -649,10 +640,6 @@ describe('Step Execution Edge Cases', () => {
     expect(dependentResult?.message).toBe('Dependencies not met')
   })
 })
-
-// ============================================================================
-// Independent Flow Step Tests
-// ============================================================================
 
 describe('Independent Flow Steps', () => {
   describe('createCheckDependentBumpsStep', () => {
@@ -743,10 +730,6 @@ describe('Independent Flow Steps', () => {
     })
   })
 })
-
-// ============================================================================
-// Synced Flow Step Tests
-// ============================================================================
 
 describe('Synced Flow Steps', () => {
   describe('createSyncAllPackagesStep', () => {

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -20,6 +20,9 @@ export interface FlowState {
   /** Published version on registry (null if never published) */
   readonly publishedVersion?: string | null
 
+  /** Git commit hash of the last published version */
+  readonly publishedCommit?: string | null
+
   /** Calculated next version */
   readonly nextVersion?: string
 

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -35,9 +35,6 @@ export interface FlowState {
   /** Classification result with source attribution (when scope filtering enabled) */
   readonly classificationResult?: ClassificationResult
 
-  /** Tag name that marks the last release */
-  readonly lastReleaseTag?: string | null
-
   /**
    * The verified base commit used for commit scoping and changelog generation.
    * This will be `publishedCommit` if that commit is reachable from HEAD,

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -38,6 +38,15 @@ export interface FlowState {
   /** Tag name that marks the last release */
   readonly lastReleaseTag?: string | null
 
+  /**
+   * The verified base commit used for commit scoping and changelog generation.
+   * This will be `publishedCommit` if that commit is reachable from HEAD,
+   * or `null` if a fallback was used (e.g., history was rewritten).
+   *
+   * When null, compare URLs are omitted from the changelog.
+   */
+  readonly effectiveBaseCommit?: string | null
+
   /** Generated changelog entry */
   readonly changelogEntry?: ChangelogEntry
 

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -1,19 +1,13 @@
 import type { Logger } from '@hyperfrontend/logging'
 import type { Tree } from '@hyperfrontend/project-scope'
-
 import type { ChangelogEntry } from '../../changelog/models/entry'
+import type { ClassificationResult } from '../../commits/classify'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { GitClient } from '../../git/factory'
 import type { Registry } from '../../registry/models/registry'
 import type { RepositoryConfig, RepositoryResolution } from '../../repository/models'
 import type { BumpType } from '../../semver/models/version'
-
-// Re-export Logger from @hyperfrontend/logging for consumers
 export type { Logger } from '@hyperfrontend/logging'
-
-// ============================================================================
-// Flow State
-// ============================================================================
 
 /**
  * Accumulated state during flow execution.
@@ -34,6 +28,9 @@ export interface FlowState {
 
   /** Analyzed commits since last release */
   readonly commits?: readonly ConventionalCommit[]
+
+  /** Classification result with source attribution (when scope filtering enabled) */
+  readonly classificationResult?: ClassificationResult
 
   /** Tag name that marks the last release */
   readonly lastReleaseTag?: string | null
@@ -60,9 +57,73 @@ export interface FlowState {
   readonly [key: string]: unknown
 }
 
-// ============================================================================
-// Flow Configuration
-// ============================================================================
+/**
+ * Strategy for filtering commits to a project's changelog.
+ *
+ * - `'hybrid'`: Use scope + file validation (default, recommended)
+ * - `'scope-only'`: Only use scope matching (fast, for disciplined teams)
+ * - `'file-only'`: Only use file-based filtering (for non-scoped repos)
+ * - `'inferred'`: Auto-detect from commit history
+ */
+export type ScopeFilteringStrategy = 'hybrid' | 'scope-only' | 'file-only' | 'inferred'
+
+/**
+ * Scope filtering configuration.
+ *
+ * By default, hybrid filtering is enabled universally.
+ * Configuration exists for edge cases and external codebases.
+ */
+export interface ScopeFilteringConfig {
+  /**
+   * Filtering strategy.
+   *
+   * @default 'hybrid'
+   */
+  readonly strategy?: ScopeFilteringStrategy
+
+  /**
+   * Additional scopes to include as direct commits.
+   * Use for shared library scopes that should appear in multiple projects.
+   *
+   * @example ['shared-utils', 'common']
+   */
+  readonly includeScopes?: readonly string[]
+
+  /**
+   * Scopes to explicitly exclude even if files match.
+   * Use for infrastructure scopes that affect build but aren't "changes".
+   *
+   * @example ['deps', 'release']
+   */
+  readonly excludeScopes?: readonly string[]
+
+  /**
+   * Include commits that touch dependency packages.
+   * When true, changes to dependencies appear as indirect commits.
+   *
+   * @default false
+   */
+  readonly trackDependencyChanges?: boolean
+
+  /**
+   * Infrastructure paths that affect all packages.
+   * Commits touching these paths may be included as indirect-infra.
+   *
+   * @example ['tools/package/', '.github/workflows/']
+   */
+  readonly infrastructurePaths?: readonly string[]
+}
+
+/**
+ * Default scope filtering configuration.
+ */
+export const DEFAULT_SCOPE_FILTERING_CONFIG: Required<ScopeFilteringConfig> = {
+  strategy: 'hybrid',
+  includeScopes: [],
+  excludeScopes: ['release', 'deps'],
+  trackDependencyChanges: false,
+  infrastructurePaths: [],
+}
 
 /**
  * Flow configuration options.
@@ -126,12 +187,22 @@ export interface FlowConfig {
    * - `RepositoryConfig`: Direct repository configuration
    */
   readonly repository?: 'disabled' | 'inferred' | RepositoryResolution | RepositoryConfig
+
+  /**
+   * Commit scope filtering configuration.
+   * Controls how commits are attributed to projects in changelogs.
+   *
+   * By default, hybrid filtering ensures commits are included based on
+   * conventional commit scope OR file changes within the project.
+   */
+  readonly scopeFiltering?: ScopeFilteringConfig
 }
 
 /**
  * Default flow configuration values.
  */
-export const DEFAULT_FLOW_CONFIG: Required<Omit<FlowConfig, 'repository'>> & Pick<FlowConfig, 'repository'> = {
+export const DEFAULT_FLOW_CONFIG: Required<Omit<FlowConfig, 'repository' | 'scopeFiltering'>> &
+  Pick<FlowConfig, 'repository' | 'scopeFiltering'> = {
   preset: 'conventional',
   releaseTypes: ['feat', 'fix', 'perf', 'revert'],
   minorTypes: ['feat'],
@@ -149,11 +220,8 @@ export const DEFAULT_FLOW_CONFIG: Required<Omit<FlowConfig, 'repository'>> & Pic
   prereleaseId: 'alpha',
   releaseAs: undefined,
   repository: undefined,
+  scopeFiltering: DEFAULT_SCOPE_FILTERING_CONFIG,
 }
-
-// ============================================================================
-// Flow Context
-// ============================================================================
 
 /**
  * Execution context passed to each step.
@@ -225,10 +293,6 @@ export interface FlowStepResultWithId extends FlowStepResult {
   /** Step display name */
   readonly stepName: string
 }
-
-// ============================================================================
-// Flow Results
-// ============================================================================
 
 /**
  * Overall flow execution status.

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -5,6 +5,7 @@ import type { ChangelogEntry } from '../../changelog/models/entry'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { GitClient } from '../../git/factory'
 import type { Registry } from '../../registry/models/registry'
+import type { RepositoryConfig, RepositoryResolution } from '../../repository/models'
 import type { BumpType } from '../../semver/models/version'
 
 // Re-export Logger from @hyperfrontend/logging for consumers
@@ -51,6 +52,9 @@ export interface FlowState {
 
   /** Whether this is a first release (no prior versions) */
   readonly isFirstRelease?: boolean
+
+  /** Repository configuration for compare URL generation */
+  readonly repositoryConfig?: RepositoryConfig
 
   /** Additional custom state for extensibility */
   readonly [key: string]: unknown
@@ -111,12 +115,23 @@ export interface FlowConfig {
 
   /** Force a specific bump type, bypassing commit analysis */
   readonly releaseAs?: 'major' | 'minor' | 'patch'
+
+  /**
+   * Repository resolution configuration for compare URL generation.
+   *
+   * Controls how repository information is resolved:
+   * - `'disabled'`: No compare URLs generated (default, backward compatible)
+   * - `'inferred'`: Auto-detect from package.json or git remote
+   * - `RepositoryResolution`: Fine-grained control with explicit mode and options
+   * - `RepositoryConfig`: Direct repository configuration
+   */
+  readonly repository?: 'disabled' | 'inferred' | RepositoryResolution | RepositoryConfig
 }
 
 /**
  * Default flow configuration values.
  */
-export const DEFAULT_FLOW_CONFIG: Required<FlowConfig> = {
+export const DEFAULT_FLOW_CONFIG: Required<Omit<FlowConfig, 'repository'>> & Pick<FlowConfig, 'repository'> = {
   preset: 'conventional',
   releaseTypes: ['feat', 'fix', 'perf', 'revert'],
   minorTypes: ['feat'],
@@ -133,6 +148,7 @@ export const DEFAULT_FLOW_CONFIG: Required<FlowConfig> = {
   allowPrerelease: false,
   prereleaseId: 'alpha',
   releaseAs: undefined,
+  repository: undefined,
 }
 
 // ============================================================================

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@hyperfrontend/logging'
 import type { Tree } from '@hyperfrontend/project-scope'
 import type { ChangelogEntry } from '../../changelog/models/entry'
-import type { ClassificationResult } from '../../commits/classify'
+import type { ClassificationResult, InfrastructureConfig, InfrastructureMatcher } from '../../commits/classify'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { GitClient } from '../../git/factory'
 import type { Registry } from '../../registry/models/registry'
@@ -106,23 +106,70 @@ export interface ScopeFilteringConfig {
   readonly trackDependencyChanges?: boolean
 
   /**
-   * Infrastructure paths that affect all packages.
-   * Commits touching these paths may be included as indirect-infra.
+   * Infrastructure tracking configuration.
    *
-   * @example ['tools/package/', '.github/workflows/']
+   * Defines how to detect commits that affect build/tooling infrastructure.
+   * Supports multiple detection methods:
+   * - `paths`: File paths to track via git queries
+   * - `scopes`: Conventional commit scopes to match
+   * - `matcher`: Custom matching logic
+   *
+   * All methods are combined with OR logic.
+   *
+   * @example
+   * // Simple path-based
+   * infrastructure: { paths: ['tools/', '.github/workflows/'] }
+   *
+   * @example
+   * // Scope-based
+   * infrastructure: { scopes: ['ci', 'build', 'tooling'] }
+   *
+   * @example
+   * // Composable matcher
+   * import { anyOf, scopeMatcher, scopePrefixMatcher } from '@hyperfrontend/versioning'
+   * infrastructure: {
+   *   paths: ['tools/'],
+   *   matcher: anyOf(
+   *     scopeMatcher(['ci', 'build']),
+   *     scopePrefixMatcher(['tool-'])
+   *   )
+   * }
    */
-  readonly infrastructurePaths?: readonly string[]
+  readonly infrastructure?: InfrastructureConfig
+
+  /**
+   * Custom infrastructure matcher function.
+   *
+   * Provides full programmatic control over infrastructure detection.
+   * Takes precedence over `infrastructure` config if both provided.
+   *
+   * @example
+   * infrastructureMatcher: (ctx) => {
+   *   // Match CI scopes
+   *   if (ctx.scope === 'ci' || ctx.scope === 'build') return true
+   *   // Match tool-prefixed scopes
+   *   if (ctx.scope?.startsWith('tool-')) return true
+   *   // Match workspace commits during major refactors
+   *   if (ctx.message.includes('[infra]')) return true
+   *   return false
+   * }
+   */
+  readonly infrastructureMatcher?: InfrastructureMatcher
 }
 
 /**
  * Default scope filtering configuration.
  */
-export const DEFAULT_SCOPE_FILTERING_CONFIG: Required<ScopeFilteringConfig> = {
+export const DEFAULT_SCOPE_FILTERING_CONFIG: Required<Omit<ScopeFilteringConfig, 'infrastructure' | 'infrastructureMatcher'>> & {
+  infrastructure: undefined
+  infrastructureMatcher: undefined
+} = {
   strategy: 'hybrid',
   includeScopes: [],
   excludeScopes: ['release', 'deps'],
   trackDependencyChanges: false,
-  infrastructurePaths: [],
+  infrastructure: undefined,
+  infrastructureMatcher: undefined,
 }
 
 /**
@@ -261,10 +308,6 @@ export interface FlowContext {
   /** Accumulated state from previous steps (mutable reference) */
   state: FlowState
 }
-
-// ============================================================================
-// Step Results
-// ============================================================================
 
 /**
  * Result of a single step execution.

--- a/libs/versioning/src/flow/presets/conventional.ts
+++ b/libs/versioning/src/flow/presets/conventional.ts
@@ -8,6 +8,7 @@ import {
   createFetchRegistryStep,
   createGenerateChangelogStep,
   createGitCommitStep,
+  createResolveRepositoryStep,
   createTagStep,
   createUpdatePackageStep,
   createWriteChangelogStep,
@@ -36,14 +37,15 @@ export const CONVENTIONAL_FLOW_CONFIG: FlowConfig = {
  *
  * This flow follows the standard conventional commits workflow:
  * 1. Fetch published version from registry
- * 2. Analyze commits since last release
- * 3. Calculate version bump based on commit types
- * 4. Check if version already published (idempotency)
- * 5. Generate changelog entry
- * 6. Update package.json version
- * 7. Write changelog to file
- * 8. Create git commit (optional)
- * 9. Create git tag (optional, typically after publish)
+ * 2. Resolve repository configuration (for compare URLs)
+ * 3. Analyze commits since last release
+ * 4. Calculate version bump based on commit types
+ * 5. Check if version already published (idempotency)
+ * 6. Generate changelog entry (with compare URL if repository resolved)
+ * 7. Update package.json version
+ * 8. Write changelog to file
+ * 9. Create git commit (optional)
+ * 10. Create git tag (optional, typically after publish)
  *
  * @param config - Optional configuration overrides
  * @returns A VersionFlow configured for conventional commits
@@ -72,6 +74,7 @@ export function createConventionalFlow(config?: Partial<FlowConfig>): VersionFlo
     'Conventional Commits Flow',
     [
       createFetchRegistryStep(),
+      createResolveRepositoryStep(),
       createAnalyzeCommitsStep(),
       createCalculateBumpStep(),
       createCheckIdempotencyStep(),

--- a/libs/versioning/src/flow/presets/independent.ts
+++ b/libs/versioning/src/flow/presets/independent.ts
@@ -6,13 +6,14 @@ import { createStep, createSkippedResult } from '../models/step'
 import {
   createAnalyzeCommitsStep,
   createCalculateBumpStep,
+  createCascadeDependenciesStep,
   createCheckIdempotencyStep,
   createFetchRegistryStep,
   createGenerateChangelogStep,
   createGitCommitStep,
+  createResolveRepositoryStep,
   createTagStep,
   createUpdatePackageStep,
-  createCascadeDependenciesStep,
   createWriteChangelogStep,
 } from '../steps'
 import { CONVENTIONAL_FLOW_CONFIG } from './conventional'
@@ -110,6 +111,7 @@ export function createIndependentFlow(config?: Partial<FlowConfig>): VersionFlow
     'Independent Versioning Flow',
     [
       createFetchRegistryStep(),
+      createResolveRepositoryStep(),
       createAnalyzeCommitsStep(),
       createCalculateBumpStep(),
       createCheckDependentBumpsStep(),
@@ -144,6 +146,7 @@ export function createBatchReleaseFlow(config?: Partial<FlowConfig>): VersionFlo
     'Batch Release Flow',
     [
       createFetchRegistryStep(),
+      createResolveRepositoryStep(),
       createAnalyzeCommitsStep(),
       createCalculateBumpStep(),
       createCheckIdempotencyStep(),

--- a/libs/versioning/src/flow/presets/synced.ts
+++ b/libs/versioning/src/flow/presets/synced.ts
@@ -11,6 +11,7 @@ import {
   createFetchRegistryStep,
   createGenerateChangelogStep,
   createGitCommitStep,
+  createResolveRepositoryStep,
   createTagStep,
   createWriteChangelogStep,
 } from '../steps'
@@ -157,6 +158,7 @@ export function createSyncedFlow(config?: Partial<FlowConfig>): VersionFlow {
     'Synced Versioning Flow',
     [
       createFetchRegistryStep(),
+      createResolveRepositoryStep(),
       createAnalyzeCommitsStep(),
       createCalculateBumpStep(),
       createCheckIdempotencyStep(),
@@ -208,6 +210,7 @@ export function createFixedVersionFlow(version: string, config?: Partial<FlowCon
     'Fixed Version Flow',
     [
       createFetchRegistryStep(),
+      createResolveRepositoryStep(),
       createAnalyzeCommitsStep(),
       fixedBumpStep,
       createCheckIdempotencyStep(),

--- a/libs/versioning/src/flow/steps/analyze-commits.spec.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.spec.ts
@@ -1207,6 +1207,144 @@ describe('analyze-commits step', () => {
           expect(infraLogs).toHaveLength(0)
         })
       })
+
+      describe('infrastructure path detection with existing release', () => {
+        it('uses getCommitsSince for infrastructure paths when tag exists', async () => {
+          const baseCommits = [
+            { message: 'feat(ci): update ci', hash: 'ci-commit' },
+            { message: 'feat(lib-test): feature', hash: 'feature-commit' },
+          ]
+          const getCommitsSinceMock = jest.fn((tag: string, opts?: { path?: string }) => {
+            if (opts?.path === 'tools/') {
+              return [{ message: 'feat(ci): update ci', hash: 'ci-commit' }]
+            }
+            return baseCommits
+          })
+          const git = {
+            ...createMockGitClient({
+              commits: baseCommits,
+              packageTags: [{ name: '@test/pkg@1.0.0', hash: 'tag-hash' }],
+            }),
+            getCommitsSince: getCommitsSinceMock,
+          } as unknown as GitClient
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: false },
+            config: {
+              scopeFiltering: {
+                infrastructure: {
+                  paths: ['tools/'],
+                },
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should call getCommitsSince with infrastructure path
+          type CommitsSinceCall = [tag: string, opts?: { path?: string }]
+          const calls = getCommitsSinceMock.mock.calls as unknown as CommitsSinceCall[]
+          const infraPathCalls = calls.filter((call) => call[1]?.path === 'tools/')
+          expect(infraPathCalls.length).toBeGreaterThan(0)
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('infrastructure paths'))
+        })
+      })
+
+      describe('infrastructure path with no matching commits', () => {
+        it('logs zero commits when infrastructure paths configured but no matches', async () => {
+          const baseCommits = [{ message: 'feat(lib-test): feature', hash: 'feature-commit' }]
+          const git = {
+            ...createMockGitClient({ commits: baseCommits }),
+            getCommitLog: (opts?: { maxCount?: number; path?: string }) => {
+              // Infrastructure path returns no commits
+              if (opts?.path === 'tools/') {
+                return []
+              }
+              if (opts?.maxCount) {
+                return baseCommits.slice(0, opts.maxCount)
+              }
+              return baseCommits
+            },
+          } as unknown as GitClient
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                infrastructure: {
+                  paths: ['tools/'],
+                },
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log 0 commits for infrastructure paths
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Found 0 commits touching infrastructure paths'))
+        })
+      })
+
+      describe('dependency tracking (Phase 4)', () => {
+        it('skips dependency map when trackDependencyChanges is false', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                trackDependencyChanges: false,
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should NOT log about dependencies
+          const debugCalls = (logger.debug as jest.Mock).mock.calls.map((call) => call[0])
+          const depLogs = debugCalls.filter((msg: string) => msg.includes('dependencies') || msg.includes('Dependency'))
+          expect(depLogs).toHaveLength(0)
+        })
+
+        it('attempts dependency map build when trackDependencyChanges is true', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                trackDependencyChanges: true,
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log about dependency discovery (may fail gracefully but will log)
+          const debugCalls = (logger.debug as jest.Mock).mock.calls.map((call) => call[0])
+          const depLogs = debugCalls.filter(
+            (msg: string) => msg.includes('dependencies') || msg.includes('Dependency') || msg.includes('dependency')
+          )
+          // Either logs "No dependencies found" or "Failed to build dependency map" or found deps
+          expect(depLogs.length).toBeGreaterThan(0)
+        })
+      })
     })
   })
 })

--- a/libs/versioning/src/flow/steps/analyze-commits.spec.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.spec.ts
@@ -193,8 +193,6 @@ describe('analyze-commits step', () => {
 
           expect(result.status).toBe('success')
           expect(result.stateUpdates?.effectiveBaseCommit).toBe('abc1234')
-          // lastReleaseTag should be null (deprecated)
-          expect(result.stateUpdates?.lastReleaseTag).toBe(null)
           expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Found 2 commits since abc1234'))
         })
 
@@ -264,7 +262,6 @@ describe('analyze-commits step', () => {
 
           expect(result.status).toBe('success')
           expect(result.stateUpdates?.effectiveBaseCommit).toBe(null)
-          expect(result.stateUpdates?.lastReleaseTag).toBe(null)
           expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('First release'))
         })
       })

--- a/libs/versioning/src/flow/steps/analyze-commits.spec.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.spec.ts
@@ -57,10 +57,11 @@ interface MockGitClientOptions {
   commits?: readonly { message: string; hash: string }[]
   packageTags?: readonly { name: string; hash: string }[]
   projectTags?: readonly { name: string; hash: string }[]
+  commitReachable?: boolean
 }
 
 function createMockGitClient(options: MockGitClientOptions = {}): GitClient {
-  const { commits = [], packageTags = [], projectTags = [] } = options
+  const { commits = [], packageTags = [], projectTags = [], commitReachable = true } = options
 
   return {
     cwd: '/workspace',
@@ -75,6 +76,7 @@ function createMockGitClient(options: MockGitClientOptions = {}): GitClient {
     getCommitsSince: () => commits,
     getCommit: () => (commits.length > 0 ? commits[0] : null),
     commitExists: () => true,
+    commitReachableFromHead: () => commitReachable,
     getTags: () => [],
     getTag: () => null,
     createTag: jest.fn(),
@@ -143,10 +145,6 @@ function createMockContext(overrides?: {
   }
 }
 
-// ============================================================================
-// Tests
-// ============================================================================
-
 describe('analyze-commits step', () => {
   describe('ANALYZE_COMMITS_STEP_ID', () => {
     it('has the correct ID', () => {
@@ -170,75 +168,88 @@ describe('analyze-commits step', () => {
     })
 
     describe('execute', () => {
-      describe('tag discovery', () => {
-        it('finds last release tag for package name', async () => {
+      describe('publishedCommit scoping', () => {
+        it('uses publishedCommit from state when commit is reachable', async () => {
           const git = createMockGitClient({
-            packageTags: [
-              { name: '@test/pkg@1.0.0', hash: 'abc123' },
-              { name: '@test/pkg@0.9.0', hash: 'def456' },
+            commits: [
+              { message: 'feat: new feature', hash: 'ghi789' },
+              { message: 'fix: bug fix', hash: 'jkl012' },
             ],
-            commits: [{ message: 'feat: new feature', hash: 'ghi789' }],
+            commitReachable: true,
           })
           const logger = createMockLogger()
           const context = createMockContext({
             git,
             logger,
-            state: { isFirstRelease: false },
+            state: {
+              isFirstRelease: false,
+              publishedCommit: 'abc1234',
+              publishedVersion: '1.0.0',
+            },
           })
           const step = createAnalyzeCommitsStep()
 
           const result = await step.execute(context)
 
           expect(result.status).toBe('success')
-          expect(result.stateUpdates?.lastReleaseTag).toBe('@test/pkg@1.0.0')
-          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Found last release tag: @test/pkg@1.0.0'))
-        })
-
-        it('falls back to project name format when no package tags exist', async () => {
-          const git = createMockGitClient({
-            packageTags: [], // No package name tags
-            projectTags: [
-              { name: 'lib-test@1.0.0', hash: 'abc123' },
-              { name: 'lib-test@0.5.0', hash: 'def456' },
-            ],
-            commits: [{ message: 'fix: bug fix', hash: 'ghi789' }],
-          })
-          const logger = createMockLogger()
-          const context = createMockContext({
-            git,
-            logger,
-            state: { isFirstRelease: false },
-          })
-          const step = createAnalyzeCommitsStep()
-
-          const result = await step.execute(context)
-
-          expect(result.status).toBe('success')
-          expect(result.stateUpdates?.lastReleaseTag).toBe('lib-test@1.0.0')
-          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Found last release tag (project format): lib-test@1.0.0'))
-        })
-
-        it('handles no tags found for non-first release', async () => {
-          const git = createMockGitClient({
-            packageTags: [],
-            projectTags: [],
-            commits: [{ message: 'feat: new feature', hash: 'abc123' }],
-          })
-          const context = createMockContext({
-            git,
-            state: { isFirstRelease: false },
-          })
-          const step = createAnalyzeCommitsStep()
-
-          const result = await step.execute(context)
-
-          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.effectiveBaseCommit).toBe('abc1234')
+          // lastReleaseTag should be null (deprecated)
           expect(result.stateUpdates?.lastReleaseTag).toBe(null)
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Found 2 commits since abc1234'))
         })
 
-        it('skips tag lookup for first release', async () => {
+        it('falls back gracefully when publishedCommit is not reachable from HEAD', async () => {
           const git = createMockGitClient({
-            packageTags: [{ name: '@test/pkg@1.0.0', hash: 'abc123' }],
+            commits: [{ message: 'feat: new feature', hash: 'xyz789' }],
+            commitReachable: false, // Commit not in history (rebase/force push)
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: {
+              isFirstRelease: false,
+              publishedCommit: 'orphaned123',
+              publishedVersion: '1.0.0',
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // effectiveBaseCommit should be null (fallback was used)
+          expect(result.stateUpdates?.effectiveBaseCommit).toBe(null)
+          // Warning should be logged
+          expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Published commit orphane not found in history'))
+          expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rebase or force push'))
+        })
+
+        it('handles no publishedCommit (first release from registry perspective)', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: initial', hash: 'def456' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: {
+              isFirstRelease: false,
+              publishedCommit: null, // No gitHead in npm
+              publishedVersion: '1.0.0',
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.effectiveBaseCommit).toBe(null)
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('First release'))
+        })
+
+        it('skips commit verification for first release', async () => {
+          const git = createMockGitClient({
             commits: [{ message: 'feat: initial', hash: 'def456' }],
           })
           const logger = createMockLogger()
@@ -252,26 +263,29 @@ describe('analyze-commits step', () => {
           const result = await step.execute(context)
 
           expect(result.status).toBe('success')
+          expect(result.stateUpdates?.effectiveBaseCommit).toBe(null)
           expect(result.stateUpdates?.lastReleaseTag).toBe(null)
-          // Should log about first release commits, not tags
           expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('First release'))
         })
       })
 
       describe('commit analysis', () => {
-        it('gets commits since last release tag', async () => {
+        it('gets commits since publishedCommit', async () => {
           const git = createMockGitClient({
-            packageTags: [{ name: '@test/pkg@1.0.0', hash: 'abc123' }],
             commits: [
               { message: 'feat: feature 1', hash: 'commit1' },
               { message: 'fix: bug fix', hash: 'commit2' },
             ],
+            commitReachable: true,
           })
           const logger = createMockLogger()
           const context = createMockContext({
             git,
             logger,
-            state: { isFirstRelease: false },
+            state: {
+              isFirstRelease: false,
+              publishedCommit: 'abc123',
+            },
           })
           const step = createAnalyzeCommitsStep()
 
@@ -1154,20 +1168,23 @@ describe('analyze-commits step', () => {
         })
       })
 
-      describe('commits since tag with path filtering', () => {
+      describe('commits since publishedCommit with path filtering', () => {
         it('uses getCommitsSince with path filter for existing releases', async () => {
           const commits = [{ message: 'feat: feature', hash: 'commit1' }]
           const getCommitsSinceMock = jest.fn(() => commits)
           const git = {
             ...createMockGitClient({
               commits,
-              packageTags: [{ name: '@test/pkg@1.0.0', hash: 'tag-hash' }],
+              commitReachable: true,
             }),
             getCommitsSince: getCommitsSinceMock,
           } as unknown as GitClient
           const context = createMockContext({
             git,
-            state: { isFirstRelease: false },
+            state: {
+              isFirstRelease: false,
+              publishedCommit: 'abc1234',
+            },
             config: {
               scopeFiltering: { strategy: 'hybrid' },
             },
@@ -1177,7 +1194,7 @@ describe('analyze-commits step', () => {
           await step.execute(context)
 
           // Should call getCommitsSince with path filter
-          type CommitsSinceCall = [tag: string, opts?: { path?: string }]
+          type CommitsSinceCall = [commit: string, opts?: { path?: string }]
           const calls = getCommitsSinceMock.mock.calls as unknown as CommitsSinceCall[]
           const pathFilteredCalls = calls.filter((call) => call[1]?.path)
           expect(pathFilteredCalls.length).toBeGreaterThan(0)
@@ -1209,12 +1226,12 @@ describe('analyze-commits step', () => {
       })
 
       describe('infrastructure path detection with existing release', () => {
-        it('uses getCommitsSince for infrastructure paths when tag exists', async () => {
+        it('uses getCommitsSince for infrastructure paths when publishedCommit exists', async () => {
           const baseCommits = [
             { message: 'feat(ci): update ci', hash: 'ci-commit' },
             { message: 'feat(lib-test): feature', hash: 'feature-commit' },
           ]
-          const getCommitsSinceMock = jest.fn((tag: string, opts?: { path?: string }) => {
+          const getCommitsSinceMock = jest.fn((commit: string, opts?: { path?: string }) => {
             if (opts?.path === 'tools/') {
               return [{ message: 'feat(ci): update ci', hash: 'ci-commit' }]
             }
@@ -1223,7 +1240,7 @@ describe('analyze-commits step', () => {
           const git = {
             ...createMockGitClient({
               commits: baseCommits,
-              packageTags: [{ name: '@test/pkg@1.0.0', hash: 'tag-hash' }],
+              commitReachable: true,
             }),
             getCommitsSince: getCommitsSinceMock,
           } as unknown as GitClient
@@ -1231,7 +1248,10 @@ describe('analyze-commits step', () => {
           const context = createMockContext({
             git,
             logger,
-            state: { isFirstRelease: false },
+            state: {
+              isFirstRelease: false,
+              publishedCommit: 'abc1234',
+            },
             config: {
               scopeFiltering: {
                 infrastructure: {
@@ -1245,7 +1265,7 @@ describe('analyze-commits step', () => {
           await step.execute(context)
 
           // Should call getCommitsSince with infrastructure path
-          type CommitsSinceCall = [tag: string, opts?: { path?: string }]
+          type CommitsSinceCall = [commit: string, opts?: { path?: string }]
           const calls = getCommitsSinceMock.mock.calls as unknown as CommitsSinceCall[]
           const infraPathCalls = calls.filter((call) => call[1]?.path === 'tools/')
           expect(infraPathCalls.length).toBeGreaterThan(0)

--- a/libs/versioning/src/flow/steps/analyze-commits.spec.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.spec.ts
@@ -434,6 +434,414 @@ describe('analyze-commits step', () => {
           expect(result.stateUpdates?.commits?.[0].type).toBe('custom')
         })
       })
+
+      describe('scope filtering strategies', () => {
+        it('uses hybrid strategy by default', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: new feature', hash: 'commit1' }],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: hybrid')
+        })
+
+        it('respects scope-only strategy from config', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat(lib-test): scoped feature', hash: 'commit1' },
+              { message: 'feat: unscoped feature', hash: 'commit2' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'scope-only' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: scope-only')
+          // Only scoped commits matching project should be included
+          // In scope-only mode, unscoped commits are filtered out
+          expect(result.stateUpdates?.commits).toHaveLength(1)
+        })
+
+        it('respects file-only strategy from config', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat(lib-test): scoped feature', hash: 'commit1' },
+              { message: 'feat: unscoped feature', hash: 'commit2' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'file-only' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: file-only')
+        })
+
+        it('infers scope-only strategy when >70% commits have scopes', async () => {
+          // 8 out of 10 commits have scopes (80%)
+          const commits = [
+            { message: 'feat(scope1): feature 1', hash: 'c1' },
+            { message: 'feat(scope2): feature 2', hash: 'c2' },
+            { message: 'fix(scope3): fix 1', hash: 'c3' },
+            { message: 'feat(scope4): feature 3', hash: 'c4' },
+            { message: 'fix(scope5): fix 2', hash: 'c5' },
+            { message: 'feat(scope6): feature 4', hash: 'c6' },
+            { message: 'fix(scope7): fix 3', hash: 'c7' },
+            { message: 'feat(scope8): feature 5', hash: 'c8' },
+            { message: 'feat: unscoped 1', hash: 'c9' },
+            { message: 'fix: unscoped 2', hash: 'c10' },
+          ]
+          const git = createMockGitClient({ commits })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'inferred' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: scope-only')
+        })
+
+        it('infers file-only strategy when <30% commits have scopes', async () => {
+          // 2 out of 10 commits have scopes (20%)
+          const commits = [
+            { message: 'feat(scope1): feature 1', hash: 'c1' },
+            { message: 'feat(scope2): feature 2', hash: 'c2' },
+            { message: 'fix: fix 1', hash: 'c3' },
+            { message: 'feat: feature 3', hash: 'c4' },
+            { message: 'fix: fix 2', hash: 'c5' },
+            { message: 'feat: feature 4', hash: 'c6' },
+            { message: 'fix: fix 3', hash: 'c7' },
+            { message: 'feat: feature 5', hash: 'c8' },
+            { message: 'feat: unscoped 1', hash: 'c9' },
+            { message: 'fix: unscoped 2', hash: 'c10' },
+          ]
+          const git = createMockGitClient({ commits })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'inferred' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: file-only')
+        })
+
+        it('infers hybrid strategy when scope ratio is between 30-70%', async () => {
+          // 5 out of 10 commits have scopes (50%)
+          const commits = [
+            { message: 'feat(scope1): feature 1', hash: 'c1' },
+            { message: 'feat(scope2): feature 2', hash: 'c2' },
+            { message: 'fix(scope3): fix 1', hash: 'c3' },
+            { message: 'feat(scope4): feature 3', hash: 'c4' },
+            { message: 'fix(scope5): fix 2', hash: 'c5' },
+            { message: 'feat: feature 4', hash: 'c6' },
+            { message: 'fix: fix 3', hash: 'c7' },
+            { message: 'feat: feature 5', hash: 'c8' },
+            { message: 'feat: unscoped 1', hash: 'c9' },
+            { message: 'fix: unscoped 2', hash: 'c10' },
+          ]
+          const git = createMockGitClient({ commits })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'inferred' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('strategy: hybrid')
+        })
+
+        it('infers file-only strategy when no commits exist (ratio is 0)', async () => {
+          const git = createMockGitClient({ commits: [] })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'inferred' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // With 0 commits, scope ratio is 0 which is < 0.3, so file-only is selected
+          expect(result.message).toContain('strategy: file-only')
+        })
+      })
+
+      describe('classification result', () => {
+        it('includes classificationResult in state updates', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat(lib-test): scoped feature', hash: 'commit1' },
+              { message: 'feat: unscoped feature', hash: 'commit2' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.classificationResult).toBeDefined()
+          expect(result.stateUpdates?.classificationResult?.summary).toBeDefined()
+          expect(result.stateUpdates?.classificationResult?.summary.bySource).toBeDefined()
+        })
+
+        it('provides classification summary breakdown', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat(lib-test): scoped feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log classification breakdown
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Classification breakdown:'))
+        })
+      })
+
+      describe('scope filtering config', () => {
+        it('applies excludeScopes from config', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat(lib-test): included', hash: 'commit1' },
+              { message: 'feat(deps): excluded dep update', hash: 'commit2' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                strategy: 'hybrid',
+                excludeScopes: ['deps'],
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // deps scope should be excluded
+          const commits = result.stateUpdates?.commits ?? []
+          expect(commits.every((c) => c.scope !== 'deps')).toBe(true)
+        })
+
+        it('applies includeScopes from config', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat(custom-scope): custom scoped', hash: 'commit1' },
+              { message: 'feat(other): other scope', hash: 'commit2' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                strategy: 'scope-only',
+                includeScopes: ['custom-scope'],
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // custom-scope should be treated as project scope and included
+          // The commit with custom-scope should be included in results
+          expect(result.stateUpdates?.commits).toHaveLength(1)
+        })
+
+        it('logs project scopes derivation', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Project scopes:'))
+        })
+      })
+
+      describe('file-based commit detection', () => {
+        it('detects commits touching project files in hybrid mode', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat: unscoped feature', hash: 'commit1' },
+              { message: 'fix: unscoped fix', hash: 'commit2' },
+            ],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'hybrid' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log about file commits
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('commits touching'))
+        })
+
+        it('detects commits touching project files in file-only mode', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: unscoped feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'file-only' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('commits touching'))
+        })
+
+        it('skips file detection in scope-only mode', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat(lib-test): scoped feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'scope-only' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should NOT log about file commits in scope-only mode
+          const debugCalls = (logger.debug as jest.Mock).mock.calls.map((call) => call[0])
+          const fileCommitLogs = debugCalls.filter((msg: string) => msg.includes('commits touching'))
+          expect(fileCommitLogs).toHaveLength(0)
+        })
+      })
+
+      describe('summary message', () => {
+        it('includes strategy in success message', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.message).toContain('strategy:')
+        })
+
+        it('includes strategy in no-commits message', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'docs: documentation', hash: 'commit1' }],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.message).toContain('No releasable commits')
+          expect(result.message).toContain('strategy:')
+        })
+
+        it('shows total commit count in message', async () => {
+          const git = createMockGitClient({
+            commits: [
+              { message: 'feat: feature 1', hash: 'c1' },
+              { message: 'docs: docs update', hash: 'c2' },
+              { message: 'chore: cleanup', hash: 'c3' },
+            ],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.message).toContain('3 total')
+        })
+      })
     })
   })
 })

--- a/libs/versioning/src/flow/steps/analyze-commits.spec.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.spec.ts
@@ -842,6 +842,371 @@ describe('analyze-commits step', () => {
           expect(result.message).toContain('3 total')
         })
       })
+
+      describe('infrastructure path-based detection', () => {
+        it('detects commits touching infrastructure paths', async () => {
+          // Create a git client that returns specific commits for infrastructure paths
+          const baseCommits = [
+            { message: 'feat(ci): update pipeline', hash: 'infra-commit1' },
+            { message: 'feat(lib-test): regular feature', hash: 'commit2' },
+          ]
+          const git = {
+            ...createMockGitClient({ commits: baseCommits }),
+            getCommitLog: (opts?: { maxCount?: number; path?: string }) => {
+              if (opts?.path === 'tools/') {
+                return [{ message: 'feat(ci): update pipeline', hash: 'infra-commit1' }]
+              }
+              if (opts?.maxCount) {
+                return baseCommits.slice(0, opts.maxCount)
+              }
+              return baseCommits
+            },
+            getCommitsSince: (tag: string, opts?: { path?: string }) => {
+              if (opts?.path === 'tools/') {
+                return [{ message: 'feat(ci): update pipeline', hash: 'infra-commit1' }]
+              }
+              return baseCommits
+            },
+          } as unknown as GitClient
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                infrastructure: {
+                  paths: ['tools/'],
+                },
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log about infrastructure paths
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('infrastructure paths'))
+        })
+
+        it('detects commits from multiple infrastructure paths', async () => {
+          const baseCommits = [
+            { message: 'feat(ci): update ci', hash: 'ci-commit' },
+            { message: 'feat(scripts): add script', hash: 'scripts-commit' },
+            { message: 'feat(lib-test): feature', hash: 'feature-commit' },
+          ]
+          const git = {
+            ...createMockGitClient({ commits: baseCommits }),
+            getCommitLog: (opts?: { maxCount?: number; path?: string }) => {
+              if (opts?.path === '.github/') {
+                return [{ message: 'feat(ci): update ci', hash: 'ci-commit' }]
+              }
+              if (opts?.path === 'scripts/') {
+                return [{ message: 'feat(scripts): add script', hash: 'scripts-commit' }]
+              }
+              if (opts?.maxCount) {
+                return baseCommits.slice(0, opts.maxCount)
+              }
+              return baseCommits
+            },
+          } as unknown as GitClient
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                infrastructure: {
+                  paths: ['.github/', 'scripts/'],
+                },
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Logs should show detected commits from infrastructure paths
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('infrastructure paths'))
+        })
+      })
+
+      describe('infrastructure scope-based detection', () => {
+        it('detects commits matching infrastructure scopes', async () => {
+          const commits = [
+            { message: 'feat(ci): update pipeline', hash: 'ci-commit' },
+            { message: 'feat(deps): update deps', hash: 'deps-commit' },
+            { message: 'feat(lib-test): feature', hash: 'feature-commit' },
+          ]
+          const git = createMockGitClient({ commits })
+          const logger = createMockLogger()
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                infrastructure: {
+                  scopes: ['ci', 'deps'],
+                },
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log about infrastructure matcher
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Infrastructure matcher'))
+        })
+      })
+
+      describe('infrastructure custom matcher', () => {
+        it('applies custom infrastructureMatcher function', async () => {
+          const commits = [
+            { message: 'feat(tooling): add tool', hash: 'tooling-commit' },
+            { message: 'feat(lib-test): feature', hash: 'feature-commit' },
+          ]
+          const git = createMockGitClient({ commits })
+          const logger = createMockLogger()
+          const customMatcher = jest.fn((ctx: { scope?: string }) => ctx.scope === 'tooling')
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                infrastructureMatcher: customMatcher,
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Custom matcher should have been called
+          expect(customMatcher).toHaveBeenCalled()
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Infrastructure matcher'))
+        })
+
+        it('combines infrastructure config matcher with custom matcher using OR logic', async () => {
+          const commits = [
+            { message: 'feat(ci): update ci', hash: 'ci-commit' },
+            { message: 'feat(custom): custom match', hash: 'custom-commit' },
+            { message: 'feat(lib-test): feature', hash: 'feature-commit' },
+          ]
+          const git = createMockGitClient({ commits })
+          const logger = createMockLogger()
+          // Custom matcher matches 'custom' scope
+          const customMatcher = jest.fn((ctx: { scope?: string }) => ctx.scope === 'custom')
+          const context = createMockContext({
+            git,
+            logger,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: {
+                // Config matcher matches 'ci' scope
+                infrastructure: {
+                  scopes: ['ci'],
+                },
+                // Custom matcher matches 'custom' scope
+                infrastructureMatcher: customMatcher,
+              },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Both matchers should contribute to infrastructure detection
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Infrastructure matcher'))
+        })
+      })
+
+      describe('toChangelogCommit transformation', () => {
+        it('removes scope from direct-scope classified commits', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat(lib-test): scoped feature', hash: 'commit1' }],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'hybrid' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // Scope should be removed from direct-scope commits
+          const commits = result.stateUpdates?.commits ?? []
+          expect(commits).toHaveLength(1)
+          expect(commits[0].scope).toBeUndefined()
+        })
+
+        it('preserves scope for file-based commits with different scope', async () => {
+          // Create git client that marks commit1 as touching project files
+          const commits = [{ message: 'feat(other-project): cross-cutting change', hash: 'commit1' }]
+          const git = {
+            ...createMockGitClient({ commits }),
+            getCommitLog: (opts?: { maxCount?: number; path?: string }) => {
+              // When querying by path (project files), return the commit
+              if (opts?.path) {
+                return commits
+              }
+              if (opts?.maxCount) {
+                return commits.slice(0, opts.maxCount)
+              }
+              return commits
+            },
+          } as unknown as GitClient
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'hybrid' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // Scope should be preserved for file-based commits
+          const resultCommits = result.stateUpdates?.commits ?? []
+          expect(resultCommits).toHaveLength(1)
+          expect(resultCommits[0].scope).toBe('other-project')
+        })
+      })
+
+      describe('relative path calculation', () => {
+        it('handles project path within workspace root', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          const context: FlowContext = {
+            ...createMockContext({ git, logger, state: { isFirstRelease: true } }),
+            workspaceRoot: '/workspace',
+            projectRoot: '/workspace/libs/test',
+          }
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should log the relative path correctly
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('libs/test'))
+        })
+
+        it('handles project path not starting with workspace root', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const logger = createMockLogger()
+          // Edge case: projectRoot doesn't start with workspaceRoot
+          const context: FlowContext = {
+            ...createMockContext({ git, logger, state: { isFirstRelease: true } }),
+            workspaceRoot: '/workspace',
+            projectRoot: '/other/path/libs/test',
+          }
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should fall back to using projectRoot as-is
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('/other/path/libs/test'))
+        })
+      })
+
+      describe('first release path filtering', () => {
+        it('uses getCommitLog with path filter for first release', async () => {
+          const commits = [{ message: 'feat: feature', hash: 'commit1' }]
+          const getCommitLogMock = jest.fn((opts?: { maxCount?: number; path?: string }) => {
+            if (opts?.path) {
+              return commits
+            }
+            if (opts?.maxCount) {
+              return commits.slice(0, opts.maxCount)
+            }
+            return commits
+          })
+          const git = {
+            ...createMockGitClient({ commits }),
+            getCommitLog: getCommitLogMock,
+          } as unknown as GitClient
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            config: {
+              scopeFiltering: { strategy: 'hybrid' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should call getCommitLog with path filter
+          const pathFilteredCalls = getCommitLogMock.mock.calls.filter((call) => call[0]?.path)
+          expect(pathFilteredCalls.length).toBeGreaterThan(0)
+        })
+      })
+
+      describe('commits since tag with path filtering', () => {
+        it('uses getCommitsSince with path filter for existing releases', async () => {
+          const commits = [{ message: 'feat: feature', hash: 'commit1' }]
+          const getCommitsSinceMock = jest.fn(() => commits)
+          const git = {
+            ...createMockGitClient({
+              commits,
+              packageTags: [{ name: '@test/pkg@1.0.0', hash: 'tag-hash' }],
+            }),
+            getCommitsSince: getCommitsSinceMock,
+          } as unknown as GitClient
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: false },
+            config: {
+              scopeFiltering: { strategy: 'hybrid' },
+            },
+          })
+          const step = createAnalyzeCommitsStep()
+
+          await step.execute(context)
+
+          // Should call getCommitsSince with path filter
+          type CommitsSinceCall = [tag: string, opts?: { path?: string }]
+          const calls = getCommitsSinceMock.mock.calls as unknown as CommitsSinceCall[]
+          const pathFilteredCalls = calls.filter((call) => call[1]?.path)
+          expect(pathFilteredCalls.length).toBeGreaterThan(0)
+        })
+      })
+
+      describe('infrastructure returns undefined when not configured', () => {
+        it('returns undefined for infrastructureCommitHashes when no infrastructure config', async () => {
+          const git = createMockGitClient({
+            commits: [{ message: 'feat: feature', hash: 'commit1' }],
+          })
+          const context = createMockContext({
+            git,
+            state: { isFirstRelease: true },
+            // No infrastructure config at all
+          })
+          const step = createAnalyzeCommitsStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          // Classification context should not have infrastructureCommitHashes set
+          // This is indirectly tested by verifying no infrastructure-related logs
+          const logger = context.logger as jest.Mocked<Logger>
+          const debugCalls = logger.debug.mock.calls.map((call) => call[0])
+          const infraLogs = debugCalls.filter((msg: string) => msg.includes('infrastructure') || msg.includes('Infrastructure'))
+          expect(infraLogs).toHaveLength(0)
+        })
+      })
     })
   })
 })

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -26,14 +26,15 @@ export const ANALYZE_COMMITS_STEP_ID = 'analyze-commits'
  * Creates the analyze-commits step.
  *
  * This step:
- * 1. Finds the last release tag for this package
- * 2. Gets all commits since that tag (or all commits if first release)
- * 3. Parses each commit using conventional commit format
- * 4. Classifies commits based on scope filtering strategy
- * 5. Filters to only release-worthy commits that belong to this project
+ * 1. Uses publishedCommit from npm registry (set by fetch-registry step)
+ * 2. Verifies the commit is reachable from current HEAD
+ * 3. Gets all commits since that commit (or recent commits if first release/fallback)
+ * 4. Parses each commit using conventional commit format
+ * 5. Classifies commits based on scope filtering strategy
+ * 6. Filters to only release-worthy commits that belong to this project
  *
  * State updates:
- * - lastReleaseTag: Tag name of last release (null if first release)
+ * - effectiveBaseCommit: The verified base commit (null if fallback was used)
  * - commits: Array of parsed conventional commits (for backward compatibility)
  * - classificationResult: Full classification result with source attribution
  *
@@ -177,7 +178,6 @@ export function createAnalyzeCommitsStep(): FlowStep {
       return {
         status: 'success',
         stateUpdates: {
-          lastReleaseTag: null, // Deprecated: use effectiveBaseCommit instead
           effectiveBaseCommit,
           commits,
           classificationResult,

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -46,34 +46,33 @@ export function createAnalyzeCommitsStep(): FlowStep {
     async (ctx) => {
       const { git, projectName, projectRoot, packageName, workspaceRoot, config, logger, state } = ctx
 
-      // Find the last release tag for this package
-      let lastReleaseTag: string | null = null
+      // Use publishedCommit from registry (set by fetch-registry step)
+      const { publishedCommit, isFirstRelease } = state
 
-      if (!state.isFirstRelease) {
-        // Try to find a tag matching the package name pattern
-        const tags = git.getTagsForPackage(packageName)
-        if (tags.length > 0) {
-          // Tags are returned in reverse chronological order
-          lastReleaseTag = tags[0].name
-          logger.debug(`Found last release tag: ${lastReleaseTag}`)
+      let rawCommits: readonly GitCommit[]
+      let effectiveBaseCommit: string | null = null
+
+      if (publishedCommit && !isFirstRelease) {
+        // CRITICAL: Verify the commit exists and is reachable from HEAD
+        if (git.commitReachableFromHead(publishedCommit)) {
+          rawCommits = git.getCommitsSince(publishedCommit)
+          effectiveBaseCommit = publishedCommit
+          logger.debug(`Found ${rawCommits.length} commits since ${publishedCommit.slice(0, 7)}`)
         } else {
-          // Try with project name format
-          const projectTags = git.getTagsForPackage(projectName)
-          if (projectTags.length > 0) {
-            lastReleaseTag = projectTags[0].name
-            logger.debug(`Found last release tag (project format): ${lastReleaseTag}`)
-          }
+          // GRACEFUL DEGRADATION: Commit not in history (rebase/force push occurred)
+          logger.warn(
+            `Published commit ${publishedCommit.slice(0, 7)} not found in history. ` +
+              `This may indicate a rebase or force push occurred after publishing v${state.publishedVersion}. ` +
+              `Falling back to recent commit analysis.`
+          )
+          rawCommits = git.getCommitLog({ maxCount: 100 })
+          // effectiveBaseCommit stays null - no compare URL will be generated
         }
+      } else {
+        // First release or no published version
+        rawCommits = git.getCommitLog({ maxCount: 100 })
+        logger.debug(`First release - analyzing up to ${rawCommits.length} commits`)
       }
-
-      // Get all commits
-      const rawCommits = lastReleaseTag ? git.getCommitsSince(lastReleaseTag) : git.getCommitLog({ maxCount: 100 })
-
-      logger.debug(
-        lastReleaseTag
-          ? `Found ${rawCommits.length} commits since ${lastReleaseTag}`
-          : `First release - analyzing up to ${rawCommits.length} commits`
-      )
 
       // Get scope filtering configuration
       const scopeFilteringConfig = {
@@ -115,8 +114,8 @@ export function createAnalyzeCommitsStep(): FlowStep {
       if (strategy === 'hybrid' || strategy === 'file-only') {
         // Get commits that touched project files using path filter
         const relativePath = getRelativePath(workspaceRoot, projectRoot)
-        const pathFilteredCommits = lastReleaseTag
-          ? git.getCommitsSince(lastReleaseTag, { path: relativePath })
+        const pathFilteredCommits = effectiveBaseCommit
+          ? git.getCommitsSince(effectiveBaseCommit, { path: relativePath })
           : git.getCommitLog({ maxCount: 100, path: relativePath })
 
         fileCommitHashes = createSet(pathFilteredCommits.map((c) => c.hash))
@@ -134,7 +133,7 @@ export function createAnalyzeCommitsStep(): FlowStep {
       // Build infrastructure commit hashes for file-based infrastructure detection
       const infrastructureCommitHashes = buildInfrastructureCommitHashes(
         git,
-        lastReleaseTag,
+        effectiveBaseCommit,
         rawCommits,
         parsedCommits,
         scopeFilteringConfig,
@@ -144,7 +143,7 @@ export function createAnalyzeCommitsStep(): FlowStep {
       // Build dependency commit map if tracking is enabled (Phase 4)
       let dependencyCommitMap: ReadonlyMap<string, ReadonlySet<string>> | undefined
       if (scopeFilteringConfig.trackDependencyChanges) {
-        dependencyCommitMap = buildDependencyCommitMap(git, workspaceRoot, projectName, lastReleaseTag, logger)
+        dependencyCommitMap = buildDependencyCommitMap(git, workspaceRoot, projectName, effectiveBaseCommit, logger)
       }
 
       // Create classification context
@@ -178,7 +177,8 @@ export function createAnalyzeCommitsStep(): FlowStep {
       return {
         status: 'success',
         stateUpdates: {
-          lastReleaseTag,
+          lastReleaseTag: null, // Deprecated: use effectiveBaseCommit instead
+          effectiveBaseCommit,
           commits,
           classificationResult,
         },
@@ -304,7 +304,7 @@ function buildSummaryMessage(
  * 3. Custom matcher: User-provided matching logic
  *
  * @param git - Git client for querying commits by path
- * @param lastReleaseTag - Last release tag (null for first release)
+ * @param baseCommit - Base commit hash for commit range (null for first release/fallback)
  * @param rawCommits - All raw commits being analyzed
  * @param parsedCommits - Parsed commits with conventional commit data
  * @param config - Scope filtering configuration
@@ -314,7 +314,7 @@ function buildSummaryMessage(
  */
 function buildInfrastructureCommitHashes(
   git: GitClient,
-  lastReleaseTag: string | null,
+  baseCommit: string | null,
   rawCommits: readonly GitCommit[],
   parsedCommits: readonly CommitWithRaw[],
   config: ScopeFilteringConfig,
@@ -327,8 +327,8 @@ function buildInfrastructureCommitHashes(
   const infraPaths = config.infrastructure?.paths ?? []
   if (infraPaths.length > 0) {
     for (const infraPath of infraPaths) {
-      const pathCommits = lastReleaseTag
-        ? git.getCommitsSince(lastReleaseTag, { path: infraPath })
+      const pathCommits = baseCommit
+        ? git.getCommitsSince(baseCommit, { path: infraPath })
         : git.getCommitLog({ maxCount: 100, path: infraPath })
 
       for (const commit of pathCommits) {
@@ -403,7 +403,7 @@ function combineMatcher(a: InfrastructureMatcher | null, b: InfrastructureMatche
  * @param git - Git client for querying commits by path
  * @param workspaceRoot - Absolute path to workspace root
  * @param projectName - Name of the project being versioned
- * @param lastReleaseTag - Last release tag (null for first release)
+ * @param baseCommit - Base commit hash for commit range (null for first release/fallback)
  * @param logger - Logger with debug method for output
  * @param logger.debug - Debug logging function
  * @returns Map of dependency names to commit hashes touching that dependency
@@ -412,7 +412,7 @@ function buildDependencyCommitMap(
   git: GitClient,
   workspaceRoot: string,
   projectName: string,
-  lastReleaseTag: string | null,
+  baseCommit: string | null,
   logger: { debug: (msg: string) => void }
 ): ReadonlyMap<string, ReadonlySet<string>> {
   let dependencyMap = createMap<string, ReadonlySet<string>>()
@@ -444,8 +444,8 @@ function buildDependencyCommitMap(
       const depRoot = depNode.data.root
 
       // Query git for commits touching this dependency's path
-      const depCommits = lastReleaseTag
-        ? git.getCommitsSince(lastReleaseTag, { path: depRoot })
+      const depCommits = baseCommit
+        ? git.getCommitsSince(baseCommit, { path: depRoot })
         : git.getCommitLog({ maxCount: 100, path: depRoot })
 
       if (depCommits.length > 0) {

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -1,9 +1,19 @@
-import type { ClassifiedCommit, CommitWithRaw } from '../../commits/classify'
+import type { ClassifiedCommit, CommitWithRaw, InfrastructureMatcher } from '../../commits/classify'
 import type { ConventionalCommit } from '../../commits/models/conventional'
+import type { GitClient } from '../../git/factory'
+import type { GitCommit } from '../../git/models/commit'
 import type { FlowStep } from '../models/step'
-import type { ScopeFilteringStrategy } from '../models/types'
+import type { ScopeFilteringConfig, ScopeFilteringStrategy } from '../models/types'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
 import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
-import { classifyCommits, createClassificationContext, deriveProjectScopes, toChangelogCommit } from '../../commits/classify'
+import {
+  buildInfrastructureMatcher,
+  classifyCommits,
+  createClassificationContext,
+  createMatchContext,
+  deriveProjectScopes,
+  toChangelogCommit,
+} from '../../commits/classify'
 import { parseConventionalCommit } from '../../commits/parse/message'
 import { createStep } from '../models/step'
 import { DEFAULT_SCOPE_FILTERING_CONFIG } from '../models/types'
@@ -119,11 +129,21 @@ export function createAnalyzeCommitsStep(): FlowStep {
       })
       logger.debug(`Project scopes: ${projectScopes.join(', ')}`)
 
+      // Build infrastructure commit hashes for file-based infrastructure detection
+      const infrastructureCommitHashes = buildInfrastructureCommitHashes(
+        git,
+        lastReleaseTag,
+        rawCommits,
+        parsedCommits,
+        scopeFilteringConfig,
+        logger
+      )
+
       // Create classification context
       const classificationContext = createClassificationContext(projectScopes, fileCommitHashes, {
         excludeScopes: scopeFilteringConfig.excludeScopes,
         includeScopes: scopeFilteringConfig.includeScopes,
-        infrastructurePaths: scopeFilteringConfig.infrastructurePaths,
+        infrastructureCommitHashes,
       })
 
       // Classify commits
@@ -264,4 +284,100 @@ function buildSummaryMessage(
   const parts = [`Found ${includedCount} releasable commits`, `(${totalCount} total`, `strategy: ${strategy})`]
 
   return parts.join(' ')
+}
+
+/**
+ * Builds a set of commit hashes that touched infrastructure paths or match infrastructure criteria.
+ *
+ * Supports multiple detection methods combined with OR logic:
+ * 1. Path-based: Commits touching configured infrastructure paths (via git)
+ * 2. Scope-based: Commits with scopes matching infrastructure.scopes
+ * 3. Custom matcher: User-provided matching logic
+ *
+ * @param git - Git client for querying commits by path
+ * @param lastReleaseTag - Last release tag (null for first release)
+ * @param rawCommits - All raw commits being analyzed
+ * @param parsedCommits - Parsed commits with conventional commit data
+ * @param config - Scope filtering configuration
+ * @param logger - Logger with debug method for output
+ * @param logger.debug - Debug logging function
+ * @returns Set of commit hashes classified as infrastructure
+ */
+function buildInfrastructureCommitHashes(
+  git: GitClient,
+  lastReleaseTag: string | null,
+  rawCommits: readonly GitCommit[],
+  parsedCommits: readonly CommitWithRaw[],
+  config: ScopeFilteringConfig,
+  logger: { debug: (msg: string) => void }
+): ReadonlySet<string> | undefined {
+  // Collect all infrastructure commit hashes
+  let infraHashes = createSet<string>()
+
+  // Method 1: Path-based detection (query git for commits touching infra paths)
+  const infraPaths = config.infrastructure?.paths ?? []
+  if (infraPaths.length > 0) {
+    for (const infraPath of infraPaths) {
+      const pathCommits = lastReleaseTag
+        ? git.getCommitsSince(lastReleaseTag, { path: infraPath })
+        : git.getCommitLog({ maxCount: 100, path: infraPath })
+
+      for (const commit of pathCommits) {
+        infraHashes = infraHashes.add(commit.hash)
+      }
+    }
+    logger.debug(`Found ${infraHashes.size} commits touching infrastructure paths: ${infraPaths.join(', ')}`)
+  }
+
+  // Method 2 & 3: Scope-based and custom matcher detection
+  // Build a combined matcher from infrastructure config and/or custom matcher
+  const configMatcher = config.infrastructure ? buildInfrastructureMatcher(config.infrastructure) : null
+  const customMatcher = config.infrastructureMatcher
+  const combinedMatcher = combineMatcher(configMatcher, customMatcher)
+
+  if (combinedMatcher) {
+    // Build a lookup for parsed commits by hash
+    let parsedByHash = createMap<string, CommitWithRaw>()
+    for (const parsed of parsedCommits) {
+      parsedByHash = parsedByHash.set(parsed.raw.hash, parsed)
+    }
+
+    // Evaluate each raw commit against the matcher
+    for (const rawCommit of rawCommits) {
+      // Skip if already matched by path
+      if (infraHashes.has(rawCommit.hash)) continue
+
+      // Get parsed scope if available
+      const parsed = parsedByHash.get(rawCommit.hash)
+      const scope = parsed?.commit.scope
+
+      // Create match context and evaluate
+      const context = createMatchContext(rawCommit, scope)
+      if (combinedMatcher(context)) {
+        infraHashes = infraHashes.add(rawCommit.hash)
+      }
+    }
+    logger.debug(`Infrastructure matcher found ${infraHashes.size} total commits`)
+  }
+
+  // Return undefined if no infrastructure detection configured
+  if (infraHashes.size === 0 && infraPaths.length === 0 && !combinedMatcher) {
+    return undefined
+  }
+
+  return infraHashes
+}
+
+/**
+ * Combines two optional matchers into one using OR logic.
+ *
+ * @param a - First matcher (may be null)
+ * @param b - Second matcher (may be undefined)
+ * @returns Combined matcher or null if neither provided
+ */
+function combineMatcher(a: InfrastructureMatcher | null, b: InfrastructureMatcher | undefined): InfrastructureMatcher | null {
+  if (a && b) {
+    return (ctx) => a(ctx) || b(ctx)
+  }
+  return a ?? b ?? null
 }

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -6,6 +6,8 @@ import type { FlowStep } from '../models/step'
 import type { ScopeFilteringConfig, ScopeFilteringStrategy } from '../models/types'
 import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
 import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { buildSimpleProjectGraph, discoverNxProjects } from '@hyperfrontend/project-scope/nx'
 import {
   buildInfrastructureMatcher,
   classifyCommits,
@@ -139,11 +141,18 @@ export function createAnalyzeCommitsStep(): FlowStep {
         logger
       )
 
+      // Build dependency commit map if tracking is enabled (Phase 4)
+      let dependencyCommitMap: ReadonlyMap<string, ReadonlySet<string>> | undefined
+      if (scopeFilteringConfig.trackDependencyChanges) {
+        dependencyCommitMap = buildDependencyCommitMap(git, workspaceRoot, projectName, lastReleaseTag, logger)
+      }
+
       // Create classification context
       const classificationContext = createClassificationContext(projectScopes, fileCommitHashes, {
         excludeScopes: scopeFilteringConfig.excludeScopes,
         includeScopes: scopeFilteringConfig.includeScopes,
         infrastructureCommitHashes,
+        dependencyCommitMap,
       })
 
       // Classify commits
@@ -380,4 +389,77 @@ function combineMatcher(a: InfrastructureMatcher | null, b: InfrastructureMatche
     return (ctx) => a(ctx) || b(ctx)
   }
   return a ?? b ?? null
+}
+
+/**
+ * Builds a map of dependency project names to the commit hashes that touched them.
+ *
+ * This enables accurate indirect-dependency classification by verifying that:
+ * 1. A commit's scope matches a dependency name
+ * 2. The commit actually touched that dependency's files (hash in set)
+ *
+ * Uses lib-project-scope for dependency discovery, avoiding hard NX dependency.
+ *
+ * @param git - Git client for querying commits by path
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param projectName - Name of the project being versioned
+ * @param lastReleaseTag - Last release tag (null for first release)
+ * @param logger - Logger with debug method for output
+ * @param logger.debug - Debug logging function
+ * @returns Map of dependency names to commit hashes touching that dependency
+ */
+function buildDependencyCommitMap(
+  git: GitClient,
+  workspaceRoot: string,
+  projectName: string,
+  lastReleaseTag: string | null,
+  logger: { debug: (msg: string) => void }
+): ReadonlyMap<string, ReadonlySet<string>> {
+  let dependencyMap = createMap<string, ReadonlySet<string>>()
+
+  try {
+    // Discover all projects in workspace using lib-project-scope
+    // This gracefully handles NX and non-NX workspaces
+    const projects = discoverNxProjects(workspaceRoot)
+    const projectGraph = buildSimpleProjectGraph(workspaceRoot, projects)
+
+    // Get dependencies for the current project
+    const projectDeps = projectGraph.dependencies[projectName] ?? []
+
+    if (projectDeps.length === 0) {
+      logger.debug(`No dependencies found for project: ${projectName}`)
+      return dependencyMap
+    }
+
+    logger.debug(`Found ${projectDeps.length} dependencies for ${projectName}: ${projectDeps.map((d) => d.target).join(', ')}`)
+
+    // For each dependency, find commits that touched its files
+    for (const dep of projectDeps) {
+      const depNode = projectGraph.nodes[dep.target]
+      if (!depNode?.data?.root) {
+        logger.debug(`Skipping dependency ${dep.target}: no root path found`)
+        continue
+      }
+
+      const depRoot = depNode.data.root
+
+      // Query git for commits touching this dependency's path
+      const depCommits = lastReleaseTag
+        ? git.getCommitsSince(lastReleaseTag, { path: depRoot })
+        : git.getCommitLog({ maxCount: 100, path: depRoot })
+
+      if (depCommits.length > 0) {
+        const hashSet = createSet(depCommits.map((c) => c.hash))
+        dependencyMap = dependencyMap.set(dep.target, hashSet)
+        logger.debug(`Dependency ${dep.target}: ${depCommits.length} commits at ${depRoot}`)
+      }
+    }
+  } catch (error) {
+    // Graceful degradation: if project discovery fails, return empty map
+    // This allows versioning to proceed without dependency tracking
+    const message = error instanceof Error ? error.message : String(error)
+    logger.debug(`Failed to build dependency map: ${message}`)
+  }
+
+  return dependencyMap
 }

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -1,7 +1,12 @@
+import type { ClassifiedCommit, CommitWithRaw } from '../../commits/classify'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { FlowStep } from '../models/step'
+import type { ScopeFilteringStrategy } from '../models/types'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
+import { classifyCommits, createClassificationContext, deriveProjectScopes, toChangelogCommit } from '../../commits/classify'
 import { parseConventionalCommit } from '../../commits/parse/message'
 import { createStep } from '../models/step'
+import { DEFAULT_SCOPE_FILTERING_CONFIG } from '../models/types'
 
 export const ANALYZE_COMMITS_STEP_ID = 'analyze-commits'
 
@@ -12,11 +17,13 @@ export const ANALYZE_COMMITS_STEP_ID = 'analyze-commits'
  * 1. Finds the last release tag for this package
  * 2. Gets all commits since that tag (or all commits if first release)
  * 3. Parses each commit using conventional commit format
- * 4. Filters to only release-worthy commits
+ * 4. Classifies commits based on scope filtering strategy
+ * 5. Filters to only release-worthy commits that belong to this project
  *
  * State updates:
  * - lastReleaseTag: Tag name of last release (null if first release)
- * - commits: Array of parsed conventional commits
+ * - commits: Array of parsed conventional commits (for backward compatibility)
+ * - classificationResult: Full classification result with source attribution
  *
  * @returns A FlowStep that analyzes commits
  */
@@ -25,7 +32,7 @@ export function createAnalyzeCommitsStep(): FlowStep {
     ANALYZE_COMMITS_STEP_ID,
     'Analyze Commits',
     async (ctx) => {
-      const { git, projectName, packageName, config, logger, state } = ctx
+      const { git, projectName, projectRoot, packageName, workspaceRoot, config, logger, state } = ctx
 
       // Find the last release tag for this package
       let lastReleaseTag: string | null = null
@@ -47,39 +54,104 @@ export function createAnalyzeCommitsStep(): FlowStep {
         }
       }
 
-      // Get commits
-      let rawCommits: readonly { message: string; hash: string }[]
+      // Get all commits
+      const rawCommits = lastReleaseTag ? git.getCommitsSince(lastReleaseTag) : git.getCommitLog({ maxCount: 100 })
 
-      if (lastReleaseTag) {
-        rawCommits = git.getCommitsSince(lastReleaseTag)
-        logger.debug(`Found ${rawCommits.length} commits since ${lastReleaseTag}`)
-      } else {
-        // First release - get all commits (limit to recent for performance)
-        rawCommits = git.getCommitLog({ maxCount: 100 })
-        logger.debug(`First release - analyzing up to ${rawCommits.length} commits`)
+      logger.debug(
+        lastReleaseTag
+          ? `Found ${rawCommits.length} commits since ${lastReleaseTag}`
+          : `First release - analyzing up to ${rawCommits.length} commits`
+      )
+
+      // Get scope filtering configuration
+      const scopeFilteringConfig = {
+        ...DEFAULT_SCOPE_FILTERING_CONFIG,
+        ...config.scopeFiltering,
       }
+      const strategy = resolveStrategy(scopeFilteringConfig.strategy ?? 'hybrid', rawCommits)
 
-      // Parse commits using conventional commit format
-      const commits: ConventionalCommit[] = []
+      // Parse commits with conventional commit format
       const releaseTypes = config.releaseTypes ?? ['feat', 'fix', 'perf', 'revert']
+      const parsedCommits: CommitWithRaw[] = []
 
       for (const rawCommit of rawCommits) {
         const parsed = parseConventionalCommit(rawCommit.message)
         if (parsed.type && releaseTypes.includes(parsed.type)) {
-          commits.push(parsed)
+          parsedCommits.push({
+            commit: parsed,
+            raw: {
+              hash: rawCommit.hash,
+              shortHash: rawCommit.hash.slice(0, 7),
+              message: rawCommit.message,
+              subject: parsed.subject ?? rawCommit.message.split('\n')[0],
+              body: parsed.body ?? '',
+              authorName: '',
+              authorEmail: '',
+              authorDate: '',
+              committerName: '',
+              committerEmail: '',
+              commitDate: '',
+              parents: [],
+              refs: [],
+            },
+          })
         }
       }
 
-      const message =
-        commits.length > 0
-          ? `Found ${commits.length} releasable commits (${rawCommits.length} total)`
-          : `No releasable commits found (${rawCommits.length} total)`
+      // Build file commit hashes for hybrid/file-only strategies
+      let fileCommitHashes = createSet<string>()
+      if (strategy === 'hybrid' || strategy === 'file-only') {
+        // Get commits that touched project files using path filter
+        const relativePath = getRelativePath(workspaceRoot, projectRoot)
+        const pathFilteredCommits = lastReleaseTag
+          ? git.getCommitsSince(lastReleaseTag, { path: relativePath })
+          : git.getCommitLog({ maxCount: 100, path: relativePath })
+
+        fileCommitHashes = createSet(pathFilteredCommits.map((c) => c.hash))
+        logger.debug(`Found ${fileCommitHashes.size} commits touching ${relativePath}`)
+      }
+
+      // Derive project scopes
+      const projectScopes = deriveProjectScopes({
+        projectName,
+        packageName,
+        additionalScopes: scopeFilteringConfig.includeScopes,
+      })
+      logger.debug(`Project scopes: ${projectScopes.join(', ')}`)
+
+      // Create classification context
+      const classificationContext = createClassificationContext(projectScopes, fileCommitHashes, {
+        excludeScopes: scopeFilteringConfig.excludeScopes,
+        includeScopes: scopeFilteringConfig.includeScopes,
+        infrastructurePaths: scopeFilteringConfig.infrastructurePaths,
+      })
+
+      // Classify commits
+      const classificationResult = classifyCommits(parsedCommits, classificationContext)
+
+      // Apply strategy-specific filtering
+      const includedCommits = applyStrategyFilter(classificationResult.included, strategy)
+
+      // Extract conventional commits for backward compatibility
+      // Use toChangelogCommit to properly handle scope based on classification
+      const commits: ConventionalCommit[] = includedCommits.map((c) => toChangelogCommit(c))
+
+      // Build message with classification summary
+      const { summary } = classificationResult
+      const message = buildSummaryMessage(commits.length, rawCommits.length, summary, strategy)
+
+      logger.debug(
+        `Classification breakdown: direct-scope=${summary.bySource['direct-scope']}, ` +
+          `direct-file=${summary.bySource['direct-file']}, unscoped-file=${summary.bySource['unscoped-file']}, ` +
+          `excluded=${summary.bySource['excluded']}`
+      )
 
       return {
         status: 'success',
         stateUpdates: {
           lastReleaseTag,
           commits,
+          classificationResult,
         },
         message,
       }
@@ -88,4 +160,108 @@ export function createAnalyzeCommitsStep(): FlowStep {
       dependsOn: ['fetch-registry'],
     }
   )
+}
+
+/**
+ * Resolves the filtering strategy, handling 'inferred' by analyzing commits.
+ *
+ * @param strategy - The configured scope filtering strategy
+ * @param commits - The commits to analyze for strategy inference
+ * @returns The resolved strategy (never 'inferred')
+ */
+function resolveStrategy(
+  strategy: ScopeFilteringStrategy,
+  commits: readonly { message: string }[]
+): Exclude<ScopeFilteringStrategy, 'inferred'> {
+  if (strategy !== 'inferred') {
+    return strategy
+  }
+
+  // Infer strategy from commit history
+  // Count commits with conventional scopes
+  let scopedCount = 0
+  for (const commit of commits) {
+    const parsed = parseConventionalCommit(commit.message)
+    if (parsed.scope) {
+      scopedCount++
+    }
+  }
+
+  const scopeRatio = commits.length > 0 ? scopedCount / commits.length : 0
+
+  // If >70% of commits have scopes, scope-only is viable
+  // If <30% have scopes, file-only is better
+  // Otherwise, use hybrid
+  if (scopeRatio > 0.7) {
+    return 'scope-only'
+  } else if (scopeRatio < 0.3) {
+    return 'file-only'
+  }
+  return 'hybrid'
+}
+
+/**
+ * Applies strategy-specific filtering to classified commits.
+ *
+ * @param commits - The classified commits to filter
+ * @param strategy - The resolved filtering strategy to apply
+ * @returns Filtered commits based on the strategy
+ */
+function applyStrategyFilter(
+  commits: readonly ClassifiedCommit[],
+  strategy: Exclude<ScopeFilteringStrategy, 'inferred'>
+): readonly ClassifiedCommit[] {
+  switch (strategy) {
+    case 'scope-only':
+      // Only include direct-scope commits
+      return commits.filter((c) => c.source === 'direct-scope')
+
+    case 'file-only':
+      // Only include file-based commits (direct-file, unscoped-file)
+      return commits.filter((c) => c.source === 'direct-file' || c.source === 'unscoped-file')
+
+    case 'hybrid':
+    default:
+      // Include all non-excluded commits (already filtered in classifyCommits)
+      return commits
+  }
+}
+
+/**
+ * Gets the relative path from workspace root to project root.
+ *
+ * @param workspaceRoot - The absolute path to the workspace root
+ * @param projectRoot - The absolute path to the project root
+ * @returns The relative path from workspace to project
+ */
+function getRelativePath(workspaceRoot: string, projectRoot: string): string {
+  if (projectRoot.startsWith(workspaceRoot)) {
+    return projectRoot.slice(workspaceRoot.length).replace(/^\//, '')
+  }
+  return projectRoot
+}
+
+/**
+ * Builds a summary message for the step result.
+ *
+ * @param includedCount - Number of commits included in the release
+ * @param totalCount - Total number of commits analyzed
+ * @param summary - Classification summary object
+ * @param summary.bySource - Count of commits by source type
+ * @param strategy - The filtering strategy used
+ * @returns A human-readable summary message
+ */
+function buildSummaryMessage(
+  includedCount: number,
+  totalCount: number,
+  summary: { bySource: Record<string, number> },
+  strategy: string
+): string {
+  if (includedCount === 0) {
+    return `No releasable commits found for this project (${totalCount} total, strategy: ${strategy})`
+  }
+
+  const parts = [`Found ${includedCount} releasable commits`, `(${totalCount} total`, `strategy: ${strategy})`]
+
+  return parts.join(' ')
 }

--- a/libs/versioning/src/flow/steps/fetch-registry.spec.ts
+++ b/libs/versioning/src/flow/steps/fetch-registry.spec.ts
@@ -42,8 +42,15 @@ function createMockTree(files: Record<string, string> = {}, throwOnRead = false)
   } as unknown as Tree
 }
 
-function createMockRegistry(options: { version?: string | null; throwOnQuery?: boolean } = {}): Registry {
-  const { version = null, throwOnQuery = false } = options
+function createMockRegistry(
+  options: {
+    version?: string | null
+    gitHead?: string | null
+    throwOnQuery?: boolean
+    throwOnVersionInfo?: boolean
+  } = {}
+): Registry {
+  const { version = null, gitHead = null, throwOnQuery = false, throwOnVersionInfo = false } = options
 
   return {
     name: 'mock',
@@ -60,7 +67,18 @@ function createMockRegistry(options: { version?: string | null; throwOnQuery?: b
     async getPackageInfo() {
       return null
     },
-    async getVersionInfo() {
+    async getVersionInfo(_pkg: string, v: string) {
+      if (throwOnVersionInfo) {
+        throw new Error('Version info query failed')
+      }
+      if (v === version && version !== null) {
+        return {
+          version: v,
+          publishedAt: '2026-03-18T00:00:00.000Z',
+          tarball: `https://mock.registry.com/${v}.tgz`,
+          gitHead: gitHead ?? undefined,
+        }
+      }
       return null
     },
     async listVersions() {
@@ -285,6 +303,114 @@ describe('fetch-registry step', () => {
         expect(result.status).toBe('success')
         expect(result.message).toContain('Published: 1.5.0')
         expect(result.message).toContain('Local: 2.0.0')
+      })
+
+      describe('publishedCommit extraction', () => {
+        it('extracts gitHead as publishedCommit when available', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              version: '1.0.0',
+            }),
+          })
+          const registry = createMockRegistry({
+            version: '1.0.0',
+            gitHead: 'abc1234567890def',
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({ tree, registry, logger })
+          const step = createFetchRegistryStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.publishedCommit).toBe('abc1234567890def')
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Published 1.0.0 at commit abc1234'))
+        })
+
+        it('sets publishedCommit to null when gitHead is missing', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              version: '1.0.0',
+            }),
+          })
+          const registry = createMockRegistry({
+            version: '1.0.0',
+            gitHead: null,
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({ tree, registry, logger })
+          const step = createFetchRegistryStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.publishedCommit).toBe(null)
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('has no gitHead'))
+        })
+
+        it('sets publishedCommit to null when getVersionInfo fails', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              version: '1.0.0',
+            }),
+          })
+          const registry = createMockRegistry({
+            version: '1.0.0',
+            throwOnVersionInfo: true,
+          })
+          const logger = createMockLogger()
+          const context = createMockContext({ tree, registry, logger })
+          const step = createFetchRegistryStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.publishedVersion).toBe('1.0.0')
+          expect(result.stateUpdates?.publishedCommit).toBe(null)
+          expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Could not fetch version info'))
+        })
+
+        it('includes commit hash in message when available', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              version: '2.0.0',
+            }),
+          })
+          const registry = createMockRegistry({
+            version: '1.5.0',
+            gitHead: 'def4567890abcdef',
+          })
+          const context = createMockContext({ tree, registry })
+          const step = createFetchRegistryStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.message).toContain('Published: 1.5.0 @ def4567')
+          expect(result.message).toContain('Local: 2.0.0')
+        })
+
+        it('sets publishedCommit to null for first release', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              version: '0.0.0',
+            }),
+          })
+          const registry = createMockRegistry({ version: null })
+          const context = createMockContext({ tree, registry })
+          const step = createFetchRegistryStep()
+
+          const result = await step.execute(context)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.publishedCommit).toBe(null)
+          expect(result.stateUpdates?.isFirstRelease).toBe(true)
+        })
       })
     })
   })

--- a/libs/versioning/src/flow/steps/fetch-registry.ts
+++ b/libs/versioning/src/flow/steps/fetch-registry.ts
@@ -39,23 +39,43 @@ export function createFetchRegistryStep(): FlowStep {
 
     // Query registry for published version
     let publishedVersion: string | null = null
+    let publishedCommit: string | null = null
     let isFirstRelease = true
 
     try {
       publishedVersion = await registry.getLatestVersion(packageName)
       isFirstRelease = publishedVersion === null
+
+      // When published version exists, get its commit hash from gitHead
+      if (publishedVersion) {
+        try {
+          const versionInfo = await registry.getVersionInfo(packageName, publishedVersion)
+          publishedCommit = versionInfo?.gitHead ?? null
+          if (publishedCommit) {
+            logger.debug(`Published ${publishedVersion} at commit ${publishedCommit.slice(0, 7)}`)
+          } else {
+            logger.debug(`Published ${publishedVersion} has no gitHead (older package or published without git)`)
+          }
+        } catch (error) {
+          // Version info fetch failed, but we still have the version
+          logger.debug(`Could not fetch version info for ${publishedVersion}: ${error}`)
+        }
+      }
     } catch (error) {
       // Package might not exist yet, which is fine
       logger.debug(`Registry query failed (package may not exist): ${error}`)
       isFirstRelease = true
     }
 
-    const message = isFirstRelease ? `First release (local: ${currentVersion})` : `Published: ${publishedVersion}, Local: ${currentVersion}`
+    const message = isFirstRelease
+      ? `First release (local: ${currentVersion})`
+      : `Published: ${publishedVersion}${publishedCommit ? ` @ ${publishedCommit.slice(0, 7)}` : ''}, Local: ${currentVersion}`
 
     return {
       status: 'success',
       stateUpdates: {
         publishedVersion,
+        publishedCommit,
         currentVersion,
         isFirstRelease,
       },

--- a/libs/versioning/src/flow/steps/generate-changelog.spec.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.spec.ts
@@ -585,6 +585,9 @@ describe('Generate Changelog Step', () => {
   })
 
   describe('execute - compare URL generation', () => {
+    // Note: Compare URLs now use commit hashes only (not tags)
+    // Mock git client returns 'abc123' for getHeadHash()
+
     const createGitHubConfig = (): RepositoryConfig => ({
       platform: 'github',
       baseUrl: 'https://github.com/owner/repo',
@@ -605,7 +608,7 @@ describe('Generate Changelog Step', () => {
       const ctx = createMockContext({
         nextVersion: '1.0.0',
         bumpType: 'minor',
-        lastReleaseTag: 'lib-test@0.9.0',
+        effectiveBaseCommit: 'def456789',
         commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
       })
 
@@ -615,7 +618,7 @@ describe('Generate Changelog Step', () => {
       expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
     })
 
-    it('does not include compareUrl when lastReleaseTag is not present', async () => {
+    it('does not include compareUrl when effectiveBaseCommit is not present', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '1.0.0',
@@ -630,13 +633,13 @@ describe('Generate Changelog Step', () => {
       expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
     })
 
-    it('does not include compareUrl when lastReleaseTag is null', async () => {
+    it('does not include compareUrl when effectiveBaseCommit is null', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '1.0.0',
         bumpType: 'minor',
         repositoryConfig: createGitHubConfig(),
-        lastReleaseTag: null,
+        effectiveBaseCommit: null,
         commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
       })
 
@@ -646,92 +649,72 @@ describe('Generate Changelog Step', () => {
       expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
     })
 
-    it('generates GitHub compareUrl when repositoryConfig and lastReleaseTag exist', async () => {
+    it('logs info when publishedCommit exists but effectiveBaseCommit is null (fallback mode)', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        publishedCommit: 'orphaned123', // Commit exists in registry but not in history
+        effectiveBaseCommit: null, // Null because fallback was used
+        commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
+      expect(ctx.logger.info).toHaveBeenCalledWith('Compare URL omitted: published commit not in current history')
+    })
+
+    it('generates GitHub compareUrl using commit hashes when effectiveBaseCommit exists', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '1.1.0',
         bumpType: 'minor',
         repositoryConfig: createGitHubConfig(),
-        lastReleaseTag: 'lib-test@1.0.0',
+        effectiveBaseCommit: 'def456789',
         commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
       })
 
       const result = await step.execute(ctx)
 
       expect(result.status).toBe('success')
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@1.0.0...lib-test@1.1.0')
+      // Uses commit hashes: effectiveBaseCommit...getHeadHash() (abc123 from mock)
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/def456789...abc123')
     })
 
-    it('generates GitLab compareUrl with /-/ prefix', async () => {
+    it('generates GitLab compareUrl with /-/ prefix using commit hashes', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '2.0.0',
         bumpType: 'major',
         repositoryConfig: createGitLabConfig(),
-        lastReleaseTag: 'lib-test@1.0.0',
+        effectiveBaseCommit: 'def456789',
         commits: [createMockCommit({ type: 'feat', subject: 'breaking change', breaking: true })],
       })
 
       const result = await step.execute(ctx)
 
       expect(result.status).toBe('success')
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe(
-        'https://gitlab.com/group/project/-/compare/lib-test@1.0.0...lib-test@2.0.0'
-      )
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://gitlab.com/group/project/-/compare/def456789...abc123')
     })
 
-    it('generates Bitbucket compareUrl with reversed order and two dots', async () => {
+    it('generates Bitbucket compareUrl with reversed order and two dots using commit hashes', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '1.0.1',
         bumpType: 'patch',
         repositoryConfig: createBitbucketConfig(),
-        lastReleaseTag: 'lib-test@1.0.0',
+        effectiveBaseCommit: 'def456789',
         commits: [createMockCommit({ type: 'fix', subject: 'bug fix' })],
       })
 
       const result = await step.execute(ctx)
 
       expect(result.status).toBe('success')
-      // Bitbucket uses reversed order (toTag..fromTag) with two dots
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://bitbucket.org/owner/repo/compare/lib-test@1.0.1..lib-test@1.0.0')
-    })
-
-    it('uses default tagFormat when not specified', async () => {
-      const step = createGenerateChangelogStep()
-      const ctx = createMockContext(
-        {
-          nextVersion: '1.0.0',
-          bumpType: 'minor',
-          repositoryConfig: createGitHubConfig(),
-          lastReleaseTag: 'lib-test@0.9.0',
-          commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
-        },
-        {} // No tagFormat in config
-      )
-
-      const result = await step.execute(ctx)
-
-      // Should use default format: ${projectName}@${version}
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@0.9.0...lib-test@1.0.0')
-    })
-
-    it('uses custom tagFormat when specified', async () => {
-      const step = createGenerateChangelogStep()
-      const ctx = createMockContext(
-        {
-          nextVersion: '1.0.0',
-          bumpType: 'minor',
-          repositoryConfig: createGitHubConfig(),
-          lastReleaseTag: 'v0.9.0',
-          commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
-        },
-        { tagFormat: 'v${version}' }
-      )
-
-      const result = await step.execute(ctx)
-
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/v0.9.0...v1.0.0')
+      // Bitbucket uses reversed order (toCommit..fromCommit) with two dots
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://bitbucket.org/owner/repo/compare/abc123..def456789')
     })
 
     it('handles initial release path with repositoryConfig but no commits', async () => {
@@ -740,7 +723,7 @@ describe('Generate Changelog Step', () => {
         nextVersion: '0.1.0',
         bumpType: 'minor',
         repositoryConfig: createGitHubConfig(),
-        // No lastReleaseTag for initial release
+        // No effectiveBaseCommit for initial release
         commits: [],
       })
 
@@ -748,24 +731,24 @@ describe('Generate Changelog Step', () => {
 
       expect(result.status).toBe('success')
       expect(result.message).toContain('initial release')
-      // No compareUrl for true initial release (no lastReleaseTag)
+      // No compareUrl for true initial release (no effectiveBaseCommit)
       expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
     })
 
-    it('generates compareUrl for version reset scenario (empty commits but has lastReleaseTag)', async () => {
+    it('generates compareUrl for version reset scenario (empty commits but has effectiveBaseCommit)', async () => {
       const step = createGenerateChangelogStep()
       const ctx = createMockContext({
         nextVersion: '1.0.0',
         bumpType: 'major',
         repositoryConfig: createGitHubConfig(),
-        lastReleaseTag: 'lib-test@0.9.0',
-        commits: [], // Empty commits but has lastReleaseTag (version reset scenario)
+        effectiveBaseCommit: 'def456789',
+        commits: [], // Empty commits but has effectiveBaseCommit (version reset scenario)
       })
 
       const result = await step.execute(ctx)
 
       expect(result.status).toBe('success')
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@0.9.0...lib-test@1.0.0')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/def456789...abc123')
     })
 
     it('uses custom formatter when platform is custom', async () => {
@@ -779,13 +762,29 @@ describe('Generate Changelog Step', () => {
         nextVersion: '1.0.0',
         bumpType: 'minor',
         repositoryConfig: customConfig,
-        lastReleaseTag: 'lib-test@0.9.0',
+        effectiveBaseCommit: 'def456789',
         commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
       })
 
       const result = await step.execute(ctx)
 
-      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://my-git.internal/diff/lib-test@0.9.0/lib-test@1.0.0')
+      // Custom formatter receives commit hashes: effectiveBaseCommit, getHeadHash()
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://my-git.internal/diff/def456789/abc123')
+    })
+
+    it('logs debug message with abbreviated commit hashes when generating compareUrl', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        effectiveBaseCommit: 'def456789abcdef',
+        commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
+      })
+
+      await step.execute(ctx)
+
+      expect(ctx.logger.debug).toHaveBeenCalledWith('Compare URL: def4567...abc123')
     })
   })
 })

--- a/libs/versioning/src/flow/steps/generate-changelog.spec.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.spec.ts
@@ -1,10 +1,10 @@
 import type { Logger } from '@hyperfrontend/logging'
 import type { Tree } from '@hyperfrontend/project-scope'
-
 import type { ChangelogEntry, ChangelogItem } from '../../changelog/models/entry'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { GitClient } from '../../git/factory'
 import type { Registry } from '../../registry/models/registry'
+import type { RepositoryConfig } from '../../repository/models'
 import type { FlowConfig, FlowContext, FlowState } from '../models/types'
 
 import { createGenerateChangelogStep, createWriteChangelogStep, GENERATE_CHANGELOG_STEP_ID } from './generate-changelog'
@@ -162,10 +162,6 @@ function createMockContext(state: Partial<FlowState> = {}, config: Partial<FlowC
     state: { ...state },
   }
 }
-
-// ============================================================================
-// Tests: createGenerateChangelogStep
-// ============================================================================
 
 describe('Generate Changelog Step', () => {
   describe('createGenerateChangelogStep', () => {
@@ -587,11 +583,212 @@ describe('Generate Changelog Step', () => {
       expect(result.message).toMatch(/\d+ commit\(s\)/)
     })
   })
-})
 
-// ============================================================================
-// Tests: createWriteChangelogStep
-// ============================================================================
+  describe('execute - compare URL generation', () => {
+    const createGitHubConfig = (): RepositoryConfig => ({
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    })
+
+    const createGitLabConfig = (): RepositoryConfig => ({
+      platform: 'gitlab',
+      baseUrl: 'https://gitlab.com/group/project',
+    })
+
+    const createBitbucketConfig = (): RepositoryConfig => ({
+      platform: 'bitbucket',
+      baseUrl: 'https://bitbucket.org/owner/repo',
+    })
+
+    it('does not include compareUrl when repositoryConfig is not present', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        lastReleaseTag: 'lib-test@0.9.0',
+        commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
+    })
+
+    it('does not include compareUrl when lastReleaseTag is not present', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
+    })
+
+    it('does not include compareUrl when lastReleaseTag is null', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        lastReleaseTag: null,
+        commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
+    })
+
+    it('generates GitHub compareUrl when repositoryConfig and lastReleaseTag exist', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.1.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        lastReleaseTag: 'lib-test@1.0.0',
+        commits: [createMockCommit({ type: 'feat', subject: 'new feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@1.0.0...lib-test@1.1.0')
+    })
+
+    it('generates GitLab compareUrl with /-/ prefix', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '2.0.0',
+        bumpType: 'major',
+        repositoryConfig: createGitLabConfig(),
+        lastReleaseTag: 'lib-test@1.0.0',
+        commits: [createMockCommit({ type: 'feat', subject: 'breaking change', breaking: true })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe(
+        'https://gitlab.com/group/project/-/compare/lib-test@1.0.0...lib-test@2.0.0'
+      )
+    })
+
+    it('generates Bitbucket compareUrl with reversed order and two dots', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.1',
+        bumpType: 'patch',
+        repositoryConfig: createBitbucketConfig(),
+        lastReleaseTag: 'lib-test@1.0.0',
+        commits: [createMockCommit({ type: 'fix', subject: 'bug fix' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      // Bitbucket uses reversed order (toTag..fromTag) with two dots
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://bitbucket.org/owner/repo/compare/lib-test@1.0.1..lib-test@1.0.0')
+    })
+
+    it('uses default tagFormat when not specified', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext(
+        {
+          nextVersion: '1.0.0',
+          bumpType: 'minor',
+          repositoryConfig: createGitHubConfig(),
+          lastReleaseTag: 'lib-test@0.9.0',
+          commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
+        },
+        {} // No tagFormat in config
+      )
+
+      const result = await step.execute(ctx)
+
+      // Should use default format: ${projectName}@${version}
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@0.9.0...lib-test@1.0.0')
+    })
+
+    it('uses custom tagFormat when specified', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext(
+        {
+          nextVersion: '1.0.0',
+          bumpType: 'minor',
+          repositoryConfig: createGitHubConfig(),
+          lastReleaseTag: 'v0.9.0',
+          commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
+        },
+        { tagFormat: 'v${version}' }
+      )
+
+      const result = await step.execute(ctx)
+
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/v0.9.0...v1.0.0')
+    })
+
+    it('handles initial release path with repositoryConfig but no commits', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '0.1.0',
+        bumpType: 'minor',
+        repositoryConfig: createGitHubConfig(),
+        // No lastReleaseTag for initial release
+        commits: [],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.message).toContain('initial release')
+      // No compareUrl for true initial release (no lastReleaseTag)
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBeUndefined()
+    })
+
+    it('generates compareUrl for version reset scenario (empty commits but has lastReleaseTag)', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'major',
+        repositoryConfig: createGitHubConfig(),
+        lastReleaseTag: 'lib-test@0.9.0',
+        commits: [], // Empty commits but has lastReleaseTag (version reset scenario)
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://github.com/owner/repo/compare/lib-test@0.9.0...lib-test@1.0.0')
+    })
+
+    it('uses custom formatter when platform is custom', async () => {
+      const step = createGenerateChangelogStep()
+      const customConfig: RepositoryConfig = {
+        platform: 'custom',
+        baseUrl: 'https://my-git.internal/repo',
+        formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`,
+      }
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        repositoryConfig: customConfig,
+        lastReleaseTag: 'lib-test@0.9.0',
+        commits: [createMockCommit({ type: 'feat', subject: 'feature' })],
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.stateUpdates?.changelogEntry.compareUrl).toBe('https://my-git.internal/diff/lib-test@0.9.0/lib-test@1.0.0')
+    })
+  })
+})
 
 describe('Write Changelog Step', () => {
   describe('createWriteChangelogStep', () => {

--- a/libs/versioning/src/flow/steps/generate-changelog.spec.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.spec.ts
@@ -999,4 +999,336 @@ describe('Write Changelog Step', () => {
       expect(result.message).toContain('Created CHANGELOG.md')
     })
   })
+
+  describe('execute - classification result', () => {
+    function createMockRawCommit(hash = 'abc123') {
+      return {
+        hash,
+        shortHash: hash.slice(0, 7),
+        authorName: 'Test',
+        authorEmail: 'test@test.com',
+        authorDate: '2024-01-15T10:00:00Z',
+        committerName: 'Test',
+        committerEmail: 'test@test.com',
+        commitDate: '2024-01-15T10:00:00Z',
+        subject: 'test commit',
+        body: '',
+        message: 'test commit',
+        parents: [],
+        refs: [],
+      }
+    }
+
+    function createMockSummary(overrides: Partial<{ total: number; included: number; excluded: number }> = {}) {
+      return {
+        total: overrides.total ?? 1,
+        included: overrides.included ?? 1,
+        excluded: overrides.excluded ?? 0,
+        bySource: {
+          'direct-scope': 0,
+          'direct-file': 0,
+          'unscoped-file': 0,
+          'indirect-dependency': 0,
+          'indirect-infra': 0,
+          'unscoped-global': 0,
+          excluded: 0,
+        },
+      }
+    }
+
+    function createClassifiedCommit(
+      overrides: Partial<{
+        type: string
+        scope: string
+        subject: string
+        breaking: boolean
+        breakingDescription: string
+        source: 'direct-scope' | 'direct-file' | 'unscoped-file' | 'indirect-dependency' | 'indirect-infra'
+        include: boolean
+        preserveScope: boolean
+      }> = {}
+    ) {
+      const {
+        type = 'feat',
+        scope,
+        subject = 'test feature',
+        breaking = false,
+        breakingDescription,
+        source = 'direct-scope',
+        include = true,
+        preserveScope = source !== 'direct-scope',
+      } = overrides
+
+      return {
+        commit: {
+          type,
+          scope,
+          subject,
+          breaking,
+          breakingDescription,
+          body: undefined,
+          footers: [],
+          raw: `${type}${scope ? `(${scope})` : ''}: ${subject}`,
+        },
+        raw: createMockRawCommit(),
+        source,
+        include,
+        preserveScope,
+      }
+    }
+
+    it('uses classificationResult when available', async () => {
+      const step = createGenerateChangelogStep()
+      const directCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-test',
+        subject: 'add new feature',
+        source: 'direct-scope',
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'lib-test', subject: 'add new feature' })],
+        classificationResult: {
+          commits: [directCommit],
+          included: [directCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      const entry = result.stateUpdates?.changelogEntry
+      expect(entry.sections.length).toBeGreaterThan(0)
+    })
+
+    it('omits scope for direct-scope commits (redundant)', async () => {
+      const step = createGenerateChangelogStep()
+      const directCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-test',
+        subject: 'add feature',
+        source: 'direct-scope',
+        preserveScope: false, // direct-scope commits do NOT preserve scope
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'lib-test', subject: 'add feature' })],
+        classificationResult: {
+          commits: [directCommit],
+          included: [directCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      const featuresSection = entry.sections.find((s: { type: string }) => s.type === 'features')
+      expect(featuresSection).toBeDefined()
+      // Scope should NOT appear in description for direct-scope commits
+      expect(featuresSection.items[0].description).not.toContain('**lib-test:**')
+      expect(featuresSection.items[0].description).toBe('add feature')
+    })
+
+    it('preserves scope for direct-file commits (informative)', async () => {
+      const step = createGenerateChangelogStep()
+      const directFileCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-other',
+        subject: 'cross-project feature',
+        source: 'direct-file',
+        preserveScope: true,
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'lib-other', subject: 'cross-project feature' })],
+        classificationResult: {
+          commits: [directFileCommit],
+          included: [directFileCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      const featuresSection = entry.sections.find((s: { type: string }) => s.type === 'features')
+      expect(featuresSection).toBeDefined()
+      // Scope SHOULD appear for direct-file commits
+      expect(featuresSection.items[0].description).toContain('**lib-other:**')
+    })
+
+    it('preserves scope for indirect-dependency commits', async () => {
+      const step = createGenerateChangelogStep()
+      const indirectCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-utils',
+        subject: 'utility improvement',
+        source: 'indirect-dependency',
+        preserveScope: true,
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'lib-utils', subject: 'utility improvement' })],
+        classificationResult: {
+          commits: [indirectCommit],
+          included: [indirectCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      // Indirect commits go to "Dependency Updates" section
+      const depSection = entry.sections.find((s: { heading: string }) => s.heading === 'Dependency Updates')
+      expect(depSection).toBeDefined()
+      expect(depSection.items[0].description).toContain('**lib-utils:**')
+    })
+
+    it('creates Dependency Updates section for indirect commits', async () => {
+      const step = createGenerateChangelogStep()
+      const directCommit = createClassifiedCommit({
+        type: 'feat',
+        subject: 'direct feature',
+        source: 'direct-scope',
+      })
+      const indirectCommit = createClassifiedCommit({
+        type: 'fix',
+        scope: 'lib-dep',
+        subject: 'dependency fix',
+        source: 'indirect-dependency',
+        preserveScope: true,
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [
+          createMockCommit({ type: 'feat', subject: 'direct feature' }),
+          createMockCommit({ type: 'fix', scope: 'lib-dep', subject: 'dependency fix' }),
+        ],
+        classificationResult: {
+          commits: [directCommit, indirectCommit],
+          included: [directCommit, indirectCommit],
+          excluded: [],
+          summary: createMockSummary({ total: 2, included: 2 }),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      // Should have Features section and Dependency Updates section
+      const featuresSection = entry.sections.find((s: { type: string }) => s.type === 'features')
+      const depSection = entry.sections.find((s: { heading: string }) => s.heading === 'Dependency Updates')
+
+      expect(featuresSection).toBeDefined()
+      expect(depSection).toBeDefined()
+      expect(depSection.items[0].description).toContain('**lib-dep:**')
+    })
+
+    it('sets indirect flag on ChangelogItem for indirect commits', async () => {
+      const step = createGenerateChangelogStep()
+      const indirectCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-infra',
+        subject: 'infra update',
+        source: 'indirect-infra',
+        preserveScope: true,
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'lib-infra', subject: 'infra update' })],
+        classificationResult: {
+          commits: [indirectCommit],
+          included: [indirectCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      const depSection = entry.sections.find((s: { heading: string }) => s.heading === 'Dependency Updates')
+      expect(depSection).toBeDefined()
+      expect(depSection.items[0].indirect).toBe(true)
+      expect(depSection.items[0].source).toBe('indirect-infra')
+    })
+
+    it('handles breaking changes with classification', async () => {
+      const step = createGenerateChangelogStep()
+      const breakingCommit = createClassifiedCommit({
+        type: 'feat',
+        scope: 'lib-test',
+        subject: 'major API change',
+        breaking: true,
+        breakingDescription: 'Removed deprecated method',
+        source: 'direct-scope',
+      })
+
+      const ctx = createMockContext({
+        nextVersion: '2.0.0',
+        bumpType: 'major',
+        commits: [
+          createMockCommit({
+            type: 'feat',
+            scope: 'lib-test',
+            subject: 'major API change',
+            breaking: true,
+            breakingDescription: 'Removed deprecated method',
+          }),
+        ],
+        classificationResult: {
+          commits: [breakingCommit],
+          included: [breakingCommit],
+          excluded: [],
+          summary: createMockSummary(),
+        },
+      })
+
+      const result = await step.execute(ctx)
+
+      const entry = result.stateUpdates?.changelogEntry
+      const breakingSection = entry.sections.find((s: { type: string }) => s.type === 'breaking')
+      expect(breakingSection).toBeDefined()
+      expect(breakingSection.heading).toBe('Breaking Changes')
+      expect(breakingSection.items[0].breaking).toBe(true)
+    })
+
+    it('falls back to commits without classification for backward compatibility', async () => {
+      const step = createGenerateChangelogStep()
+      const ctx = createMockContext({
+        nextVersion: '1.0.0',
+        bumpType: 'minor',
+        commits: [createMockCommit({ type: 'feat', scope: 'other', subject: 'fallback feature' })],
+        // No classificationResult provided
+      })
+
+      const result = await step.execute(ctx)
+
+      expect(result.status).toBe('success')
+      const entry = result.stateUpdates?.changelogEntry
+      const featuresSection = entry.sections.find((s: { type: string }) => s.type === 'features')
+      expect(featuresSection).toBeDefined()
+      // Fallback path preserves all scopes
+      expect(featuresSection.items[0].description).toContain('**other:**')
+    })
+  })
 })

--- a/libs/versioning/src/flow/steps/generate-changelog.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.ts
@@ -1,10 +1,12 @@
 import type { ChangelogItem, ChangelogSection } from '../../changelog/models/entry'
 import type { ChangelogSectionType } from '../../changelog/models/section'
+import type { ClassifiedCommit } from '../../commits/classify'
 import type { ConventionalCommit } from '../../commits/models/conventional'
 import type { FlowStep } from '../models/step'
 import { createDate } from '@hyperfrontend/immutable-api-utils/built-in-copy/date'
 import { serializeChangelog, parseChangelog, addEntry } from '../../changelog'
 import { createChangelogEntry, createChangelogItem, createChangelogSection } from '../../changelog/models/entry'
+import { toChangelogCommit } from '../../commits/classify'
 import { createCompareUrl } from '../../repository/url'
 import { createStep, createSkippedResult } from '../models/step'
 
@@ -28,6 +30,36 @@ const COMMIT_TYPE_TO_SECTION: Record<string, ChangelogSectionType> = {
 }
 
 /**
+ * Checks if a commit source represents an indirect change.
+ *
+ * @param source - The commit source type
+ * @returns True if the commit is indirect (dependency or infrastructure)
+ */
+function isIndirectSource(source: ClassifiedCommit['source']): boolean {
+  return source === 'indirect-dependency' || source === 'indirect-infra'
+}
+
+/**
+ * Groups classified commits by their section type.
+ *
+ * @param commits - Array of classified commits
+ * @returns Record of section type to classified commits
+ */
+function groupClassifiedCommitsBySection(commits: readonly ClassifiedCommit[]): Record<ChangelogSectionType, ClassifiedCommit[]> {
+  const groups: Record<string, ClassifiedCommit[]> = {}
+
+  for (const classified of commits) {
+    const sectionType = COMMIT_TYPE_TO_SECTION[classified.commit.type ?? 'chore'] ?? 'chores'
+    if (!groups[sectionType]) {
+      groups[sectionType] = []
+    }
+    groups[sectionType].push(classified)
+  }
+
+  return <Record<ChangelogSectionType, ClassifiedCommit[]>>groups
+}
+
+/**
  * Groups commits by their section type.
  *
  * @param commits - Array of conventional commits
@@ -45,6 +77,40 @@ function groupCommitsBySection(commits: readonly ConventionalCommit[]): Record<C
   }
 
   return <Record<ChangelogSectionType, ConventionalCommit[]>>groups
+}
+
+/**
+ * Creates a changelog item from a classified commit.
+ *
+ * Applies scope display rules:
+ * - Direct commits: scope omitted (redundant in project changelog)
+ * - Indirect commits: scope preserved (provides context)
+ *
+ * @param classified - The classified commit with source metadata
+ * @returns A changelog item with proper scope handling
+ */
+function classifiedCommitToItem(classified: ClassifiedCommit): ChangelogItem {
+  // Apply scope transformation based on classification
+  const commit = toChangelogCommit(classified)
+  const indirect = isIndirectSource(classified.source)
+
+  let text = commit.subject
+
+  // Add scope prefix if preserved (indirect commits)
+  if (commit.scope) {
+    text = `**${commit.scope}:** ${text}`
+  }
+
+  // Add breaking change indicator
+  if (commit.breaking) {
+    text = `⚠️ BREAKING: ${text}`
+  }
+
+  return createChangelogItem(text, {
+    source: classified.source,
+    indirect,
+    breaking: commit.breaking,
+  })
 }
 
 /**
@@ -129,45 +195,111 @@ export function createGenerateChangelogStep(): FlowStep {
         }
       }
 
-      // Group commits by section
-      const grouped = groupCommitsBySection(commits)
-
-      // Create sections
+      // Use classification result when available for proper scope handling
+      const { classificationResult } = state
       const sections: ChangelogSection[] = []
 
-      // Add breaking changes section first if any
-      const breakingCommits = commits.filter((c) => c.breaking)
-      if (breakingCommits.length > 0) {
-        sections.push(
-          createChangelogSection(
-            'breaking',
-            'Breaking Changes',
-            breakingCommits.map((c) => {
-              const text = c.breakingDescription ?? c.subject
-              return createChangelogItem(c.scope ? `**${c.scope}:** ${text}` : text)
-            })
+      if (classificationResult && classificationResult.included.length > 0) {
+        // Use classified commits for proper scope display rules
+        const classifiedCommits = classificationResult.included
+
+        // Separate direct and indirect commits
+        const directCommits = classifiedCommits.filter((c) => !isIndirectSource(c.source))
+        const indirectCommits = classifiedCommits.filter((c) => isIndirectSource(c.source))
+
+        // Add breaking changes section first if any
+        const breakingCommits = classifiedCommits.filter((c) => c.commit.breaking)
+        if (breakingCommits.length > 0) {
+          sections.push(
+            createChangelogSection(
+              'breaking',
+              'Breaking Changes',
+              breakingCommits.map((c) => {
+                const commit = toChangelogCommit(c)
+                const text = commit.breakingDescription ?? commit.subject
+                const indirect = isIndirectSource(c.source)
+                return createChangelogItem(commit.scope ? `**${commit.scope}:** ${text}` : text, {
+                  source: c.source,
+                  indirect,
+                  breaking: true,
+                })
+              })
+            )
           )
-        )
-      }
+        }
 
-      // Add other sections in conventional order
-      const sectionOrder: readonly { type: ChangelogSectionType; heading: string }[] = [
-        { type: 'features', heading: 'Features' },
-        { type: 'fixes', heading: 'Bug Fixes' },
-        { type: 'performance', heading: 'Performance' },
-        { type: 'documentation', heading: 'Documentation' },
-        { type: 'refactoring', heading: 'Code Refactoring' },
-        { type: 'build', heading: 'Build' },
-        { type: 'ci', heading: 'Continuous Integration' },
-        { type: 'tests', heading: 'Tests' },
-        { type: 'chores', heading: 'Chores' },
-        { type: 'other', heading: 'Other' },
-      ]
+        // Group direct commits by section
+        const groupedDirect = groupClassifiedCommitsBySection(directCommits)
 
-      for (const { type: sectionType, heading } of sectionOrder) {
-        const sectionCommits = grouped[sectionType]
-        if (sectionCommits && sectionCommits.length > 0) {
-          sections.push(createChangelogSection(sectionType, heading, sectionCommits.map(commitToItem)))
+        // Add other sections in conventional order (direct commits only)
+        const sectionOrder: readonly { type: ChangelogSectionType; heading: string }[] = [
+          { type: 'features', heading: 'Features' },
+          { type: 'fixes', heading: 'Bug Fixes' },
+          { type: 'performance', heading: 'Performance' },
+          { type: 'documentation', heading: 'Documentation' },
+          { type: 'refactoring', heading: 'Code Refactoring' },
+          { type: 'build', heading: 'Build' },
+          { type: 'ci', heading: 'Continuous Integration' },
+          { type: 'tests', heading: 'Tests' },
+          { type: 'chores', heading: 'Chores' },
+          { type: 'other', heading: 'Other' },
+        ]
+
+        for (const { type: sectionType, heading } of sectionOrder) {
+          const sectionCommits = groupedDirect[sectionType]
+          if (sectionCommits && sectionCommits.length > 0) {
+            sections.push(createChangelogSection(sectionType, heading, sectionCommits.map(classifiedCommitToItem)))
+          }
+        }
+
+        // Add Dependency Updates section for indirect commits if any
+        if (indirectCommits.length > 0) {
+          sections.push(
+            createChangelogSection(
+              'other', // Use 'other' as section type for dependency updates
+              'Dependency Updates',
+              indirectCommits.map((c) => classifiedCommitToItem(c))
+            )
+          )
+        }
+      } else {
+        // Fallback: use commits without classification (backward compatibility)
+        const grouped = groupCommitsBySection(commits)
+
+        // Add breaking changes section first if any
+        const breakingCommits = commits.filter((c) => c.breaking)
+        if (breakingCommits.length > 0) {
+          sections.push(
+            createChangelogSection(
+              'breaking',
+              'Breaking Changes',
+              breakingCommits.map((c) => {
+                const text = c.breakingDescription ?? c.subject
+                return createChangelogItem(c.scope ? `**${c.scope}:** ${text}` : text)
+              })
+            )
+          )
+        }
+
+        // Add other sections in conventional order
+        const sectionOrder: readonly { type: ChangelogSectionType; heading: string }[] = [
+          { type: 'features', heading: 'Features' },
+          { type: 'fixes', heading: 'Bug Fixes' },
+          { type: 'performance', heading: 'Performance' },
+          { type: 'documentation', heading: 'Documentation' },
+          { type: 'refactoring', heading: 'Code Refactoring' },
+          { type: 'build', heading: 'Build' },
+          { type: 'ci', heading: 'Continuous Integration' },
+          { type: 'tests', heading: 'Tests' },
+          { type: 'chores', heading: 'Chores' },
+          { type: 'other', heading: 'Other' },
+        ]
+
+        for (const { type: sectionType, heading } of sectionOrder) {
+          const sectionCommits = grouped[sectionType]
+          if (sectionCommits && sectionCommits.length > 0) {
+            sections.push(createChangelogSection(sectionType, heading, sectionCommits.map(commitToItem)))
+          }
         }
       }
 

--- a/libs/versioning/src/flow/steps/generate-changelog.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.ts
@@ -168,18 +168,21 @@ export function createGenerateChangelogStep(): FlowStep {
 
       // Handle case with no commits (e.g., first release)
       if (!commits || commits.length === 0) {
-        // Generate compare URL if repository config and last release tag exist
-        // (typically won't exist for true first release, but may for version reset)
+        // Generate compare URL using commit hashes ONLY
+        // Only generate if we have a valid base commit (effectiveBaseCommit will be null if fallback was used)
         let compareUrl: string | undefined
-        if (state.repositoryConfig && state.lastReleaseTag) {
-          const tagFormat = config.tagFormat ?? '${projectName}@${version}'
-          const toTag = tagFormat.replace('${projectName}', ctx.projectName).replace('${version}', nextVersion)
+        if (state.repositoryConfig && state.effectiveBaseCommit) {
+          const currentCommit = ctx.git.getHeadHash()
           compareUrl =
             createCompareUrl({
               repository: state.repositoryConfig,
-              fromTag: state.lastReleaseTag,
-              toTag,
+              // TODO: Phase 6 will rename these to fromCommit/toCommit
+              fromTag: state.effectiveBaseCommit,
+              toTag: currentCommit,
             }) ?? undefined
+        } else if (state.publishedCommit && !state.effectiveBaseCommit) {
+          // Log why we're not generating a compare URL
+          ctx.logger.info('Compare URL omitted: published commit not in current history')
         }
 
         const entry = createChangelogEntry(nextVersion, {
@@ -303,17 +306,22 @@ export function createGenerateChangelogStep(): FlowStep {
         }
       }
 
-      // Generate compare URL if repository config and last release tag exist
+      // Generate compare URL using commit hashes ONLY
+      // Only generate if we have a valid base commit (effectiveBaseCommit will be null if fallback was used)
       let compareUrl: string | undefined
-      if (state.repositoryConfig && state.lastReleaseTag) {
-        const tagFormat = config.tagFormat ?? '${projectName}@${version}'
-        const toTag = tagFormat.replace('${projectName}', ctx.projectName).replace('${version}', nextVersion)
+      if (state.repositoryConfig && state.effectiveBaseCommit) {
+        const currentCommit = ctx.git.getHeadHash()
         compareUrl =
           createCompareUrl({
             repository: state.repositoryConfig,
-            fromTag: state.lastReleaseTag,
-            toTag,
+            // TODO: Phase 6 will rename these to fromCommit/toCommit
+            fromTag: state.effectiveBaseCommit,
+            toTag: currentCommit,
           }) ?? undefined
+        ctx.logger.debug(`Compare URL: ${state.effectiveBaseCommit.slice(0, 7)}...${currentCommit.slice(0, 7)}`)
+      } else if (state.publishedCommit && !state.effectiveBaseCommit) {
+        // Log why we're not generating a compare URL
+        ctx.logger.info('Compare URL omitted: published commit not in current history')
       }
 
       // Create the entry

--- a/libs/versioning/src/flow/steps/generate-changelog.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.ts
@@ -5,6 +5,7 @@ import type { FlowStep } from '../models/step'
 import { createDate } from '@hyperfrontend/immutable-api-utils/built-in-copy/date'
 import { serializeChangelog, parseChangelog, addEntry } from '../../changelog'
 import { createChangelogEntry, createChangelogItem, createChangelogSection } from '../../changelog/models/entry'
+import { createCompareUrl } from '../../repository/url'
 import { createStep, createSkippedResult } from '../models/step'
 
 export const GENERATE_CHANGELOG_STEP_ID = 'generate-changelog'
@@ -101,9 +102,24 @@ export function createGenerateChangelogStep(): FlowStep {
 
       // Handle case with no commits (e.g., first release)
       if (!commits || commits.length === 0) {
+        // Generate compare URL if repository config and last release tag exist
+        // (typically won't exist for true first release, but may for version reset)
+        let compareUrl: string | undefined
+        if (state.repositoryConfig && state.lastReleaseTag) {
+          const tagFormat = config.tagFormat ?? '${projectName}@${version}'
+          const toTag = tagFormat.replace('${projectName}', ctx.projectName).replace('${version}', nextVersion)
+          compareUrl =
+            createCompareUrl({
+              repository: state.repositoryConfig,
+              fromTag: state.lastReleaseTag,
+              toTag,
+            }) ?? undefined
+        }
+
         const entry = createChangelogEntry(nextVersion, {
           date: createDate().toISOString().split('T')[0],
           sections: [createChangelogSection('features', 'Features', [createChangelogItem('Initial release')])],
+          compareUrl,
         })
 
         return {
@@ -155,10 +171,24 @@ export function createGenerateChangelogStep(): FlowStep {
         }
       }
 
+      // Generate compare URL if repository config and last release tag exist
+      let compareUrl: string | undefined
+      if (state.repositoryConfig && state.lastReleaseTag) {
+        const tagFormat = config.tagFormat ?? '${projectName}@${version}'
+        const toTag = tagFormat.replace('${projectName}', ctx.projectName).replace('${version}', nextVersion)
+        compareUrl =
+          createCompareUrl({
+            repository: state.repositoryConfig,
+            fromTag: state.lastReleaseTag,
+            toTag,
+          }) ?? undefined
+      }
+
       // Create the entry
       const entry = createChangelogEntry(nextVersion, {
         date: createDate().toISOString().split('T')[0],
         sections,
+        compareUrl,
       })
 
       return {

--- a/libs/versioning/src/flow/steps/generate-changelog.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.ts
@@ -176,9 +176,8 @@ export function createGenerateChangelogStep(): FlowStep {
           compareUrl =
             createCompareUrl({
               repository: state.repositoryConfig,
-              // TODO: Phase 6 will rename these to fromCommit/toCommit
-              fromTag: state.effectiveBaseCommit,
-              toTag: currentCommit,
+              fromCommit: state.effectiveBaseCommit,
+              toCommit: currentCommit,
             }) ?? undefined
         } else if (state.publishedCommit && !state.effectiveBaseCommit) {
           // Log why we're not generating a compare URL
@@ -314,9 +313,8 @@ export function createGenerateChangelogStep(): FlowStep {
         compareUrl =
           createCompareUrl({
             repository: state.repositoryConfig,
-            // TODO: Phase 6 will rename these to fromCommit/toCommit
-            fromTag: state.effectiveBaseCommit,
-            toTag: currentCommit,
+            fromCommit: state.effectiveBaseCommit,
+            toCommit: currentCommit,
           }) ?? undefined
         ctx.logger.debug(`Compare URL: ${state.effectiveBaseCommit.slice(0, 7)}...${currentCommit.slice(0, 7)}`)
       } else if (state.publishedCommit && !state.effectiveBaseCommit) {

--- a/libs/versioning/src/flow/steps/index.ts
+++ b/libs/versioning/src/flow/steps/index.ts
@@ -1,4 +1,5 @@
 export { FETCH_REGISTRY_STEP_ID, createFetchRegistryStep } from './fetch-registry'
+export { RESOLVE_REPOSITORY_STEP_ID, createResolveRepositoryStep } from './resolve-repository'
 export { ANALYZE_COMMITS_STEP_ID, createAnalyzeCommitsStep } from './analyze-commits'
 export { CALCULATE_BUMP_STEP_ID, createCalculateBumpStep, createCheckIdempotencyStep } from './calculate-bump'
 export { GENERATE_CHANGELOG_STEP_ID, createGenerateChangelogStep, createWriteChangelogStep } from './generate-changelog'

--- a/libs/versioning/src/flow/steps/resolve-repository.spec.ts
+++ b/libs/versioning/src/flow/steps/resolve-repository.spec.ts
@@ -1,0 +1,1073 @@
+import type { Logger } from '@hyperfrontend/logging'
+import type { Tree } from '@hyperfrontend/project-scope'
+import type { GitClient } from '../../git/factory'
+import type { Registry } from '../../registry/models/registry'
+import type { RepositoryConfig } from '../../repository/models/repository-config'
+import type { RepositoryResolution } from '../../repository/models/resolution'
+import type { FlowConfig, FlowContext, FlowState } from '../models/types'
+import { createResolveRepositoryStep, RESOLVE_REPOSITORY_STEP_ID } from './resolve-repository'
+
+function createMockLogger(): Logger {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    setLogLevel: jest.fn(),
+  } as unknown as Logger
+}
+
+function createMockTree(files: Record<string, string> = {}): Tree {
+  const fileSystem = new Map(Object.entries(files))
+
+  return {
+    root: '/workspace',
+    read(filePath: string, encoding?: string) {
+      const content = fileSystem.get(filePath)
+      if (content === undefined) {
+        return null
+      }
+      return encoding ? content : Buffer.from(content)
+    },
+    write: jest.fn(),
+    exists: (path: string) => fileSystem.has(path),
+    delete: jest.fn(),
+    rename: jest.fn(),
+    isFile: (path: string) => fileSystem.has(path),
+    children: () => [],
+    listChanges: () => [],
+  } as unknown as Tree
+}
+
+function createMockRegistry(): Registry {
+  return {
+    name: 'mock',
+    url: 'https://mock.registry.com',
+    async getLatestVersion() {
+      return null
+    },
+    async isVersionPublished() {
+      return false
+    },
+    async getPackageInfo() {
+      return null
+    },
+    async getVersionInfo() {
+      return null
+    },
+    async listVersions() {
+      return []
+    },
+  }
+}
+
+function createMockGitClient(options: { remoteUrl?: string | null } = {}): GitClient {
+  const { remoteUrl = null } = options
+
+  return {
+    cwd: '/workspace',
+    timeout: 30000,
+    getCommitLog: () => [],
+    getCommitsBetween: () => [],
+    getCommitsSince: () => [],
+    getCommit: () => null,
+    commitExists: () => true,
+    getTags: () => [],
+    getTag: () => null,
+    createTag: jest.fn(),
+    deleteTag: () => true,
+    tagExists: () => false,
+    getLatestTag: () => null,
+    getTagsForPackage: () => [],
+    pushTag: () => true,
+    createCommit: jest.fn(),
+    stage: () => true,
+    unstage: () => true,
+    stageAll: () => true,
+    amendCommit: jest.fn(),
+    createEmptyCommit: jest.fn(),
+    getHead: () => 'abc123',
+    getCurrentBranch: () => 'main',
+    hasStagedChanges: () => false,
+    hasUnstagedChanges: () => false,
+    hasUntrackedFiles: () => false,
+    getStatus: () => ({
+      clean: true,
+      entries: [],
+      staged: [],
+      unstaged: [],
+      untracked: [],
+    }),
+    isClean: () => true,
+    getRepositoryRoot: () => '/workspace',
+    getHeadHash: () => 'abc123',
+    getHeadShortHash: () => 'abc123',
+    getModifiedFiles: () => [],
+    getUntrackedFiles: () => [],
+    getStagedFiles: () => [],
+    getRemoteUrl: jest.fn().mockResolvedValue(remoteUrl),
+  } as unknown as GitClient
+}
+
+function createMockContext(overrides?: {
+  tree?: Tree
+  registry?: Registry
+  git?: GitClient
+  logger?: Logger
+  state?: FlowState
+  config?: Partial<FlowConfig>
+}): FlowContext {
+  return {
+    workspaceRoot: '/workspace',
+    projectName: 'lib-test',
+    projectRoot: '/workspace/libs/test',
+    packageName: '@test/pkg',
+    tree: overrides?.tree ?? createMockTree(),
+    registry: overrides?.registry ?? createMockRegistry(),
+    git: overrides?.git ?? createMockGitClient(),
+    logger: overrides?.logger ?? createMockLogger(),
+    config: { preset: 'conventional', ...overrides?.config },
+    state: overrides?.state ?? {},
+  }
+}
+
+describe('resolve-repository step', () => {
+  describe('RESOLVE_REPOSITORY_STEP_ID', () => {
+    it('has the correct ID', () => {
+      expect(RESOLVE_REPOSITORY_STEP_ID).toBe('resolve-repository')
+    })
+  })
+
+  describe('createResolveRepositoryStep', () => {
+    it('creates a step with correct ID and name', () => {
+      const step = createResolveRepositoryStep()
+
+      expect(step.id).toBe('resolve-repository')
+      expect(step.name).toBe('Resolve Repository')
+    })
+
+    describe('when repository is undefined', () => {
+      it('skips with backward-compatible message', async () => {
+        const ctx = createMockContext({
+          config: { repository: undefined },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toBe('Repository resolution disabled')
+        expect(result.stateUpdates).toBeUndefined()
+      })
+    })
+
+    describe('when repository is "disabled"', () => {
+      it('skips with disabled message', async () => {
+        const ctx = createMockContext({
+          config: { repository: 'disabled' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toBe('Repository resolution disabled')
+        expect(result.stateUpdates).toBeUndefined()
+      })
+    })
+
+    describe('when repository is a direct RepositoryConfig', () => {
+      it('uses the provided config', async () => {
+        const repoConfig: RepositoryConfig = {
+          platform: 'github',
+          baseUrl: 'https://github.com/owner/repo',
+        }
+
+        const ctx = createMockContext({
+          config: { repository: repoConfig },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig).toEqual(repoConfig)
+        expect(result.message).toContain('explicit')
+        expect(result.message).toContain('github')
+      })
+    })
+
+    describe('when repository is "inferred"', () => {
+      it('infers from package.json repository field', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            name: '@test/pkg',
+            repository: 'https://github.com/owner/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig).toEqual({
+          platform: 'github',
+          baseUrl: 'https://github.com/owner/repo',
+        })
+      })
+
+      it('infers from git remote when package.json has no repository', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            name: '@test/pkg',
+          }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'https://github.com/git-owner/git-repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig).toEqual({
+          platform: 'github',
+          baseUrl: 'https://github.com/git-owner/git-repo',
+        })
+      })
+
+      it('skips gracefully when neither source has repository info', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            name: '@test/pkg',
+          }),
+        })
+
+        const git = createMockGitClient({ remoteUrl: null })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toContain('Could not infer')
+        expect(result.stateUpdates).toBeUndefined()
+      })
+
+      it('skips gracefully when package.json does not exist', async () => {
+        const tree = createMockTree({})
+        const git = createMockGitClient({ remoteUrl: null })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toContain('Could not infer')
+      })
+    })
+
+    describe('when repository is a RepositoryResolution', () => {
+      describe('with mode "disabled"', () => {
+        it('skips resolution', async () => {
+          const resolution: RepositoryResolution = {
+            mode: 'disabled',
+          }
+
+          const ctx = createMockContext({
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('skipped')
+          expect(result.message).toBe('Repository resolution disabled')
+        })
+      })
+
+      describe('with mode "explicit"', () => {
+        it('uses provided repository', async () => {
+          const resolution: RepositoryResolution = {
+            mode: 'explicit',
+            repository: {
+              platform: 'gitlab',
+              baseUrl: 'https://gitlab.com/group/project',
+            },
+          }
+
+          const ctx = createMockContext({
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('success')
+          expect(result.stateUpdates?.repositoryConfig).toEqual({
+            platform: 'gitlab',
+            baseUrl: 'https://gitlab.com/group/project',
+          })
+        })
+
+        it('fails when repository is not provided', async () => {
+          const resolution: RepositoryResolution = {
+            mode: 'explicit',
+          }
+
+          const ctx = createMockContext({
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('failed')
+          expect(result.error).toBeDefined()
+          expect(result.message).toContain('required')
+        })
+      })
+
+      describe('with mode "inferred"', () => {
+        it('uses default inference order (package-json first)', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              repository: 'https://github.com/pkg-owner/pkg-repo',
+            }),
+          })
+
+          const git = createMockGitClient({
+            remoteUrl: 'https://github.com/git-owner/git-repo.git',
+          })
+
+          const resolution: RepositoryResolution = {
+            mode: 'inferred',
+          }
+
+          const ctx = createMockContext({
+            tree,
+            git,
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('success')
+          // Should use package.json (default order)
+          expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/pkg-owner/pkg-repo')
+        })
+
+        it('respects custom inference order', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              repository: 'https://github.com/pkg-owner/pkg-repo',
+            }),
+          })
+
+          const git = createMockGitClient({
+            remoteUrl: 'https://github.com/git-owner/git-repo.git',
+          })
+
+          const resolution: RepositoryResolution = {
+            mode: 'inferred',
+            inferenceOrder: ['git-remote', 'package-json'],
+          }
+
+          const ctx = createMockContext({
+            tree,
+            git,
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('success')
+          // Should use git remote (custom order)
+          expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/git-owner/git-repo')
+        })
+
+        it('falls back to next source when first fails', async () => {
+          const tree = createMockTree({
+            '/workspace/libs/test/package.json': JSON.stringify({
+              name: '@test/pkg',
+              // No repository field
+            }),
+          })
+
+          const git = createMockGitClient({
+            remoteUrl: 'https://github.com/git-owner/git-repo.git',
+          })
+
+          const resolution: RepositoryResolution = {
+            mode: 'inferred',
+            inferenceOrder: ['package-json', 'git-remote'],
+          }
+
+          const ctx = createMockContext({
+            tree,
+            git,
+            config: { repository: resolution },
+          })
+
+          const step = createResolveRepositoryStep()
+          const result = await step.execute(ctx)
+
+          expect(result.status).toBe('success')
+          // Should fall back to git remote
+          expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/git-owner/git-repo')
+        })
+      })
+    })
+
+    describe('platform detection', () => {
+      it('detects GitHub', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://github.com/owner/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('github')
+      })
+
+      it('detects GitLab', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://gitlab.com/group/project',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('gitlab')
+      })
+
+      it('detects Bitbucket', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://bitbucket.org/team/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('bitbucket')
+      })
+    })
+
+    describe('shorthand formats', () => {
+      it('handles github shorthand', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'github:owner/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('github')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+
+      it('handles object format with url', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: {
+              type: 'git',
+              url: 'https://github.com/owner/repo.git',
+            },
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('github')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+    })
+
+    describe('git remote formats', () => {
+      it('handles HTTPS remote', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'https://github.com/owner/repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+
+      it('handles SSH remote', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'git@github.com:owner/repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('github')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+    })
+
+    describe('step metadata', () => {
+      it('has a description', () => {
+        const step = createResolveRepositoryStep()
+
+        expect(step.description).toBe('Resolves repository configuration for compare URL generation')
+      })
+    })
+
+    describe('logger calls', () => {
+      it('logs debug when repository is undefined', async () => {
+        const logger = createMockLogger()
+        const ctx = createMockContext({
+          logger,
+          config: { repository: undefined },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('Repository resolution disabled')
+      })
+
+      it('logs debug when using explicit config', async () => {
+        const logger = createMockLogger()
+        const ctx = createMockContext({
+          logger,
+          config: {
+            repository: {
+              platform: 'github',
+              baseUrl: 'https://github.com/owner/repo',
+            },
+          },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('Using explicit repository config: github')
+      })
+
+      it('logs debug when inference fails', async () => {
+        const logger = createMockLogger()
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+        const git = createMockGitClient({ remoteUrl: null })
+
+        const ctx = createMockContext({
+          logger,
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('Could not infer repository from package.json or git remote')
+      })
+
+      it('logs debug when package.json not found', async () => {
+        const logger = createMockLogger()
+        const tree = createMockTree({})
+        const git = createMockGitClient({ remoteUrl: 'https://github.com/owner/repo.git' })
+
+        const ctx = createMockContext({
+          logger,
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('package.json not found at /workspace/libs/test/package.json')
+      })
+
+      it('logs debug when successfully inferring from source', async () => {
+        const logger = createMockLogger()
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://github.com/owner/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          logger,
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('Inferred repository from package-json: github')
+      })
+    })
+
+    describe('RepositoryResolution with mode "inferred" graceful degradation', () => {
+      it('skips when all inference sources fail', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+        const git = createMockGitClient({ remoteUrl: null })
+
+        const resolution: RepositoryResolution = {
+          mode: 'inferred',
+          inferenceOrder: ['package-json', 'git-remote'],
+        }
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: resolution },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toContain('Could not infer')
+      })
+
+      it('handles empty inferenceOrder array', async () => {
+        const resolution: RepositoryResolution = {
+          mode: 'inferred',
+          inferenceOrder: [],
+        }
+
+        const ctx = createMockContext({
+          config: { repository: resolution },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toContain('Could not infer')
+      })
+    })
+
+    describe('edge cases', () => {
+      it('handles tree.read returning null for existing file', async () => {
+        // Custom tree that returns null for read even when file exists
+        const tree = {
+          root: '/workspace',
+          read: () => null,
+          write: jest.fn(),
+          exists: () => true, // File exists
+          delete: jest.fn(),
+          rename: jest.fn(),
+          isFile: () => true,
+          children: () => [],
+          listChanges: () => [],
+        } as unknown as Tree
+
+        const git = createMockGitClient({
+          remoteUrl: 'https://github.com/git-owner/git-repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        // Should fall back to git remote
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/git-owner/git-repo')
+      })
+
+      it('logs debug when tree.read returns null', async () => {
+        const logger = createMockLogger()
+        const tree = {
+          root: '/workspace',
+          read: () => null,
+          write: jest.fn(),
+          exists: () => true,
+          delete: jest.fn(),
+          rename: jest.fn(),
+          isFile: () => true,
+          children: () => [],
+          listChanges: () => [],
+        } as unknown as Tree
+
+        const git = createMockGitClient({ remoteUrl: null })
+
+        const ctx = createMockContext({
+          logger,
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        await step.execute(ctx)
+
+        expect(logger.debug).toHaveBeenCalledWith('Could not read package.json')
+      })
+
+      it('handles invalid JSON in package.json', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': 'not valid json',
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'https://github.com/git-owner/git-repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        // Should fall back to git remote
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/git-owner/git-repo')
+      })
+
+      it('handles unknown repository configuration format', async () => {
+        const logger = createMockLogger()
+        // Force an unknown config type that bypasses TypeScript checks
+        const ctx = createMockContext({
+          logger,
+          config: { repository: { unknownKey: 'unknownValue' } as unknown as RepositoryConfig },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(result.message).toBe('Unknown repository configuration format')
+        expect(logger.warn).toHaveBeenCalledWith('Unknown repository configuration format')
+      })
+
+      it('handles unknown inference source', async () => {
+        const logger = createMockLogger()
+        const resolution: RepositoryResolution = {
+          mode: 'inferred',
+          // Force an unknown inference source that bypasses TypeScript checks
+          inferenceOrder: ['unknown-source' as 'package-json'],
+        }
+
+        const ctx = createMockContext({
+          logger,
+          config: { repository: resolution },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('skipped')
+        expect(logger.warn).toHaveBeenCalledWith('Unknown inference source: unknown-source')
+      })
+    })
+
+    describe('additional platform detection', () => {
+      it('detects Azure DevOps', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://dev.azure.com/org/project/_git/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('azure-devops')
+      })
+
+      it('detects Azure DevOps visualstudio.com format', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'https://org.visualstudio.com/project/_git/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('azure-devops')
+      })
+    })
+
+    describe('additional shorthand formats', () => {
+      it('handles gitlab shorthand', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'gitlab:group/project',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('gitlab')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://gitlab.com/group/project')
+      })
+
+      it('handles bitbucket shorthand', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: 'bitbucket:team/repo',
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('bitbucket')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://bitbucket.org/team/repo')
+      })
+
+      it('handles git+https URL format', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({
+            repository: {
+              type: 'git',
+              url: 'git+https://github.com/owner/repo.git',
+            },
+          }),
+        })
+
+        const ctx = createMockContext({
+          tree,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('github')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+    })
+
+    describe('additional git remote formats', () => {
+      it('handles SSH remote for GitLab', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'git@gitlab.com:group/project.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('gitlab')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://gitlab.com/group/project')
+      })
+
+      it('handles SSH remote for Bitbucket', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'git@bitbucket.org:team/repo.git',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('bitbucket')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://bitbucket.org/team/repo')
+      })
+
+      it('handles HTTPS remote without .git extension', async () => {
+        const tree = createMockTree({
+          '/workspace/libs/test/package.json': JSON.stringify({ name: '@test/pkg' }),
+        })
+
+        const git = createMockGitClient({
+          remoteUrl: 'https://github.com/owner/repo',
+        })
+
+        const ctx = createMockContext({
+          tree,
+          git,
+          config: { repository: 'inferred' },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.baseUrl).toBe('https://github.com/owner/repo')
+      })
+    })
+
+    describe('RepositoryConfig with all platforms', () => {
+      it('handles azure-devops platform', async () => {
+        const repoConfig: RepositoryConfig = {
+          platform: 'azure-devops',
+          baseUrl: 'https://dev.azure.com/org/project/_git/repo',
+        }
+
+        const ctx = createMockContext({
+          config: { repository: repoConfig },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('azure-devops')
+        expect(result.message).toContain('azure-devops')
+      })
+
+      it('handles bitbucket platform', async () => {
+        const repoConfig: RepositoryConfig = {
+          platform: 'bitbucket',
+          baseUrl: 'https://bitbucket.org/team/repo',
+        }
+
+        const ctx = createMockContext({
+          config: { repository: repoConfig },
+        })
+
+        const step = createResolveRepositoryStep()
+        const result = await step.execute(ctx)
+
+        expect(result.status).toBe('success')
+        expect(result.stateUpdates?.repositoryConfig?.platform).toBe('bitbucket')
+        expect(result.message).toContain('bitbucket')
+      })
+    })
+  })
+})

--- a/libs/versioning/src/flow/steps/resolve-repository.ts
+++ b/libs/versioning/src/flow/steps/resolve-repository.ts
@@ -1,0 +1,303 @@
+import type { RepositoryConfig } from '../../repository/models/repository-config'
+import type { RepositoryInferenceSource, RepositoryResolution } from '../../repository/models/resolution'
+import type { FlowStep } from '../models/step'
+import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
+import { isRepositoryConfig } from '../../repository/models/repository-config'
+import { isRepositoryResolution, DEFAULT_INFERENCE_ORDER } from '../../repository/models/resolution'
+import { inferRepositoryFromPackageJson } from '../../repository/parse/package-json'
+import { createRepositoryConfigFromUrl } from '../../repository/parse/url'
+import { createStep } from '../models/step'
+
+export const RESOLVE_REPOSITORY_STEP_ID = 'resolve-repository'
+
+/**
+ * Creates the resolve-repository step.
+ *
+ * This step resolves repository configuration for compare URL generation.
+ * It supports multiple resolution modes:
+ *
+ * - `undefined` or `'disabled'`: No-op, backward compatible default
+ * - `'inferred'`: Auto-detect from package.json or git remote
+ * - `RepositoryConfig`: Direct repository configuration provided
+ * - `RepositoryResolution`: Fine-grained control with mode and options
+ *
+ * State updates:
+ * - repositoryConfig: Resolved repository configuration (if successful)
+ *
+ * @returns A FlowStep that resolves repository configuration
+ *
+ * @example
+ * ```typescript
+ * // Auto-detect repository
+ * const flow = createFlow({
+ *   repository: 'inferred'
+ * })
+ *
+ * // Explicit repository
+ * const flow = createFlow({
+ *   repository: {
+ *     platform: 'github',
+ *     baseUrl: 'https://github.com/owner/repo'
+ *   }
+ * })
+ * ```
+ */
+export function createResolveRepositoryStep(): FlowStep {
+  return createStep(
+    RESOLVE_REPOSITORY_STEP_ID,
+    'Resolve Repository',
+    async (ctx) => {
+      const { config, logger, tree, git, projectRoot } = ctx
+      const repoConfig = config.repository
+
+      // Disabled or undefined - no-op for backward compatibility
+      if (repoConfig === undefined || repoConfig === 'disabled') {
+        logger.debug('Repository resolution disabled')
+        return {
+          status: 'skipped',
+          message: 'Repository resolution disabled',
+        }
+      }
+
+      // Direct RepositoryConfig provided
+      if (isRepositoryConfig(repoConfig)) {
+        logger.debug(`Using explicit repository config: ${repoConfig.platform}`)
+        return {
+          status: 'success',
+          stateUpdates: {
+            repositoryConfig: repoConfig,
+          },
+          message: `Using explicit ${repoConfig.platform} repository`,
+        }
+      }
+
+      // Shorthand 'inferred' mode
+      if (repoConfig === 'inferred') {
+        const resolved = await inferRepository(tree, git, projectRoot, DEFAULT_INFERENCE_ORDER, logger)
+        if (resolved) {
+          return {
+            status: 'success',
+            stateUpdates: {
+              repositoryConfig: resolved,
+            },
+            message: `Inferred ${resolved.platform} repository from ${resolved.baseUrl}`,
+          }
+        }
+
+        // Graceful degradation - no error, just no URLs
+        logger.debug('Could not infer repository from package.json or git remote')
+        return {
+          status: 'skipped',
+          message: 'Could not infer repository configuration',
+        }
+      }
+
+      // Full RepositoryResolution object
+      if (isRepositoryResolution(repoConfig)) {
+        return handleRepositoryResolution(repoConfig, tree, git, projectRoot, logger)
+      }
+
+      // Unknown configuration - should not happen with TypeScript
+      logger.warn('Unknown repository configuration format')
+      return {
+        status: 'skipped',
+        message: 'Unknown repository configuration format',
+      }
+    },
+    {
+      description: 'Resolves repository configuration for compare URL generation',
+    }
+  )
+}
+
+/**
+ * Handles a full RepositoryResolution configuration.
+ *
+ * @param resolution - Repository resolution configuration
+ * @param tree - Virtual file system tree
+ * @param git - Git client instance
+ * @param projectRoot - Path to the project root
+ * @param logger - Logger instance
+ * @returns Flow step result with repository config or skip/error status
+ * @internal
+ */
+async function handleRepositoryResolution(
+  resolution: RepositoryResolution,
+  tree: import('@hyperfrontend/project-scope').Tree,
+  git: import('../../git/factory').GitClient,
+  projectRoot: string,
+  logger: import('@hyperfrontend/logging').Logger
+): Promise<import('../models/types').FlowStepResult> {
+  const { mode, repository, inferenceOrder } = resolution
+
+  // Disabled mode
+  if (mode === 'disabled') {
+    logger.debug('Repository resolution explicitly disabled')
+    return {
+      status: 'skipped',
+      message: 'Repository resolution disabled',
+    }
+  }
+
+  // Explicit mode - must have repository
+  if (mode === 'explicit') {
+    if (!repository) {
+      return {
+        status: 'failed',
+        message: 'Repository config required when mode is "explicit"',
+        error: createError('Repository config required when mode is "explicit"'),
+      }
+    }
+
+    logger.debug(`Using explicit repository config: ${repository.platform}`)
+    return {
+      status: 'success',
+      stateUpdates: {
+        repositoryConfig: repository,
+      },
+      message: `Using explicit ${repository.platform} repository`,
+    }
+  }
+
+  // Inferred mode
+  const order = inferenceOrder ?? DEFAULT_INFERENCE_ORDER
+  const resolved = await inferRepository(tree, git, projectRoot, order, logger)
+
+  if (resolved) {
+    return {
+      status: 'success',
+      stateUpdates: {
+        repositoryConfig: resolved,
+      },
+      message: `Inferred ${resolved.platform} repository`,
+    }
+  }
+
+  // Graceful degradation
+  logger.debug('Could not infer repository configuration')
+  return {
+    status: 'skipped',
+    message: 'Could not infer repository configuration',
+  }
+}
+
+/**
+ * Infers repository configuration from available sources.
+ *
+ * @param tree - Virtual file system tree
+ * @param git - Git client instance
+ * @param projectRoot - Path to the project root
+ * @param order - Inference source order
+ * @param logger - Logger instance
+ * @returns Repository config or null if none found
+ * @internal
+ */
+async function inferRepository(
+  tree: import('@hyperfrontend/project-scope').Tree,
+  git: import('../../git/factory').GitClient,
+  projectRoot: string,
+  order: readonly RepositoryInferenceSource[],
+  logger: import('@hyperfrontend/logging').Logger
+): Promise<RepositoryConfig | null> {
+  for (const source of order) {
+    const config = await inferFromSource(tree, git, projectRoot, source, logger)
+    if (config) {
+      logger.debug(`Inferred repository from ${source}: ${config.platform}`)
+      return config
+    }
+  }
+
+  return null
+}
+
+/**
+ * Infers repository from a single source.
+ *
+ * @param tree - Virtual file system tree
+ * @param git - Git client instance
+ * @param projectRoot - Path to the project root
+ * @param source - Inference source type
+ * @param logger - Logger instance
+ * @returns Repository config or null if not found
+ * @internal
+ */
+async function inferFromSource(
+  tree: import('@hyperfrontend/project-scope').Tree,
+  git: import('../../git/factory').GitClient,
+  projectRoot: string,
+  source: RepositoryInferenceSource,
+  logger: import('@hyperfrontend/logging').Logger
+): Promise<RepositoryConfig | null> {
+  if (source === 'package-json') {
+    return inferFromPackageJson(tree, projectRoot, logger)
+  }
+
+  if (source === 'git-remote') {
+    return inferFromGitRemote(git, logger)
+  }
+
+  logger.warn(`Unknown inference source: ${source}`)
+  return null
+}
+
+/**
+ * Infers repository from package.json repository field.
+ *
+ * @param tree - Virtual file system tree
+ * @param projectRoot - Path to the project root
+ * @param logger - Logger instance
+ * @returns Repository config or null if not found
+ * @internal
+ */
+function inferFromPackageJson(
+  tree: import('@hyperfrontend/project-scope').Tree,
+  projectRoot: string,
+  logger: import('@hyperfrontend/logging').Logger
+): RepositoryConfig | null {
+  const packageJsonPath = `${projectRoot}/package.json`
+
+  if (!tree.exists(packageJsonPath)) {
+    logger.debug(`package.json not found at ${packageJsonPath}`)
+    return null
+  }
+
+  const content = tree.read(packageJsonPath, 'utf-8')
+  if (!content) {
+    logger.debug('Could not read package.json')
+    return null
+  }
+
+  const config = inferRepositoryFromPackageJson(content)
+  if (config) {
+    logger.debug(`Found repository in package.json: ${config.baseUrl}`)
+  }
+
+  return config
+}
+
+/**
+ * Infers repository from git remote URL.
+ *
+ * @param git - Git client instance
+ * @param logger - Logger instance
+ * @returns Repository config or null if not found
+ * @internal
+ */
+async function inferFromGitRemote(
+  git: import('../../git/factory').GitClient,
+  logger: import('@hyperfrontend/logging').Logger
+): Promise<RepositoryConfig | null> {
+  const remoteUrl = await git.getRemoteUrl('origin')
+
+  if (!remoteUrl) {
+    logger.debug('Could not get git remote URL')
+    return null
+  }
+
+  const config = createRepositoryConfigFromUrl(remoteUrl)
+  if (config) {
+    logger.debug(`Inferred repository from git remote: ${config.baseUrl}`)
+  }
+
+  return config
+}

--- a/libs/versioning/src/flow/steps/update-packages.ts
+++ b/libs/versioning/src/flow/steps/update-packages.ts
@@ -31,23 +31,26 @@ export function createUpdatePackageStep(): FlowStep {
       }
 
       const packageJsonPath = `${projectRoot}/package.json`
+      logger.debug(`Reading package.json from: ${packageJsonPath}`)
 
       // Read package.json
       let content: string
       try {
         content = tree.read(packageJsonPath, 'utf-8') ?? ''
         if (!content) {
+          logger.error(`package.json not found at ${packageJsonPath}`)
           return {
             status: 'failed',
-            error: createError('package.json not found'),
-            message: 'Could not read package.json',
+            error: createError(`package.json not found at ${packageJsonPath}`),
+            message: `Could not read package.json at ${packageJsonPath}`,
           }
         }
       } catch (error) {
+        logger.error(`Failed to read package.json at ${packageJsonPath}: ${error}`)
         return {
           status: 'failed',
           error: error instanceof Error ? error : createError(String(error)),
-          message: 'Failed to read package.json',
+          message: `Failed to read package.json at ${packageJsonPath}`,
         }
       }
 

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -29,6 +29,7 @@ jest.mock('./operations/log', () => ({
   getCommitsSince: jest.fn().mockReturnValue([]),
   getCommit: jest.fn().mockReturnValue(null),
   commitExists: jest.fn().mockReturnValue(false),
+  commitReachableFromHead: jest.fn().mockReturnValue(false),
 }))
 jest.mock('./operations/status', () => ({
   getStatus: jest.fn().mockReturnValue({
@@ -141,6 +142,14 @@ describe('createGitClient', () => {
       const client = createGitClient()
 
       const result = client.commitExists('abc123')
+
+      expect(result).toBe(false)
+    })
+
+    it('provides commitReachableFromHead method', () => {
+      const client = createGitClient()
+
+      const result = client.commitReachableFromHead('abc123')
 
       expect(result).toBe(false)
     })

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -1,7 +1,9 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { createGitClient, DEFAULT_GIT_CLIENT_CONFIG } from './factory'
 
 jest.mock('node:child_process')
+
+const mockExecFileSync = <jest.MockedFunction<typeof execFileSync>>execFileSync
 jest.mock('./operations/commit', () => ({
   ...jest.requireActual('./operations/commit'),
   commit: jest.fn().mockReturnValue({ hash: 'mock-hash', shortHash: 'mock', message: 'test' }),
@@ -626,27 +628,27 @@ describe('createGitClient', () => {
 
   describe('getRemoteUrl operation', () => {
     it('returns remote URL on success', () => {
-      mockExecSync.mockReturnValue('https://github.com/owner/repo.git\n')
+      mockExecFileSync.mockReturnValue('https://github.com/owner/repo.git\n')
 
       const client = createGitClient()
       const result = client.getRemoteUrl()
 
       expect(result).toBe('https://github.com/owner/repo.git')
-      expect(mockExecSync).toHaveBeenCalledWith('git remote get-url origin', expect.any(Object))
+      expect(mockExecFileSync).toHaveBeenCalledWith('git', ['remote', 'get-url', 'origin'], expect.any(Object))
     })
 
     it('uses custom remote name', () => {
-      mockExecSync.mockReturnValue('https://github.com/other/repo.git\n')
+      mockExecFileSync.mockReturnValue('https://github.com/other/repo.git\n')
 
       const client = createGitClient()
       const result = client.getRemoteUrl('upstream')
 
       expect(result).toBe('https://github.com/other/repo.git')
-      expect(mockExecSync).toHaveBeenCalledWith('git remote get-url upstream', expect.any(Object))
+      expect(mockExecFileSync).toHaveBeenCalledWith('git', ['remote', 'get-url', 'upstream'], expect.any(Object))
     })
 
     it('returns null when remote does not exist', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("fatal: No such remote 'nonexistent'")
       })
 
@@ -657,7 +659,7 @@ describe('createGitClient', () => {
     })
 
     it('returns null for empty output', () => {
-      mockExecSync.mockReturnValue('')
+      mockExecFileSync.mockReturnValue('')
 
       const client = createGitClient()
       const result = client.getRemoteUrl()
@@ -666,7 +668,7 @@ describe('createGitClient', () => {
     })
 
     it('trims whitespace from URL', () => {
-      mockExecSync.mockReturnValue('  git@github.com:owner/repo.git  \n')
+      mockExecFileSync.mockReturnValue('  git@github.com:owner/repo.git  \n')
 
       const client = createGitClient()
       const result = client.getRemoteUrl()

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -614,6 +614,57 @@ describe('createGitClient', () => {
       expect(result).toBe(false)
     })
   })
+
+  describe('getRemoteUrl operation', () => {
+    it('returns remote URL on success', () => {
+      mockExecSync.mockReturnValue('https://github.com/owner/repo.git\n')
+
+      const client = createGitClient()
+      const result = client.getRemoteUrl()
+
+      expect(result).toBe('https://github.com/owner/repo.git')
+      expect(mockExecSync).toHaveBeenCalledWith('git remote get-url origin', expect.any(Object))
+    })
+
+    it('uses custom remote name', () => {
+      mockExecSync.mockReturnValue('https://github.com/other/repo.git\n')
+
+      const client = createGitClient()
+      const result = client.getRemoteUrl('upstream')
+
+      expect(result).toBe('https://github.com/other/repo.git')
+      expect(mockExecSync).toHaveBeenCalledWith('git remote get-url upstream', expect.any(Object))
+    })
+
+    it('returns null when remote does not exist', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error("fatal: No such remote 'nonexistent'")
+      })
+
+      const client = createGitClient()
+      const result = client.getRemoteUrl('nonexistent')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null for empty output', () => {
+      mockExecSync.mockReturnValue('')
+
+      const client = createGitClient()
+      const result = client.getRemoteUrl()
+
+      expect(result).toBeNull()
+    })
+
+    it('trims whitespace from URL', () => {
+      mockExecSync.mockReturnValue('  git@github.com:owner/repo.git  \n')
+
+      const client = createGitClient()
+      const result = client.getRemoteUrl()
+
+      expect(result).toBe('git@github.com:owner/repo.git')
+    })
+  })
 })
 
 describe('DEFAULT_GIT_CLIENT_CONFIG', () => {

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -288,6 +288,14 @@ export interface GitClient {
    * Pushes to remote.
    */
   push(remote?: string, branch?: string, options?: { force?: boolean; setUpstream?: boolean }): boolean
+
+  /**
+   * Gets the URL of a remote.
+   *
+   * @param remoteName - Name of the remote (defaults to 'origin')
+   * @returns The remote URL, or null if not found
+   */
+  getRemoteUrl(remoteName?: string): string | null
 }
 
 /**
@@ -373,6 +381,7 @@ export function createGitClient(config: GitClientConfig = {}): GitClient {
     fetch: (remote, options) => fetch(opts, remote, options),
     pull: (remote, branch) => pull(opts, remote, branch),
     push: (remote, branch, options) => push(opts, remote, branch, options),
+    getRemoteUrl: (remoteName) => getRemoteUrl(opts, remoteName),
   }
 }
 
@@ -556,5 +565,28 @@ function push(
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Gets the URL of a remote.
+ *
+ * @param options - Configuration object containing cwd and timeout
+ * @param options.cwd - Working directory for the git command
+ * @param options.timeout - Command timeout in milliseconds
+ * @param remoteName - Name of the remote (defaults to 'origin')
+ * @returns The remote URL, or null if not found
+ */
+function getRemoteUrl(options: { cwd: string; timeout: number }, remoteName = 'origin'): string | null {
+  try {
+    const output = execSync(`git remote get-url ${remoteName}`, {
+      encoding: 'utf-8',
+      cwd: options.cwd,
+      timeout: options.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return output.trim() || null
+  } catch {
+    return null
   }
 }

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -11,7 +11,7 @@ import { execSync } from 'node:child_process'
 import { createGitRef } from './models/ref'
 import { commit, amendCommit, createEmptyCommit } from './operations/commit'
 import { getHead, getCurrentBranch, hasUntrackedFiles } from './operations/head-info'
-import { getCommitLog, getCommitsBetween, getCommitsSince, getCommit, commitExists } from './operations/log'
+import { getCommitLog, getCommitsBetween, getCommitsSince, getCommit, commitExists, commitReachableFromHead } from './operations/log'
 import { createTag, deleteTag, pushTag } from './operations/manage-tags'
 import { getTags, getTag, tagExists, getLatestTag, getTagsForPackage } from './operations/query-tags'
 import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges } from './operations/stage'
@@ -85,6 +85,14 @@ export interface GitClient {
    * Checks if a commit exists.
    */
   commitExists(hash: string): boolean
+
+  /**
+   * Checks if a commit is reachable from HEAD (i.e., is an ancestor of HEAD).
+   *
+   * Use this to verify an external commit reference before using it for
+   * range queries. Detects if history was rewritten after the reference was recorded.
+   */
+  commitReachableFromHead(hash: string): boolean
 
   // ========== Tag Operations ==========
 
@@ -334,6 +342,7 @@ export function createGitClient(config: GitClientConfig = {}): GitClient {
     getCommitsSince: (since, options) => getCommitsSince(since, { ...opts, ...options }),
     getCommit: (hash) => getCommit(hash, opts),
     commitExists: (hash) => commitExists(hash, opts),
+    commitReachableFromHead: (hash) => commitReachableFromHead(hash, opts),
 
     // Tag operations
     getTags: (options) => getTags({ ...opts, ...options }),

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -7,7 +7,7 @@ import type { CreateTagOptions } from './operations/manage-tags'
 import type { ListTagsOptions } from './operations/query-tags'
 import type { StageOptions } from './operations/stage'
 import type { RepositoryStatus } from './operations/status'
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { createGitRef } from './models/ref'
 import { commit, amendCommit, createEmptyCommit } from './operations/commit'
 import { getHead, getCurrentBranch, hasUntrackedFiles } from './operations/head-info'
@@ -588,7 +588,7 @@ function push(
  */
 function getRemoteUrl(options: { cwd: string; timeout: number }, remoteName = 'origin'): string | null {
   try {
-    const output = execSync(`git remote get-url ${remoteName}`, {
+    const output = execFileSync('git', ['remote', 'get-url', remoteName], {
       encoding: 'utf-8',
       cwd: options.cwd,
       timeout: options.timeout,

--- a/libs/versioning/src/git/operations/index.ts
+++ b/libs/versioning/src/git/operations/index.ts
@@ -11,6 +11,7 @@ export {
   getCommitsSince,
   getCommit,
   commitExists,
+  commitReachableFromHead,
   escapeGitRef,
   escapeGitPath,
   escapeGitArg,

--- a/libs/versioning/src/git/operations/log.spec.ts
+++ b/libs/versioning/src/git/operations/log.spec.ts
@@ -5,6 +5,7 @@ import {
   getCommitsSince,
   getCommit,
   commitExists,
+  commitReachableFromHead,
   escapeGitRef,
   escapeGitPath,
   escapeGitArg,
@@ -447,6 +448,74 @@ describe('commitExists', () => {
     commitExists('abc123', { timeout: 1000 })
 
     expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ timeout: 1000 }))
+  })
+})
+
+// ============================================================================
+// commitReachableFromHead Tests
+// ============================================================================
+
+describe('commitReachableFromHead', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true when commit is ancestor of HEAD', () => {
+    // git merge-base --is-ancestor exits with 0 (no output) when commit is ancestor
+    mockExecSync.mockReturnValue('')
+
+    const result = commitReachableFromHead('abc123')
+
+    expect(result).toBe(true)
+    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('git merge-base --is-ancestor'), expect.any(Object))
+  })
+
+  it('returns false when commit is not ancestor of HEAD', () => {
+    // git merge-base --is-ancestor exits with 1 when not an ancestor
+    mockExecSync.mockImplementation(() => {
+      const error = new Error('exit code 1')
+      ;(error as NodeJS.ErrnoException).code = '1'
+      throw error
+    })
+
+    const result = commitReachableFromHead('orphaned123')
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false when commit does not exist', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('fatal: Not a valid object name')
+    })
+
+    const result = commitReachableFromHead('nonexistent')
+
+    expect(result).toBe(false)
+  })
+
+  it('uses custom cwd', () => {
+    mockExecSync.mockReturnValue('')
+
+    commitReachableFromHead('abc123', { cwd: '/tmp/repo' })
+
+    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ cwd: '/tmp/repo' }))
+  })
+
+  it('uses custom timeout', () => {
+    mockExecSync.mockReturnValue('')
+
+    commitReachableFromHead('abc123', { timeout: 1000 })
+
+    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ timeout: 1000 }))
+  })
+
+  it('escapes potentially dangerous commit hashes', () => {
+    mockExecSync.mockReturnValue('')
+
+    // The function should escape the hash before using it
+    commitReachableFromHead('abc123')
+
+    expect(mockExecSync).toHaveBeenCalledWith('git merge-base --is-ancestor abc123 HEAD', expect.any(Object))
   })
 })
 

--- a/libs/versioning/src/git/operations/log.spec.ts
+++ b/libs/versioning/src/git/operations/log.spec.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import {
   getCommitLog,
   getCommitsBetween,
@@ -15,6 +15,7 @@ import {
 jest.mock('node:child_process')
 
 const mockExecSync = execSync as jest.MockedFunction<typeof execSync>
+const mockExecFileSync = <jest.MockedFunction<typeof execFileSync>>execFileSync
 
 // Record separator used in git log format
 const RECORD_SEPARATOR = '\x1e'
@@ -77,10 +78,6 @@ describe('DEFAULT_LOG_OPTIONS', () => {
     expect(DEFAULT_LOG_OPTIONS.timeout).toBe(30000)
   })
 })
-
-// ============================================================================
-// getCommitLog Tests
-// ============================================================================
 
 describe('getCommitLog', () => {
   beforeEach(() => {
@@ -305,10 +302,6 @@ describe('getCommitLog', () => {
   })
 })
 
-// ============================================================================
-// getCommitsBetween Tests
-// ============================================================================
-
 describe('getCommitsBetween', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -339,10 +332,6 @@ describe('getCommitsBetween', () => {
   })
 })
 
-// ============================================================================
-// getCommitsSince Tests
-// ============================================================================
-
 describe('getCommitsSince', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -364,10 +353,6 @@ describe('getCommitsSince', () => {
     expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('--no-merges'), expect.any(Object))
   })
 })
-
-// ============================================================================
-// getCommit Tests
-// ============================================================================
 
 describe('getCommit', () => {
   beforeEach(() => {
@@ -405,10 +390,6 @@ describe('getCommit', () => {
     expect(result).toBeNull()
   })
 })
-
-// ============================================================================
-// commitExists Tests
-// ============================================================================
 
 describe('commitExists', () => {
   beforeEach(() => {
@@ -451,10 +432,6 @@ describe('commitExists', () => {
   })
 })
 
-// ============================================================================
-// commitReachableFromHead Tests
-// ============================================================================
-
 describe('commitReachableFromHead', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -462,17 +439,17 @@ describe('commitReachableFromHead', () => {
 
   it('returns true when commit is ancestor of HEAD', () => {
     // git merge-base --is-ancestor exits with 0 (no output) when commit is ancestor
-    mockExecSync.mockReturnValue('')
+    mockExecFileSync.mockReturnValue('')
 
     const result = commitReachableFromHead('abc123')
 
     expect(result).toBe(true)
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('git merge-base --is-ancestor'), expect.any(Object))
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['merge-base', '--is-ancestor', 'abc123', 'HEAD'], expect.any(Object))
   })
 
   it('returns false when commit is not ancestor of HEAD', () => {
     // git merge-base --is-ancestor exits with 1 when not an ancestor
-    mockExecSync.mockImplementation(() => {
+    mockExecFileSync.mockImplementation(() => {
       const error = new Error('exit code 1')
       ;(error as NodeJS.ErrnoException).code = '1'
       throw error
@@ -484,7 +461,7 @@ describe('commitReachableFromHead', () => {
   })
 
   it('returns false when commit does not exist', () => {
-    mockExecSync.mockImplementation(() => {
+    mockExecFileSync.mockImplementation(() => {
       throw new Error('fatal: Not a valid object name')
     })
 
@@ -494,34 +471,30 @@ describe('commitReachableFromHead', () => {
   })
 
   it('uses custom cwd', () => {
-    mockExecSync.mockReturnValue('')
+    mockExecFileSync.mockReturnValue('')
 
     commitReachableFromHead('abc123', { cwd: '/tmp/repo' })
 
-    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ cwd: '/tmp/repo' }))
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', expect.any(Array), expect.objectContaining({ cwd: '/tmp/repo' }))
   })
 
   it('uses custom timeout', () => {
-    mockExecSync.mockReturnValue('')
+    mockExecFileSync.mockReturnValue('')
 
     commitReachableFromHead('abc123', { timeout: 1000 })
 
-    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ timeout: 1000 }))
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', expect.any(Array), expect.objectContaining({ timeout: 1000 }))
   })
 
   it('escapes potentially dangerous commit hashes', () => {
-    mockExecSync.mockReturnValue('')
+    mockExecFileSync.mockReturnValue('')
 
     // The function should escape the hash before using it
     commitReachableFromHead('abc123')
 
-    expect(mockExecSync).toHaveBeenCalledWith('git merge-base --is-ancestor abc123 HEAD', expect.any(Object))
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['merge-base', '--is-ancestor', 'abc123', 'HEAD'], expect.any(Object))
   })
 })
-
-// ============================================================================
-// escapeGitRef Tests
-// ============================================================================
 
 describe('escapeGitRef', () => {
   it('allows valid git references', () => {
@@ -566,10 +539,6 @@ describe('escapeGitRef', () => {
   })
 })
 
-// ============================================================================
-// escapeGitPath Tests
-// ============================================================================
-
 describe('escapeGitPath', () => {
   it('allows valid file paths', () => {
     expect(escapeGitPath('src/index.ts')).toBe('src/index.ts')
@@ -607,10 +576,6 @@ describe('escapeGitPath', () => {
     expect(() => escapeGitPath('path\nnewline')).toThrow('Invalid character')
   })
 })
-
-// ============================================================================
-// escapeGitArg Tests
-// ============================================================================
 
 describe('escapeGitArg', () => {
   it('allows valid arguments', () => {

--- a/libs/versioning/src/git/operations/log.ts
+++ b/libs/versioning/src/git/operations/log.ts
@@ -209,6 +209,45 @@ export function commitExists(hash: string, options: Pick<GitLogOptions, 'cwd' | 
 }
 
 /**
+ * Checks if a commit is reachable from HEAD (i.e., is an ancestor of HEAD).
+ *
+ * A commit may exist in the repository but be orphaned (not in current branch history).
+ * This function verifies that the commit is actually in the history of the current HEAD.
+ *
+ * Common use cases:
+ * - Verify an external commit reference before using it for range queries
+ * - Detect if history was rewritten (rebase/force push) after a reference was recorded
+ *
+ * @param hash - Commit hash to check
+ * @param options - Additional options
+ * @returns True if the commit is an ancestor of HEAD
+ *
+ * @example
+ * if (commitReachableFromHead(baseCommit)) {
+ *   // Safe to use for commit range queries
+ *   const commits = getCommitsSince(baseCommit)
+ * } else {
+ *   // Commit not in current history, need fallback strategy
+ * }
+ */
+export function commitReachableFromHead(hash: string, options: Pick<GitLogOptions, 'cwd' | 'timeout'> = {}): boolean {
+  const safeHash = escapeGitRef(hash)
+  try {
+    // git merge-base --is-ancestor exits with 0 if commit is ancestor of HEAD
+    execSync(`git merge-base --is-ancestor ${safeHash} HEAD`, {
+      encoding: 'utf-8',
+      cwd: options.cwd,
+      timeout: options.timeout ?? 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return true
+  } catch {
+    // Exit code 1 means not an ancestor, other errors also return false
+    return false
+  }
+}
+
+/**
  * Parses raw git log output into GitCommit objects.
  *
  * @param output - Raw git log output

--- a/libs/versioning/src/git/operations/log.ts
+++ b/libs/versioning/src/git/operations/log.ts
@@ -1,5 +1,5 @@
 import type { GitCommit } from '../models/commit'
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
 import { createGitCommit } from '../models/commit'
 
@@ -234,7 +234,7 @@ export function commitReachableFromHead(hash: string, options: Pick<GitLogOption
   const safeHash = escapeGitRef(hash)
   try {
     // git merge-base --is-ancestor exits with 0 if commit is ancestor of HEAD
-    execSync(`git merge-base --is-ancestor ${safeHash} HEAD`, {
+    execFileSync('git', ['merge-base', '--is-ancestor', safeHash, 'HEAD'], {
       encoding: 'utf-8',
       cwd: options.cwd,
       timeout: options.timeout ?? 5000,

--- a/libs/versioning/src/registry/models/version-info.spec.ts
+++ b/libs/versioning/src/registry/models/version-info.spec.ts
@@ -42,4 +42,25 @@ describe('createVersionInfo', () => {
     expect(info.nodeVersion).toBe('18.0.0')
     expect(info.npmVersion).toBe('9.0.0')
   })
+
+  it('includes gitHead for commit tracking', () => {
+    const info = createVersionInfo({
+      version: '1.0.0',
+      publishedAt: '2024-01-01T00:00:00Z',
+      tarball: 'https://example.com/test.tgz',
+      gitHead: 'a9185d9b783d7d8d51cc4ad91eb3178eba3e3930',
+    })
+
+    expect(info.gitHead).toBe('a9185d9b783d7d8d51cc4ad91eb3178eba3e3930')
+  })
+
+  it('allows undefined gitHead for legacy packages', () => {
+    const info = createVersionInfo({
+      version: '0.1.0',
+      publishedAt: '2020-01-01T00:00:00Z',
+      tarball: 'https://example.com/legacy.tgz',
+    })
+
+    expect(info.gitHead).toBeUndefined()
+  })
 })

--- a/libs/versioning/src/registry/models/version-info.ts
+++ b/libs/versioning/src/registry/models/version-info.ts
@@ -45,6 +45,15 @@ export interface VersionInfo {
 
   /** npm version used to publish */
   readonly npmVersion?: string
+
+  /**
+   * Git commit hash at publish time.
+   * Used to determine commit range for changelog generation.
+   *
+   * NOTE: This value comes from npm registry, making it immutable
+   * and independent of local git state.
+   */
+  readonly gitHead?: string
 }
 
 /**
@@ -62,6 +71,7 @@ export interface VersionInfo {
  * @param options.engines - Node/npm engine requirements
  * @param options.nodeVersion - Node.js version used during publish
  * @param options.npmVersion - npm version used during publish
+ * @param options.gitHead - Git commit hash at publish time
  * @returns A new VersionInfo object
  */
 export function createVersionInfo(options: {
@@ -76,6 +86,7 @@ export function createVersionInfo(options: {
   engines?: Record<string, string>
   nodeVersion?: string
   npmVersion?: string
+  gitHead?: string
 }): VersionInfo {
   return {
     version: options.version,
@@ -89,5 +100,6 @@ export function createVersionInfo(options: {
     engines: options.engines,
     nodeVersion: options.nodeVersion,
     npmVersion: options.npmVersion,
+    gitHead: options.gitHead,
   }
 }

--- a/libs/versioning/src/registry/npm/client.ts
+++ b/libs/versioning/src/registry/npm/client.ts
@@ -196,6 +196,7 @@ async function getVersionInfo(state: NpmRegistryState, packageName: string, vers
       engines: data.engines,
       nodeVersion: data._nodeVersion,
       npmVersion: data._npmVersion,
+      gitHead: data.gitHead,
     }
 
     state.cache.set(cacheKey, info)
@@ -235,10 +236,6 @@ async function listVersions(state: NpmRegistryState, packageName: string): Promi
     return []
   }
 }
-
-// ============================================================================
-// Security helpers - character-by-character validation (no regex)
-// ============================================================================
 
 /**
  * Maximum allowed package name length (npm limit).

--- a/libs/versioning/src/repository/README.md
+++ b/libs/versioning/src/repository/README.md
@@ -1,0 +1,177 @@
+# repository/
+
+Repository detection and compare URL generation for changelog entries.
+
+## Overview
+
+This module handles repository configuration for generating compare URLs in changelog entries. It supports automatic detection from package.json or git remotes, with built-in formatters for GitHub, GitLab, Bitbucket, and Azure DevOps.
+
+```mermaid
+flowchart TB
+    subgraph Input
+        PKG[package.json]
+        GIT[git remote]
+        URL[Repository URL]
+    end
+
+    subgraph Detection
+        PARSE[parseRepositoryUrl]
+        INFER_PKG[inferRepositoryFromPackageJson]
+        DETECT[detectPlatformFromHostname]
+    end
+
+    subgraph Configuration
+        CONFIG[RepositoryConfig]
+        RES[RepositoryResolution]
+    end
+
+    subgraph Output
+        COMPARE[createCompareUrl]
+        FMT[Platform Formatters]
+    end
+
+    PKG --> INFER_PKG --> CONFIG
+    GIT --> PARSE --> CONFIG
+    URL --> PARSE --> DETECT --> CONFIG
+    CONFIG --> COMPARE --> FMT
+    RES --> CONFIG
+```
+
+## API
+
+### Models
+
+| Export                      | Description                                     | Implementation                                        |
+| --------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| `RepositoryPlatform`        | Platform type: github, gitlab, bitbucket, etc.  | [platform.ts](./models/platform.ts)                   |
+| `KnownPlatform`             | Platforms with built-in compare URL formatters  | [platform.ts](./models/platform.ts)                   |
+| `RepositoryConfig`          | Repository configuration with platform and URL  | [repository-config.ts](./models/repository-config.ts) |
+| `CompareUrlFormatter`       | Custom function to format compare URLs          | [repository-config.ts](./models/repository-config.ts) |
+| `RepositoryResolution`      | Resolution config: disabled, inferred, explicit | [resolution.ts](./models/resolution.ts)               |
+| `RepositoryResolutionMode`  | `'disabled' \| 'inferred' \| 'explicit'`        | [resolution.ts](./models/resolution.ts)               |
+| `RepositoryInferenceSource` | `'package-json' \| 'git-remote'`                | [resolution.ts](./models/resolution.ts)               |
+
+### Model Factories
+
+| Function                     | Description                            | Implementation                                        |
+| ---------------------------- | -------------------------------------- | ----------------------------------------------------- |
+| `createRepositoryConfig()`   | Create a RepositoryConfig              | [repository-config.ts](./models/repository-config.ts) |
+| `createDisabledResolution()` | Create disabled resolution (no URLs)   | [resolution.ts](./models/resolution.ts)               |
+| `createExplicitResolution()` | Create explicit resolution with config | [resolution.ts](./models/resolution.ts)               |
+| `createInferredResolution()` | Create inferred resolution             | [resolution.ts](./models/resolution.ts)               |
+
+### Model Utilities
+
+| Function                       | Description                              | Implementation                                        |
+| ------------------------------ | ---------------------------------------- | ----------------------------------------------------- |
+| `isKnownPlatform(platform)`    | Check if platform has built-in formatter | [platform.ts](./models/platform.ts)                   |
+| `detectPlatformFromHostname()` | Detect platform from hostname            | [platform.ts](./models/platform.ts)                   |
+| `isRepositoryConfig(value)`    | Type guard for RepositoryConfig          | [repository-config.ts](./models/repository-config.ts) |
+| `isRepositoryResolution()`     | Type guard for RepositoryResolution      | [resolution.ts](./models/resolution.ts)               |
+
+### Parse Functions
+
+| Function                           | Description                              | Implementation                             |
+| ---------------------------------- | ---------------------------------------- | ------------------------------------------ |
+| `parseRepositoryUrl(url)`          | Parse git URL to platform and base URL   | [url.ts](./parse/url.ts)                   |
+| `createRepositoryConfigFromUrl()`  | Create config directly from URL          | [url.ts](./parse/url.ts)                   |
+| `inferRepositoryFromPackageJson()` | Infer config from package.json path      | [package-json.ts](./parse/package-json.ts) |
+| `extractRepositoryUrl(pkg)`        | Extract URL from package.json repository | [package-json.ts](./parse/package-json.ts) |
+
+### URL Functions
+
+| Function             | Description                       | Implementation                 |
+| -------------------- | --------------------------------- | ------------------------------ |
+| `createCompareUrl()` | Generate compare URL for two tags | [compare.ts](./url/compare.ts) |
+
+## Supported Platforms
+
+| Platform     | Compare URL Format                                    |
+| ------------ | ----------------------------------------------------- |
+| GitHub       | `{baseUrl}/compare/{fromTag}...{toTag}`               |
+| GitLab       | `{baseUrl}/-/compare/{fromTag}...{toTag}`             |
+| Bitbucket    | `{baseUrl}/compare/{toTag}..{fromTag}` (reversed)     |
+| Azure DevOps | `{baseUrl}?version=GT{toTag}&compareVersion=GT{from}` |
+
+## Usage Examples
+
+### Parse Repository URL
+
+```typescript
+import { parseRepositoryUrl } from '@hyperfrontend/versioning/repository/parse'
+
+// HTTPS URLs
+parseRepositoryUrl('https://github.com/owner/repo')
+// → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+
+// SSH URLs
+parseRepositoryUrl('git@github.com:owner/repo.git')
+// → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+
+// GitLab with subgroups
+parseRepositoryUrl('https://gitlab.com/group/subgroup/project')
+// → { platform: 'gitlab', baseUrl: 'https://gitlab.com/group/subgroup/project' }
+```
+
+### Generate Compare URL
+
+```typescript
+import { createRepositoryConfig } from '@hyperfrontend/versioning/repository'
+import { createCompareUrl } from '@hyperfrontend/versioning/repository/url'
+
+const repo = createRepositoryConfig({
+  platform: 'github',
+  baseUrl: 'https://github.com/owner/repo',
+})
+
+createCompareUrl({ repository: repo, fromTag: 'v1.0.0', toTag: 'v1.1.0' })
+// → 'https://github.com/owner/repo/compare/v1.0.0...v1.1.0'
+```
+
+### Custom Platform Formatter
+
+```typescript
+import { createRepositoryConfig } from '@hyperfrontend/versioning/repository'
+
+const repo = createRepositoryConfig({
+  platform: 'custom',
+  baseUrl: 'https://my-git.internal/repo',
+  formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`,
+})
+```
+
+### Flow Integration
+
+The repository module integrates with the versioning flow via the `repository` config option:
+
+```typescript
+import { createVersionFlow } from '@hyperfrontend/versioning/flow'
+
+// Auto-detect from package.json or git remote
+const flow = createVersionFlow('conventional', {
+  repository: 'inferred',
+})
+
+// Explicit configuration
+const flow2 = createVersionFlow('conventional', {
+  repository: {
+    mode: 'explicit',
+    repository: {
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    },
+  },
+})
+
+// Disable compare URLs
+const flow3 = createVersionFlow('conventional', {
+  repository: 'disabled',
+})
+```
+
+## Constants
+
+| Export                    | Value                            | Description                     |
+| ------------------------- | -------------------------------- | ------------------------------- |
+| `PLATFORM_HOSTNAMES`      | Map of hostnames to platforms    | Known platform hostname mapping |
+| `DEFAULT_INFERENCE_ORDER` | `['package-json', 'git-remote']` | Default inference source order  |

--- a/libs/versioning/src/repository/README.md
+++ b/libs/versioning/src/repository/README.md
@@ -86,12 +86,12 @@ flowchart TB
 
 ## Supported Platforms
 
-| Platform     | Compare URL Format                                    |
-| ------------ | ----------------------------------------------------- |
-| GitHub       | `{baseUrl}/compare/{fromTag}...{toTag}`               |
-| GitLab       | `{baseUrl}/-/compare/{fromTag}...{toTag}`             |
-| Bitbucket    | `{baseUrl}/compare/{toTag}..{fromTag}` (reversed)     |
-| Azure DevOps | `{baseUrl}?version=GT{toTag}&compareVersion=GT{from}` |
+| Platform     | Compare URL Format                                       |
+| ------------ | -------------------------------------------------------- |
+| GitHub       | `{baseUrl}/compare/{fromCommit}...{toCommit}`            |
+| GitLab       | `{baseUrl}/-/compare/{fromCommit}...{toCommit}`          |
+| Bitbucket    | `{baseUrl}/compare/{toCommit}..{fromCommit}` (reversed)  |
+| Azure DevOps | `{baseUrl}?version=GT{toCommit}&compareVersion=GT{from}` |
 
 ## Usage Examples
 

--- a/libs/versioning/src/repository/README.md
+++ b/libs/versioning/src/repository/README.md
@@ -80,9 +80,9 @@ flowchart TB
 
 ### URL Functions
 
-| Function             | Description                       | Implementation                 |
-| -------------------- | --------------------------------- | ------------------------------ |
-| `createCompareUrl()` | Generate compare URL for two tags | [compare.ts](./url/compare.ts) |
+| Function             | Description                          | Implementation                 |
+| -------------------- | ------------------------------------ | ------------------------------ |
+| `createCompareUrl()` | Generate compare URL for two commits | [compare.ts](./url/compare.ts) |
 
 ## Supported Platforms
 
@@ -124,8 +124,8 @@ const repo = createRepositoryConfig({
   baseUrl: 'https://github.com/owner/repo',
 })
 
-createCompareUrl({ repository: repo, fromTag: 'v1.0.0', toTag: 'v1.1.0' })
-// → 'https://github.com/owner/repo/compare/v1.0.0...v1.1.0'
+createCompareUrl({ repository: repo, fromCommit: 'abc1234', toCommit: 'def5678' })
+// → 'https://github.com/owner/repo/compare/abc1234...def5678'
 ```
 
 ### Custom Platform Formatter

--- a/libs/versioning/src/repository/index.ts
+++ b/libs/versioning/src/repository/index.ts
@@ -1,0 +1,1 @@
+export * from './models'

--- a/libs/versioning/src/repository/index.ts
+++ b/libs/versioning/src/repository/index.ts
@@ -1,1 +1,2 @@
 export * from './models'
+export * from './parse'

--- a/libs/versioning/src/repository/index.ts
+++ b/libs/versioning/src/repository/index.ts
@@ -1,2 +1,3 @@
 export * from './models'
 export * from './parse'
+export * from './url'

--- a/libs/versioning/src/repository/models/index.ts
+++ b/libs/versioning/src/repository/models/index.ts
@@ -1,0 +1,12 @@
+export type { KnownPlatform, RepositoryPlatform } from './platform'
+export type { RepositoryResolutionMode, RepositoryInferenceSource, RepositoryResolution } from './resolution'
+export type { CompareUrlFormatter, RepositoryConfig, CreateRepositoryConfigOptions } from './repository-config'
+export { isKnownPlatform, detectPlatformFromHostname, PLATFORM_HOSTNAMES } from './platform'
+export { createRepositoryConfig, isRepositoryConfig } from './repository-config'
+export {
+  createDisabledResolution,
+  createExplicitResolution,
+  createInferredResolution,
+  isRepositoryResolution,
+  DEFAULT_INFERENCE_ORDER,
+} from './resolution'

--- a/libs/versioning/src/repository/models/platform.spec.ts
+++ b/libs/versioning/src/repository/models/platform.spec.ts
@@ -1,0 +1,133 @@
+import { isKnownPlatform, detectPlatformFromHostname, PLATFORM_HOSTNAMES } from './platform'
+
+describe('isKnownPlatform', () => {
+  it('returns true for github', () => {
+    expect(isKnownPlatform('github')).toBe(true)
+  })
+
+  it('returns true for gitlab', () => {
+    expect(isKnownPlatform('gitlab')).toBe(true)
+  })
+
+  it('returns true for bitbucket', () => {
+    expect(isKnownPlatform('bitbucket')).toBe(true)
+  })
+
+  it('returns true for azure-devops', () => {
+    expect(isKnownPlatform('azure-devops')).toBe(true)
+  })
+
+  it('returns false for custom', () => {
+    expect(isKnownPlatform('custom')).toBe(false)
+  })
+
+  it('returns false for unknown', () => {
+    expect(isKnownPlatform('unknown')).toBe(false)
+  })
+})
+
+describe('PLATFORM_HOSTNAMES', () => {
+  it('maps github.com to github', () => {
+    expect(PLATFORM_HOSTNAMES.get('github.com')).toBe('github')
+  })
+
+  it('maps gitlab.com to gitlab', () => {
+    expect(PLATFORM_HOSTNAMES.get('gitlab.com')).toBe('gitlab')
+  })
+
+  it('maps bitbucket.org to bitbucket', () => {
+    expect(PLATFORM_HOSTNAMES.get('bitbucket.org')).toBe('bitbucket')
+  })
+
+  it('maps dev.azure.com to azure-devops', () => {
+    expect(PLATFORM_HOSTNAMES.get('dev.azure.com')).toBe('azure-devops')
+  })
+
+  it('maps visualstudio.com to azure-devops', () => {
+    expect(PLATFORM_HOSTNAMES.get('visualstudio.com')).toBe('azure-devops')
+  })
+
+  it('returns undefined for unknown hostnames', () => {
+    expect(PLATFORM_HOSTNAMES.get('unknown.com')).toBeUndefined()
+  })
+})
+
+describe('detectPlatformFromHostname', () => {
+  describe('exact matches', () => {
+    it('detects github.com', () => {
+      expect(detectPlatformFromHostname('github.com')).toBe('github')
+    })
+
+    it('detects gitlab.com', () => {
+      expect(detectPlatformFromHostname('gitlab.com')).toBe('gitlab')
+    })
+
+    it('detects bitbucket.org', () => {
+      expect(detectPlatformFromHostname('bitbucket.org')).toBe('bitbucket')
+    })
+
+    it('detects dev.azure.com', () => {
+      expect(detectPlatformFromHostname('dev.azure.com')).toBe('azure-devops')
+    })
+
+    it('detects visualstudio.com', () => {
+      expect(detectPlatformFromHostname('visualstudio.com')).toBe('azure-devops')
+    })
+  })
+
+  describe('case insensitivity', () => {
+    it('handles uppercase GitHub.com', () => {
+      expect(detectPlatformFromHostname('GitHub.com')).toBe('github')
+    })
+
+    it('handles mixed case GitLab.COM', () => {
+      expect(detectPlatformFromHostname('GitLab.COM')).toBe('gitlab')
+    })
+  })
+
+  describe('Azure DevOps legacy domains', () => {
+    it('detects org.visualstudio.com', () => {
+      expect(detectPlatformFromHostname('myorg.visualstudio.com')).toBe('azure-devops')
+    })
+
+    it('detects company.visualstudio.com', () => {
+      expect(detectPlatformFromHostname('company.visualstudio.com')).toBe('azure-devops')
+    })
+  })
+
+  describe('self-hosted instances', () => {
+    it('detects GitHub Enterprise (github.company.com)', () => {
+      expect(detectPlatformFromHostname('github.company.com')).toBe('github')
+    })
+
+    it('detects GitHub Enterprise (git.github-internal.com)', () => {
+      expect(detectPlatformFromHostname('git.github-internal.com')).toBe('github')
+    })
+
+    it('detects self-hosted GitLab (gitlab.mycompany.com)', () => {
+      expect(detectPlatformFromHostname('gitlab.mycompany.com')).toBe('gitlab')
+    })
+
+    it('detects self-hosted GitLab (code.gitlab.internal)', () => {
+      expect(detectPlatformFromHostname('code.gitlab.internal')).toBe('gitlab')
+    })
+
+    it('detects Bitbucket Data Center (bitbucket.internal.com)', () => {
+      expect(detectPlatformFromHostname('bitbucket.internal.com')).toBe('bitbucket')
+    })
+  })
+
+  describe('unknown hosts', () => {
+    it('returns unknown for generic git server', () => {
+      expect(detectPlatformFromHostname('git.company.com')).toBe('unknown')
+    })
+
+    it('returns unknown for custom domain', () => {
+      expect(detectPlatformFromHostname('code.internal.net')).toBe('unknown')
+    })
+
+    it('returns unknown for self-hosted Gitea', () => {
+      expect(detectPlatformFromHostname('gitea.company.com')).toBe('unknown')
+    })
+  })
+})

--- a/libs/versioning/src/repository/models/platform.spec.ts
+++ b/libs/versioning/src/repository/models/platform.spec.ts
@@ -95,6 +95,12 @@ describe('detectPlatformFromHostname', () => {
     })
   })
 
+  describe('Azure DevOps SSH domain', () => {
+    it('detects ssh.dev.azure.com', () => {
+      expect(detectPlatformFromHostname('ssh.dev.azure.com')).toBe('azure-devops')
+    })
+  })
+
   describe('self-hosted instances', () => {
     it('detects GitHub Enterprise (github.company.com)', () => {
       expect(detectPlatformFromHostname('github.company.com')).toBe('github')

--- a/libs/versioning/src/repository/models/platform.ts
+++ b/libs/versioning/src/repository/models/platform.ts
@@ -89,6 +89,11 @@ export function detectPlatformFromHostname(hostname: string): RepositoryPlatform
     return 'azure-devops'
   }
 
+  // Check for Azure DevOps modern domain pattern (includes ssh.dev.azure.com)
+  if (normalized.endsWith('.azure.com')) {
+    return 'azure-devops'
+  }
+
   // Heuristics for self-hosted instances
   // GitHub Enterprise typically uses "github" in the hostname
   if (normalized.includes('github')) {

--- a/libs/versioning/src/repository/models/platform.ts
+++ b/libs/versioning/src/repository/models/platform.ts
@@ -1,0 +1,109 @@
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+
+/**
+ * Known git hosting platforms with built-in compare URL support.
+ *
+ * Each platform has a specific URL format for compare links:
+ * - `github`: `{baseUrl}/compare/{fromTag}...{toTag}`
+ * - `gitlab`: `{baseUrl}/-/compare/{fromTag}...{toTag}`
+ * - `bitbucket`: `{baseUrl}/compare/{toTag}..{fromTag}` (reversed order)
+ * - `azure-devops`: `{baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}`
+ */
+export type KnownPlatform = 'github' | 'gitlab' | 'bitbucket' | 'azure-devops'
+
+/**
+ * Platform identifier.
+ *
+ * - Known platforms have built-in compare URL formatters
+ * - `custom` requires a custom `formatCompareUrl` function
+ * - `unknown` indicates platform could not be determined (no URL generation)
+ */
+export type RepositoryPlatform = KnownPlatform | 'custom' | 'unknown'
+
+/**
+ * Checks if a platform identifier is a known platform with built-in support.
+ *
+ * @param platform - Platform identifier to check
+ * @returns True if the platform is a known platform
+ *
+ * @example
+ * ```typescript
+ * isKnownPlatform('github')     // true
+ * isKnownPlatform('gitlab')     // true
+ * isKnownPlatform('custom')     // false
+ * isKnownPlatform('unknown')    // false
+ * ```
+ */
+export function isKnownPlatform(platform: RepositoryPlatform): platform is KnownPlatform {
+  return platform === 'github' || platform === 'gitlab' || platform === 'bitbucket' || platform === 'azure-devops'
+}
+
+/**
+ * Known platform hostnames mapped to their platform type.
+ * Used for automatic platform detection from repository URLs.
+ *
+ * Includes both standard SaaS domains and common patterns for self-hosted instances.
+ */
+export const PLATFORM_HOSTNAMES: ReadonlyMap<string, KnownPlatform> = createMap<string, KnownPlatform>([
+  // GitHub
+  ['github.com', 'github'],
+
+  // GitLab
+  ['gitlab.com', 'gitlab'],
+
+  // Bitbucket
+  ['bitbucket.org', 'bitbucket'],
+
+  // Azure DevOps
+  ['dev.azure.com', 'azure-devops'],
+  ['visualstudio.com', 'azure-devops'],
+])
+
+/**
+ * Detects platform from a hostname.
+ *
+ * First checks for exact match in known platforms, then applies heuristics
+ * for self-hosted instances (e.g., `github.company.com` → `github`).
+ *
+ * @param hostname - Hostname to detect platform from (e.g., "github.com")
+ * @returns Detected platform or 'unknown' if not recognized
+ *
+ * @example
+ * ```typescript
+ * detectPlatformFromHostname('github.com')           // 'github'
+ * detectPlatformFromHostname('gitlab.mycompany.com') // 'gitlab'
+ * detectPlatformFromHostname('custom-git.internal')  // 'unknown'
+ * ```
+ */
+export function detectPlatformFromHostname(hostname: string): RepositoryPlatform {
+  const normalized = hostname.toLowerCase()
+
+  // Check exact matches first
+  const exactMatch = PLATFORM_HOSTNAMES.get(normalized)
+  if (exactMatch) {
+    return exactMatch
+  }
+
+  // Check for Azure DevOps legacy domain pattern
+  if (normalized.endsWith('.visualstudio.com')) {
+    return 'azure-devops'
+  }
+
+  // Heuristics for self-hosted instances
+  // GitHub Enterprise typically uses "github" in the hostname
+  if (normalized.includes('github')) {
+    return 'github'
+  }
+
+  // GitLab self-hosted typically uses "gitlab" in the hostname
+  if (normalized.includes('gitlab')) {
+    return 'gitlab'
+  }
+
+  // Bitbucket Data Center/Server might use "bitbucket" in hostname
+  if (normalized.includes('bitbucket')) {
+    return 'bitbucket'
+  }
+
+  return 'unknown'
+}

--- a/libs/versioning/src/repository/models/platform.ts
+++ b/libs/versioning/src/repository/models/platform.ts
@@ -4,10 +4,10 @@ import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
  * Known git hosting platforms with built-in compare URL support.
  *
  * Each platform has a specific URL format for compare links:
- * - `github`: `{baseUrl}/compare/{fromTag}...{toTag}`
- * - `gitlab`: `{baseUrl}/-/compare/{fromTag}...{toTag}`
- * - `bitbucket`: `{baseUrl}/compare/{toTag}..{fromTag}` (reversed order)
- * - `azure-devops`: `{baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}`
+ * - `github`: `{baseUrl}/compare/{fromCommit}...{toCommit}`
+ * - `gitlab`: `{baseUrl}/-/compare/{fromCommit}...{toCommit}`
+ * - `bitbucket`: `{baseUrl}/compare/{toCommit}..{fromCommit}` (reversed order)
+ * - `azure-devops`: `{baseUrl}/compare?version=GT{toCommit}&compareVersion=GT{fromCommit}`
  */
 export type KnownPlatform = 'github' | 'gitlab' | 'bitbucket' | 'azure-devops'
 

--- a/libs/versioning/src/repository/models/repository-config.spec.ts
+++ b/libs/versioning/src/repository/models/repository-config.spec.ts
@@ -1,0 +1,247 @@
+import { createRepositoryConfig, isRepositoryConfig } from './repository-config'
+
+describe('createRepositoryConfig', () => {
+  describe('basic creation', () => {
+    it('creates a GitHub repository config', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+
+      expect(config.platform).toBe('github')
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+      expect(config.formatCompareUrl).toBeUndefined()
+    })
+
+    it('creates a GitLab repository config', () => {
+      const config = createRepositoryConfig({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+      })
+
+      expect(config.platform).toBe('gitlab')
+      expect(config.baseUrl).toBe('https://gitlab.com/group/project')
+    })
+
+    it('creates a Bitbucket repository config', () => {
+      const config = createRepositoryConfig({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.org/owner/repo',
+      })
+
+      expect(config.platform).toBe('bitbucket')
+      expect(config.baseUrl).toBe('https://bitbucket.org/owner/repo')
+    })
+
+    it('creates an Azure DevOps repository config', () => {
+      const config = createRepositoryConfig({
+        platform: 'azure-devops',
+        baseUrl: 'https://dev.azure.com/org/project/_git/repo',
+      })
+
+      expect(config.platform).toBe('azure-devops')
+      expect(config.baseUrl).toBe('https://dev.azure.com/org/project/_git/repo')
+    })
+  })
+
+  describe('URL normalization', () => {
+    it('strips trailing slashes', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo/',
+      })
+
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+    })
+
+    it('strips multiple trailing slashes', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo///',
+      })
+
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+    })
+
+    it('strips .git suffix', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo.git',
+      })
+
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+    })
+
+    it('strips both trailing slash and .git suffix', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo.git/',
+      })
+
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+    })
+
+    it('trims whitespace', () => {
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: '  https://github.com/owner/repo  ',
+      })
+
+      expect(config.baseUrl).toBe('https://github.com/owner/repo')
+    })
+  })
+
+  describe('custom platform', () => {
+    it('creates custom platform with formatter', () => {
+      const formatter = (from: string, to: string) => `https://custom.com/diff/${from}/${to}`
+
+      const config = createRepositoryConfig({
+        platform: 'custom',
+        baseUrl: 'https://custom.com/repo',
+        formatCompareUrl: formatter,
+      })
+
+      expect(config.platform).toBe('custom')
+      expect(config.baseUrl).toBe('https://custom.com/repo')
+      expect(config.formatCompareUrl).toBe(formatter)
+    })
+
+    it('throws error when custom platform has no formatter', () => {
+      expect(() =>
+        createRepositoryConfig({
+          platform: 'custom',
+          baseUrl: 'https://custom.com/repo',
+        })
+      ).toThrow("Repository config with platform 'custom' requires a formatCompareUrl function")
+    })
+  })
+
+  describe('known platform with custom formatter', () => {
+    it('allows custom formatter to override built-in', () => {
+      const customFormatter = (from: string, to: string) => `custom/${from}/${to}`
+
+      const config = createRepositoryConfig({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: customFormatter,
+      })
+
+      expect(config.platform).toBe('github')
+      expect(config.formatCompareUrl).toBe(customFormatter)
+    })
+  })
+
+  describe('unknown platform', () => {
+    it('creates unknown platform config', () => {
+      const config = createRepositoryConfig({
+        platform: 'unknown',
+        baseUrl: 'https://git.internal.com/repo',
+      })
+
+      expect(config.platform).toBe('unknown')
+      expect(config.baseUrl).toBe('https://git.internal.com/repo')
+    })
+  })
+})
+
+describe('isRepositoryConfig', () => {
+  describe('valid configs', () => {
+    it('returns true for minimal config', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 'github',
+          baseUrl: 'https://github.com/owner/repo',
+        })
+      ).toBe(true)
+    })
+
+    it('returns true for config with formatter', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 'custom',
+          baseUrl: 'https://custom.com',
+          formatCompareUrl: () => 'url',
+        })
+      ).toBe(true)
+    })
+
+    it('returns true for config created by factory', () => {
+      const config = createRepositoryConfig({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+      })
+
+      expect(isRepositoryConfig(config)).toBe(true)
+    })
+  })
+
+  describe('invalid values', () => {
+    it('returns false for null', () => {
+      expect(isRepositoryConfig(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isRepositoryConfig(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isRepositoryConfig('github')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isRepositoryConfig(123)).toBe(false)
+    })
+
+    it('returns false for array', () => {
+      expect(isRepositoryConfig(['github', 'https://github.com'])).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(isRepositoryConfig({})).toBe(false)
+    })
+
+    it('returns false when platform is missing', () => {
+      expect(
+        isRepositoryConfig({
+          baseUrl: 'https://github.com/owner/repo',
+        })
+      ).toBe(false)
+    })
+
+    it('returns false when baseUrl is missing', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 'github',
+        })
+      ).toBe(false)
+    })
+
+    it('returns false when platform is not a string', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 123,
+          baseUrl: 'https://github.com/owner/repo',
+        })
+      ).toBe(false)
+    })
+
+    it('returns false when baseUrl is not a string', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 'github',
+          baseUrl: 123,
+        })
+      ).toBe(false)
+    })
+
+    it('returns false when formatCompareUrl is not a function', () => {
+      expect(
+        isRepositoryConfig({
+          platform: 'github',
+          baseUrl: 'https://github.com',
+          formatCompareUrl: 'not-a-function',
+        })
+      ).toBe(false)
+    })
+  })
+})

--- a/libs/versioning/src/repository/models/repository-config.ts
+++ b/libs/versioning/src/repository/models/repository-config.ts
@@ -4,8 +4,8 @@ import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/er
 /**
  * Custom compare URL formatter function.
  *
- * @param fromTag - The source tag for comparison (older version)
- * @param toTag - The target tag for comparison (newer version)
+ * @param fromCommit - The source commit hash for comparison (older version)
+ * @param toCommit - The target commit hash for comparison (newer version)
  * @returns Full compare URL string
  *
  * @example
@@ -14,7 +14,7 @@ import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/er
  *   `https://my-git.internal/diff/${from}/${to}`
  * ```
  */
-export type CompareUrlFormatter = (fromTag: string, toTag: string) => string
+export type CompareUrlFormatter = (fromCommit: string, toCommit: string) => string
 
 /**
  * Repository configuration for compare URL generation.

--- a/libs/versioning/src/repository/models/repository-config.ts
+++ b/libs/versioning/src/repository/models/repository-config.ts
@@ -1,0 +1,193 @@
+import type { RepositoryPlatform } from './platform'
+import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
+
+/**
+ * Custom compare URL formatter function.
+ *
+ * @param fromTag - The source tag for comparison (older version)
+ * @param toTag - The target tag for comparison (newer version)
+ * @returns Full compare URL string
+ *
+ * @example
+ * ```typescript
+ * const formatter: CompareUrlFormatter = (from, to) =>
+ *   `https://my-git.internal/diff/${from}/${to}`
+ * ```
+ */
+export type CompareUrlFormatter = (fromTag: string, toTag: string) => string
+
+/**
+ * Repository configuration for compare URL generation.
+ *
+ * Supports both standard platforms and self-hosted instances.
+ * When using a known platform, compare URLs are generated automatically.
+ * For custom or unknown platforms, provide a `formatCompareUrl` function.
+ *
+ * @example
+ * ```typescript
+ * // GitHub repository
+ * const github: RepositoryConfig = {
+ *   platform: 'github',
+ *   baseUrl: 'https://github.com/owner/repo'
+ * }
+ *
+ * // Self-hosted GitLab
+ * const gitlabSelfHosted: RepositoryConfig = {
+ *   platform: 'gitlab',
+ *   baseUrl: 'https://gitlab.mycompany.com/team/project'
+ * }
+ *
+ * // Custom platform with formatter
+ * const custom: RepositoryConfig = {
+ *   platform: 'custom',
+ *   baseUrl: 'https://custom-git.internal/repo',
+ *   formatCompareUrl: (from, to) => `https://custom-git.internal/diff/${from}/${to}`
+ * }
+ * ```
+ */
+export interface RepositoryConfig {
+  /**
+   * Platform type - determines URL format for known platforms.
+   */
+  readonly platform: RepositoryPlatform
+
+  /**
+   * Base URL for the repository.
+   *
+   * This is the URL without any trailing slashes or paths like `/compare`.
+   *
+   * @example
+   * - GitHub: `"https://github.com/owner/repo"`
+   * - GitLab: `"https://gitlab.com/group/project"`
+   * - Azure DevOps: `"https://dev.azure.com/org/project/_git/repo"`
+   */
+  readonly baseUrl: string
+
+  /**
+   * Custom compare URL formatter.
+   *
+   * Required when `platform` is `'custom'`.
+   * Optional for known platforms (overrides built-in formatter).
+   *
+   * Receives the from and to tags, returns the full compare URL.
+   */
+  readonly formatCompareUrl?: CompareUrlFormatter
+}
+
+/**
+ * Options for creating a repository config.
+ */
+export interface CreateRepositoryConfigOptions {
+  /**
+   * Platform type - determines URL format for known platforms.
+   */
+  readonly platform: RepositoryPlatform
+
+  /**
+   * Base URL for the repository.
+   * Trailing slashes will be automatically stripped.
+   */
+  readonly baseUrl: string
+
+  /**
+   * Custom compare URL formatter.
+   * Required when platform is 'custom'.
+   */
+  readonly formatCompareUrl?: CompareUrlFormatter
+}
+
+/**
+ * Creates a new RepositoryConfig.
+ *
+ * Normalizes the base URL by stripping trailing slashes and validating
+ * that custom platforms have a formatter function.
+ *
+ * @param options - Repository configuration options
+ * @returns A new RepositoryConfig object
+ * @throws {Error} if platform is 'custom' but no formatCompareUrl is provided
+ *
+ * @example
+ * ```typescript
+ * // GitHub repository
+ * const config = createRepositoryConfig({
+ *   platform: 'github',
+ *   baseUrl: 'https://github.com/owner/repo'
+ * })
+ *
+ * // Custom platform
+ * const customConfig = createRepositoryConfig({
+ *   platform: 'custom',
+ *   baseUrl: 'https://my-git.internal/repo',
+ *   formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`
+ * })
+ * ```
+ */
+export function createRepositoryConfig(options: CreateRepositoryConfigOptions): RepositoryConfig {
+  const { platform, formatCompareUrl } = options
+
+  // Validate custom platform has formatter
+  if (platform === 'custom' && !formatCompareUrl) {
+    throw createError("Repository config with platform 'custom' requires a formatCompareUrl function")
+  }
+
+  // Normalize base URL - strip trailing slashes
+  const baseUrl = normalizeBaseUrl(options.baseUrl)
+
+  return {
+    platform,
+    baseUrl,
+    formatCompareUrl,
+  }
+}
+
+/**
+ * Checks if a value is a RepositoryConfig object.
+ *
+ * @param value - Value to check
+ * @returns True if the value is a RepositoryConfig
+ *
+ * @example
+ * ```typescript
+ * const config = { platform: 'github', baseUrl: 'https://...' }
+ * if (isRepositoryConfig(config)) {
+ *   // config is typed as RepositoryConfig
+ * }
+ * ```
+ */
+export function isRepositoryConfig(value: unknown): value is RepositoryConfig {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = <Record<string, unknown>>value
+
+  return (
+    typeof obj['platform'] === 'string' &&
+    typeof obj['baseUrl'] === 'string' &&
+    (obj['formatCompareUrl'] === undefined || typeof obj['formatCompareUrl'] === 'function')
+  )
+}
+
+/**
+ * Normalizes a base URL by stripping trailing slashes and .git suffix.
+ *
+ * @param url - URL to normalize
+ * @returns Normalized URL
+ *
+ * @internal
+ */
+function normalizeBaseUrl(url: string): string {
+  let normalized = url.trim()
+
+  // Remove trailing slashes
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1)
+  }
+
+  // Remove .git suffix if present
+  if (normalized.endsWith('.git')) {
+    normalized = normalized.slice(0, -4)
+  }
+
+  return normalized
+}

--- a/libs/versioning/src/repository/models/resolution.spec.ts
+++ b/libs/versioning/src/repository/models/resolution.spec.ts
@@ -1,0 +1,186 @@
+import {
+  createDisabledResolution,
+  createExplicitResolution,
+  createInferredResolution,
+  isRepositoryResolution,
+  DEFAULT_INFERENCE_ORDER,
+} from './resolution'
+
+describe('createDisabledResolution', () => {
+  it('creates a disabled resolution', () => {
+    const resolution = createDisabledResolution()
+
+    expect(resolution.mode).toBe('disabled')
+    expect(resolution.repository).toBeUndefined()
+    expect(resolution.inferenceOrder).toBeUndefined()
+  })
+})
+
+describe('createExplicitResolution', () => {
+  it('creates an explicit resolution with repository config', () => {
+    const repository = <const>{
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    }
+
+    const resolution = createExplicitResolution(repository)
+
+    expect(resolution.mode).toBe('explicit')
+    expect(resolution.repository).toBe(repository)
+    expect(resolution.inferenceOrder).toBeUndefined()
+  })
+
+  it('preserves the repository config exactly', () => {
+    const formatter = (from: string, to: string) => `${from}-${to}`
+    const repository = <const>{
+      platform: 'custom',
+      baseUrl: 'https://custom.com',
+      formatCompareUrl: formatter,
+    }
+
+    const resolution = createExplicitResolution(repository)
+
+    expect(resolution.repository?.platform).toBe('custom')
+    expect(resolution.repository?.formatCompareUrl).toBe(formatter)
+  })
+})
+
+describe('createInferredResolution', () => {
+  it('creates an inferred resolution with default order', () => {
+    const resolution = createInferredResolution()
+
+    expect(resolution.mode).toBe('inferred')
+    expect(resolution.inferenceOrder).toEqual(['package-json', 'git-remote'])
+    expect(resolution.repository).toBeUndefined()
+  })
+
+  it('creates an inferred resolution with custom order', () => {
+    const resolution = createInferredResolution(['git-remote', 'package-json'])
+
+    expect(resolution.mode).toBe('inferred')
+    expect(resolution.inferenceOrder).toEqual(['git-remote', 'package-json'])
+  })
+
+  it('accepts single source order', () => {
+    const resolution = createInferredResolution(['package-json'])
+
+    expect(resolution.inferenceOrder).toEqual(['package-json'])
+  })
+
+  it('accepts git-remote only', () => {
+    const resolution = createInferredResolution(['git-remote'])
+
+    expect(resolution.inferenceOrder).toEqual(['git-remote'])
+  })
+})
+
+describe('DEFAULT_INFERENCE_ORDER', () => {
+  it('has package-json first', () => {
+    expect(DEFAULT_INFERENCE_ORDER[0]).toBe('package-json')
+  })
+
+  it('has git-remote second', () => {
+    expect(DEFAULT_INFERENCE_ORDER[1]).toBe('git-remote')
+  })
+
+  it('has exactly 2 sources', () => {
+    expect(DEFAULT_INFERENCE_ORDER).toHaveLength(2)
+  })
+})
+
+describe('isRepositoryResolution', () => {
+  describe('valid resolutions', () => {
+    it('returns true for disabled mode', () => {
+      expect(isRepositoryResolution({ mode: 'disabled' })).toBe(true)
+    })
+
+    it('returns true for explicit mode', () => {
+      expect(
+        isRepositoryResolution({
+          mode: 'explicit',
+          repository: { platform: 'github', baseUrl: 'https://github.com/o/r' },
+        })
+      ).toBe(true)
+    })
+
+    it('returns true for inferred mode', () => {
+      expect(
+        isRepositoryResolution({
+          mode: 'inferred',
+          inferenceOrder: ['package-json'],
+        })
+      ).toBe(true)
+    })
+
+    it('returns true for resolution created by createDisabledResolution', () => {
+      expect(isRepositoryResolution(createDisabledResolution())).toBe(true)
+    })
+
+    it('returns true for resolution created by createExplicitResolution', () => {
+      const resolution = createExplicitResolution({
+        platform: 'github',
+        baseUrl: 'https://github.com/o/r',
+      })
+      expect(isRepositoryResolution(resolution)).toBe(true)
+    })
+
+    it('returns true for resolution created by createInferredResolution', () => {
+      expect(isRepositoryResolution(createInferredResolution())).toBe(true)
+    })
+
+    it('returns true for explicit mode without repository', () => {
+      // Type system prevents this, but runtime check should handle it
+      expect(isRepositoryResolution({ mode: 'explicit' })).toBe(true)
+    })
+
+    it('returns true for inferred mode without inferenceOrder', () => {
+      expect(isRepositoryResolution({ mode: 'inferred' })).toBe(true)
+    })
+  })
+
+  describe('invalid values', () => {
+    it('returns false for null', () => {
+      expect(isRepositoryResolution(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isRepositoryResolution(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isRepositoryResolution('disabled')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isRepositoryResolution(123)).toBe(false)
+    })
+
+    it('returns false for array', () => {
+      expect(isRepositoryResolution(['disabled'])).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(isRepositoryResolution({})).toBe(false)
+    })
+
+    it('returns false for object without mode', () => {
+      expect(
+        isRepositoryResolution({
+          repository: { platform: 'github', baseUrl: 'https://...' },
+        })
+      ).toBe(false)
+    })
+
+    it('returns false for invalid mode value', () => {
+      expect(isRepositoryResolution({ mode: 'auto' })).toBe(false)
+    })
+
+    it('returns false for mode as number', () => {
+      expect(isRepositoryResolution({ mode: 1 })).toBe(false)
+    })
+
+    it('returns false for mode as null', () => {
+      expect(isRepositoryResolution({ mode: null })).toBe(false)
+    })
+  })
+})

--- a/libs/versioning/src/repository/models/resolution.ts
+++ b/libs/versioning/src/repository/models/resolution.ts
@@ -1,0 +1,153 @@
+import type { RepositoryConfig } from './repository-config'
+
+/**
+ * How to resolve repository information for compare URLs.
+ *
+ * - `explicit`: Use only the provided `RepositoryConfig`; error if missing
+ * - `inferred`: Auto-detect from package.json repository field or git remote
+ * - `disabled`: Do not generate compare URLs (default for backward compatibility)
+ */
+export type RepositoryResolutionMode = 'explicit' | 'inferred' | 'disabled'
+
+/**
+ * Sources for repository inference, in order of preference.
+ *
+ * - `package-json`: Read from `repository` field in package.json
+ * - `git-remote`: Read from `git remote get-url origin`
+ */
+export type RepositoryInferenceSource = 'package-json' | 'git-remote'
+
+/**
+ * Full repository resolution configuration.
+ *
+ * Provides fine-grained control over repository resolution behavior.
+ *
+ * @example
+ * ```typescript
+ * // Explicit configuration - must provide repository
+ * const explicit: RepositoryResolution = {
+ *   mode: 'explicit',
+ *   repository: {
+ *     platform: 'github',
+ *     baseUrl: 'https://github.com/owner/repo'
+ *   }
+ * }
+ *
+ * // Auto-detection with custom order
+ * const inferred: RepositoryResolution = {
+ *   mode: 'inferred',
+ *   inferenceOrder: ['git-remote', 'package-json']  // Try git first
+ * }
+ *
+ * // Disabled
+ * const disabled: RepositoryResolution = {
+ *   mode: 'disabled'
+ * }
+ * ```
+ */
+export interface RepositoryResolution {
+  /**
+   * Resolution mode.
+   */
+  readonly mode: RepositoryResolutionMode
+
+  /**
+   * Explicit repository config.
+   *
+   * Required when `mode` is `'explicit'`.
+   * Ignored when `mode` is `'inferred'` or `'disabled'`.
+   */
+  readonly repository?: RepositoryConfig
+
+  /**
+   * Inference source order when `mode` is `'inferred'`.
+   *
+   * Sources are tried in order until one succeeds.
+   * Default: `['package-json', 'git-remote']`
+   */
+  readonly inferenceOrder?: readonly RepositoryInferenceSource[]
+}
+
+/**
+ * Creates a disabled repository resolution configuration.
+ *
+ * No compare URLs will be generated.
+ *
+ * @returns A RepositoryResolution with mode 'disabled'
+ *
+ * @example
+ * ```typescript
+ * const config = createDisabledResolution()
+ * // { mode: 'disabled' }
+ * ```
+ */
+export function createDisabledResolution(): RepositoryResolution {
+  return { mode: 'disabled' }
+}
+
+/**
+ * Creates an explicit repository resolution configuration.
+ *
+ * @param repository - The repository config to use
+ * @returns A RepositoryResolution with mode 'explicit'
+ *
+ * @example
+ * ```typescript
+ * const config = createExplicitResolution({
+ *   platform: 'github',
+ *   baseUrl: 'https://github.com/owner/repo'
+ * })
+ * ```
+ */
+export function createExplicitResolution(repository: RepositoryConfig): RepositoryResolution {
+  return {
+    mode: 'explicit',
+    repository,
+  }
+}
+
+/**
+ * Creates an inferred repository resolution configuration.
+ *
+ * @param inferenceOrder - Order to try inference sources (default: package-json first)
+ * @returns A RepositoryResolution with mode 'inferred'
+ *
+ * @example
+ * ```typescript
+ * // Default order: package.json → git remote
+ * const config = createInferredResolution()
+ *
+ * // Custom order: git remote → package.json
+ * const customOrder = createInferredResolution(['git-remote', 'package-json'])
+ * ```
+ */
+export function createInferredResolution(
+  inferenceOrder: readonly RepositoryInferenceSource[] = ['package-json', 'git-remote']
+): RepositoryResolution {
+  return {
+    mode: 'inferred',
+    inferenceOrder,
+  }
+}
+
+/**
+ * Checks if a value is a RepositoryResolution object.
+ *
+ * @param value - Value to check
+ * @returns True if the value is a RepositoryResolution
+ */
+export function isRepositoryResolution(value: unknown): value is RepositoryResolution {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = <Record<string, unknown>>value
+  const mode = obj['mode']
+
+  return mode === 'explicit' || mode === 'inferred' || mode === 'disabled'
+}
+
+/**
+ * Default inference order when mode is 'inferred'.
+ */
+export const DEFAULT_INFERENCE_ORDER: readonly RepositoryInferenceSource[] = ['package-json', 'git-remote']

--- a/libs/versioning/src/repository/parse/index.ts
+++ b/libs/versioning/src/repository/parse/index.ts
@@ -1,0 +1,4 @@
+export type { ParsedRepository } from './url'
+export type { PackageJsonRepository, PackageJsonForRepository } from './package-json'
+export { parseRepositoryUrl, createRepositoryConfigFromUrl } from './url'
+export { inferRepositoryFromPackageJson, inferRepositoryFromPackageJsonObject, extractRepositoryUrl } from './package-json'

--- a/libs/versioning/src/repository/parse/package-json.spec.ts
+++ b/libs/versioning/src/repository/parse/package-json.spec.ts
@@ -1,0 +1,355 @@
+import { inferRepositoryFromPackageJson, inferRepositoryFromPackageJsonObject, extractRepositoryUrl } from './package-json'
+
+describe('inferRepositoryFromPackageJson', () => {
+  describe('shorthand formats', () => {
+    it('parses github shorthand', () => {
+      const content = JSON.stringify({ repository: 'github:owner/repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses gitlab shorthand', () => {
+      const content = JSON.stringify({ repository: 'gitlab:group/project' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses bitbucket shorthand', () => {
+      const content = JSON.stringify({ repository: 'bitbucket:team/repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.org/team/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('handles case-insensitive platform prefix', () => {
+      const content = JSON.stringify({ repository: 'GitHub:Owner/Repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/Owner/Repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('returns null for unknown shorthand platform', () => {
+      const content = JSON.stringify({ repository: 'unknown:owner/repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toBeNull()
+    })
+  })
+
+  describe('bare shorthand (defaults to GitHub)', () => {
+    it('parses owner/repo format as GitHub', () => {
+      const content = JSON.stringify({ repository: 'owner/repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses complex owner/repo names', () => {
+      const content = JSON.stringify({ repository: 'my-org/my-awesome-repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/my-org/my-awesome-repo',
+        formatCompareUrl: undefined,
+      })
+    })
+  })
+
+  describe('URL string format', () => {
+    it('parses https URL', () => {
+      const content = JSON.stringify({ repository: 'https://github.com/owner/repo' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses git+https URL', () => {
+      const content = JSON.stringify({ repository: 'git+https://github.com/owner/repo.git' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses SSH URL', () => {
+      const content = JSON.stringify({ repository: 'git@github.com:owner/repo.git' })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+  })
+
+  describe('object format', () => {
+    it('parses object with type and url', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'https://github.com/owner/repo',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses object with git+https url', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'git+https://github.com/owner/repo.git',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('parses object with SSH url', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'git@gitlab.com:group/project.git',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+        formatCompareUrl: undefined,
+      })
+    })
+
+    it('ignores directory field', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'https://github.com/owner/monorepo',
+          directory: 'packages/my-package',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/monorepo',
+        formatCompareUrl: undefined,
+      })
+    })
+  })
+
+  describe('multiple platforms', () => {
+    it('handles GitLab', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'https://gitlab.com/group/project',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config?.platform).toBe('gitlab')
+    })
+
+    it('handles Bitbucket', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'https://bitbucket.org/team/repo',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config?.platform).toBe('bitbucket')
+    })
+
+    it('handles Azure DevOps', () => {
+      const content = JSON.stringify({
+        repository: {
+          type: 'git',
+          url: 'https://dev.azure.com/org/project/_git/repo',
+        },
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config?.platform).toBe('azure-devops')
+    })
+
+    it('handles self-hosted GitLab', () => {
+      const content = JSON.stringify({
+        repository: 'https://gitlab.company.com/team/project',
+      })
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config?.platform).toBe('gitlab')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null for empty string', () => {
+      expect(inferRepositoryFromPackageJson('')).toBeNull()
+    })
+
+    it('returns null for invalid JSON', () => {
+      expect(inferRepositoryFromPackageJson('not json')).toBeNull()
+    })
+
+    it('returns null for missing repository field', () => {
+      const content = JSON.stringify({ name: 'my-package' })
+      expect(inferRepositoryFromPackageJson(content)).toBeNull()
+    })
+
+    it('returns null for empty repository field', () => {
+      const content = JSON.stringify({ repository: '' })
+      expect(inferRepositoryFromPackageJson(content)).toBeNull()
+    })
+
+    it('returns null for null repository field', () => {
+      const content = JSON.stringify({ repository: null })
+      expect(inferRepositoryFromPackageJson(content)).toBeNull()
+    })
+
+    it('returns null for unknown platform', () => {
+      const content = JSON.stringify({
+        repository: 'https://custom-git.internal/team/project',
+      })
+      expect(inferRepositoryFromPackageJson(content)).toBeNull()
+    })
+
+    it('returns null for object without url', () => {
+      const content = JSON.stringify({
+        repository: { type: 'git' },
+      })
+      expect(inferRepositoryFromPackageJson(content)).toBeNull()
+    })
+
+    it('handles whitespace in content', () => {
+      const content = `  ${JSON.stringify({ repository: 'github:owner/repo' })}  `
+      const config = inferRepositoryFromPackageJson(content)
+      expect(config).toBeTruthy()
+    })
+
+    it('returns null for null content', () => {
+      expect(inferRepositoryFromPackageJson(null as never)).toBeNull()
+    })
+
+    it('returns null for undefined content', () => {
+      expect(inferRepositoryFromPackageJson(undefined as never)).toBeNull()
+    })
+  })
+})
+
+describe('inferRepositoryFromPackageJsonObject', () => {
+  it('parses string repository', () => {
+    const config = inferRepositoryFromPackageJsonObject({ repository: 'github:owner/repo' })
+    expect(config).toEqual({
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('parses object repository', () => {
+    const config = inferRepositoryFromPackageJsonObject({
+      repository: { type: 'git', url: 'https://github.com/owner/repo' },
+    })
+    expect(config).toEqual({
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('returns null for missing repository', () => {
+    expect(inferRepositoryFromPackageJsonObject({})).toBeNull()
+  })
+
+  it('returns null for undefined repository', () => {
+    expect(inferRepositoryFromPackageJsonObject({ repository: undefined })).toBeNull()
+  })
+})
+
+describe('extractRepositoryUrl', () => {
+  describe('object format', () => {
+    it('extracts URL from object', () => {
+      const content = JSON.stringify({
+        repository: { type: 'git', url: 'https://github.com/owner/repo' },
+      })
+      expect(extractRepositoryUrl(content)).toBe('https://github.com/owner/repo')
+    })
+
+    it('extracts and normalizes git+https URL', () => {
+      const content = JSON.stringify({
+        repository: { url: 'git+https://github.com/owner/repo.git' },
+      })
+      expect(extractRepositoryUrl(content)).toBe('https://github.com/owner/repo')
+    })
+  })
+
+  describe('string format', () => {
+    it('extracts https URL', () => {
+      const content = JSON.stringify({ repository: 'https://github.com/owner/repo' })
+      expect(extractRepositoryUrl(content)).toBe('https://github.com/owner/repo')
+    })
+
+    it('expands shorthand to URL', () => {
+      const content = JSON.stringify({ repository: 'github:owner/repo' })
+      expect(extractRepositoryUrl(content)).toBe('https://github.com/owner/repo')
+    })
+
+    it('expands bare shorthand to URL', () => {
+      const content = JSON.stringify({ repository: 'owner/repo' })
+      expect(extractRepositoryUrl(content)).toBe('https://github.com/owner/repo')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null for empty content', () => {
+      expect(extractRepositoryUrl('')).toBeNull()
+    })
+
+    it('returns null for missing repository', () => {
+      expect(extractRepositoryUrl(JSON.stringify({}))).toBeNull()
+    })
+
+    it('returns null for invalid JSON', () => {
+      expect(extractRepositoryUrl('not json')).toBeNull()
+    })
+
+    it('returns null for unknown platform', () => {
+      const content = JSON.stringify({ repository: 'https://custom.internal/team/project' })
+      expect(extractRepositoryUrl(content)).toBeNull()
+    })
+
+    it('returns null for object with unknown platform URL', () => {
+      const content = JSON.stringify({
+        repository: { type: 'git', url: 'https://custom.internal/team/project' },
+      })
+      expect(extractRepositoryUrl(content)).toBeNull()
+    })
+  })
+})

--- a/libs/versioning/src/repository/parse/package-json.ts
+++ b/libs/versioning/src/repository/parse/package-json.ts
@@ -1,0 +1,280 @@
+import type { RepositoryConfig } from '../models/repository-config'
+import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+import { createRepositoryConfigFromUrl, parseRepositoryUrl } from './url'
+
+/**
+ * Repository field formats from package.json.
+ *
+ * Package.json supports multiple formats for the repository field:
+ * - Shorthand: `"github:owner/repo"`
+ * - URL string: `"https://github.com/owner/repo"`
+ * - Object: `{ "type": "git", "url": "..." }`
+ */
+export interface PackageJsonRepository {
+  /**
+   * Repository type (typically "git").
+   */
+  readonly type?: string
+
+  /**
+   * Repository URL.
+   */
+  readonly url: string
+
+  /**
+   * Directory within the repository (for monorepos).
+   */
+  readonly directory?: string
+}
+
+/**
+ * Minimal package.json structure for repository inference.
+ */
+export interface PackageJsonForRepository {
+  /**
+   * Repository field - can be a string or object.
+   */
+  readonly repository?: string | PackageJsonRepository
+}
+
+/**
+ * Shorthand platform prefixes supported in package.json repository field.
+ *
+ * Format: `"platform:owner/repo"` or `"owner/repo"` (defaults to GitHub)
+ *
+ * @see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository
+ */
+const SHORTHAND_PLATFORMS: ReadonlyMap<string, string> = createMap([
+  ['github', 'https://github.com'],
+  ['gitlab', 'https://gitlab.com'],
+  ['bitbucket', 'https://bitbucket.org'],
+  ['gist', 'https://gist.github.com'],
+])
+
+/**
+ * Infers repository configuration from package.json content.
+ *
+ * Handles multiple formats:
+ * - Shorthand: `"github:owner/repo"`, `"gitlab:group/project"`, `"bitbucket:team/repo"`
+ * - Bare shorthand: `"owner/repo"` (defaults to GitHub)
+ * - URL string: `"https://github.com/owner/repo"`
+ * - Object with URL: `{ "type": "git", "url": "https://..." }`
+ *
+ * @param packageJsonContent - Raw JSON string content of package.json
+ * @returns RepositoryConfig or null if repository cannot be inferred
+ *
+ * @example
+ * ```typescript
+ * // Shorthand format
+ * inferRepositoryFromPackageJson('{"repository": "github:owner/repo"}')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * // URL string
+ * inferRepositoryFromPackageJson('{"repository": "https://github.com/owner/repo"}')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * // Object format
+ * inferRepositoryFromPackageJson('{"repository": {"type": "git", "url": "https://github.com/owner/repo"}}')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * // Bare shorthand (defaults to GitHub)
+ * inferRepositoryFromPackageJson('{"repository": "owner/repo"}')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ * ```
+ */
+export function inferRepositoryFromPackageJson(packageJsonContent: string): RepositoryConfig | null {
+  if (!packageJsonContent || typeof packageJsonContent !== 'string') {
+    return null
+  }
+
+  let packageJson: PackageJsonForRepository
+  try {
+    packageJson = parse(packageJsonContent)
+  } catch {
+    return null
+  }
+
+  return inferRepositoryFromPackageJsonObject(packageJson)
+}
+
+/**
+ * Infers repository configuration from a parsed package.json object.
+ *
+ * This is useful when you already have the parsed object.
+ *
+ * @param packageJson - Parsed package.json object
+ * @returns RepositoryConfig or null if repository cannot be inferred
+ *
+ * @example
+ * ```typescript
+ * const pkg = { repository: 'github:owner/repo' }
+ * inferRepositoryFromPackageJsonObject(pkg)
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ * ```
+ */
+export function inferRepositoryFromPackageJsonObject(packageJson: PackageJsonForRepository): RepositoryConfig | null {
+  const { repository } = packageJson
+
+  if (!repository) {
+    return null
+  }
+
+  // Handle string format
+  if (typeof repository === 'string') {
+    return parseRepositoryString(repository)
+  }
+
+  // Handle object format
+  if (typeof repository === 'object' && repository.url) {
+    return createRepositoryConfigFromUrl(repository.url)
+  }
+
+  return null
+}
+
+/**
+ * Parses a repository string (shorthand or URL).
+ *
+ * @param repoString - Repository string from package.json
+ * @returns RepositoryConfig or null
+ *
+ * @internal
+ */
+function parseRepositoryString(repoString: string): RepositoryConfig | null {
+  const trimmed = repoString.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  // Check for shorthand format: platform:owner/repo
+  const colonIndex = trimmed.indexOf(':')
+  if (colonIndex > 0) {
+    const potentialPlatform = trimmed.slice(0, colonIndex)
+    // Platform must be only letters (a-z, case insensitive)
+    if (isOnlyLetters(potentialPlatform)) {
+      const platform = potentialPlatform.toLowerCase()
+      const path = trimmed.slice(colonIndex + 1)
+
+      if (path) {
+        const baseUrl = SHORTHAND_PLATFORMS.get(platform)
+        if (baseUrl) {
+          // Construct full URL and parse it
+          const fullUrl = `${baseUrl}/${path}`
+          return createRepositoryConfigFromUrl(fullUrl)
+        }
+
+        // Unknown shorthand platform - try as URL
+        return createRepositoryConfigFromUrl(trimmed)
+      }
+    }
+  }
+
+  // Check for bare shorthand: owner/repo (no protocol, no platform prefix)
+  // Must match pattern like "owner/repo" but not "https://..." or "git@..."
+  if (!trimmed.includes('://') && !trimmed.startsWith('git@')) {
+    if (isBareShorthand(trimmed)) {
+      // Bare shorthand defaults to GitHub
+      const fullUrl = `https://github.com/${trimmed}`
+      return createRepositoryConfigFromUrl(fullUrl)
+    }
+  }
+
+  // Try as a full URL
+  return createRepositoryConfigFromUrl(trimmed)
+}
+
+/**
+ * Checks if a string contains only ASCII letters (a-z, A-Z).
+ *
+ * @param str - String to check
+ * @returns True if string contains only letters
+ *
+ * @internal
+ */
+function isOnlyLetters(str: string): boolean {
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    const isLowercase = char >= 97 && char <= 122 // a-z
+    const isUppercase = char >= 65 && char <= 90 // A-Z
+    if (!isLowercase && !isUppercase) {
+      return false
+    }
+  }
+  return str.length > 0
+}
+
+/**
+ * Checks if a string is a bare shorthand format (owner/repo).
+ * Must have exactly one forward slash with content on both sides.
+ *
+ * @param str - String to check
+ * @returns True if string matches owner/repo format
+ *
+ * @internal
+ */
+function isBareShorthand(str: string): boolean {
+  const slashIndex = str.indexOf('/')
+  if (slashIndex <= 0 || slashIndex === str.length - 1) {
+    return false
+  }
+  // Must not have another slash
+  return str.indexOf('/', slashIndex + 1) === -1
+}
+
+/**
+ * Extracts the repository URL from package.json content.
+ *
+ * Unlike `inferRepositoryFromPackageJson`, this returns just the URL string
+ * without creating a RepositoryConfig. Useful when you need the raw URL.
+ *
+ * @param packageJsonContent - Raw JSON string content of package.json
+ * @returns Repository URL string or null if not found
+ *
+ * @example
+ * ```typescript
+ * extractRepositoryUrl('{"repository": {"url": "https://github.com/owner/repo"}}')
+ * // → 'https://github.com/owner/repo'
+ *
+ * extractRepositoryUrl('{"repository": "github:owner/repo"}')
+ * // → null (shorthand is not a URL)
+ * ```
+ */
+export function extractRepositoryUrl(packageJsonContent: string): string | null {
+  if (!packageJsonContent || typeof packageJsonContent !== 'string') {
+    return null
+  }
+
+  let packageJson: PackageJsonForRepository
+  try {
+    packageJson = parse(packageJsonContent)
+  } catch {
+    return null
+  }
+
+  const { repository } = packageJson
+
+  if (!repository) {
+    return null
+  }
+
+  // String URL format
+  if (typeof repository === 'string') {
+    // Check if it's a URL (has protocol)
+    if (repository.includes('://') || repository.startsWith('git@')) {
+      const parsed = parseRepositoryUrl(repository)
+      return parsed && parsed.platform !== 'unknown' ? parsed.baseUrl : null
+    }
+    // Shorthand - need to expand
+    const config = parseRepositoryString(repository)
+    return config ? config.baseUrl : null
+  }
+
+  // Object format
+  if (typeof repository === 'object' && repository.url) {
+    const parsed = parseRepositoryUrl(repository.url)
+    return parsed && parsed.platform !== 'unknown' ? parsed.baseUrl : null
+  }
+
+  return null
+}

--- a/libs/versioning/src/repository/parse/url.spec.ts
+++ b/libs/versioning/src/repository/parse/url.spec.ts
@@ -1,0 +1,349 @@
+import { parseRepositoryUrl, createRepositoryConfigFromUrl } from './url'
+
+describe('parseRepositoryUrl', () => {
+  describe('GitHub URLs', () => {
+    it('parses https URL', () => {
+      const result = parseRepositoryUrl('https://github.com/owner/repo')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses https URL with .git suffix', () => {
+      const result = parseRepositoryUrl('https://github.com/owner/repo.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses git+https URL', () => {
+      const result = parseRepositoryUrl('git+https://github.com/owner/repo.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses git:// URL', () => {
+      const result = parseRepositoryUrl('git://github.com/owner/repo.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses SSH URL', () => {
+      const result = parseRepositoryUrl('git@github.com:owner/repo.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses SSH URL without .git suffix', () => {
+      const result = parseRepositoryUrl('git@github.com:owner/repo')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('parses ssh:// URL', () => {
+      const result = parseRepositoryUrl('ssh://git@github.com/owner/repo.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('handles trailing slashes', () => {
+      const result = parseRepositoryUrl('https://github.com/owner/repo/')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+  })
+
+  describe('GitLab URLs', () => {
+    it('parses https URL', () => {
+      const result = parseRepositoryUrl('https://gitlab.com/group/project')
+      expect(result).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+      })
+    })
+
+    it('parses nested group URL', () => {
+      const result = parseRepositoryUrl('https://gitlab.com/group/subgroup/project')
+      expect(result).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/subgroup/project',
+      })
+    })
+
+    it('parses SSH URL', () => {
+      const result = parseRepositoryUrl('git@gitlab.com:group/project.git')
+      expect(result).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+      })
+    })
+
+    it('parses git+https URL', () => {
+      const result = parseRepositoryUrl('git+https://gitlab.com/group/project.git')
+      expect(result).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/project',
+      })
+    })
+  })
+
+  describe('Bitbucket URLs', () => {
+    it('parses https URL', () => {
+      const result = parseRepositoryUrl('https://bitbucket.org/owner/repo')
+      expect(result).toEqual({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.org/owner/repo',
+      })
+    })
+
+    it('parses SSH URL', () => {
+      const result = parseRepositoryUrl('git@bitbucket.org:owner/repo.git')
+      expect(result).toEqual({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.org/owner/repo',
+      })
+    })
+
+    it('parses git+https URL', () => {
+      const result = parseRepositoryUrl('git+https://bitbucket.org/team/project.git')
+      expect(result).toEqual({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.org/team/project',
+      })
+    })
+  })
+
+  describe('Azure DevOps URLs', () => {
+    it('parses dev.azure.com URL', () => {
+      const result = parseRepositoryUrl('https://dev.azure.com/org/project/_git/repo')
+      expect(result).toEqual({
+        platform: 'azure-devops',
+        baseUrl: 'https://dev.azure.com/org/project/_git/repo',
+      })
+    })
+
+    it('parses visualstudio.com URL and normalizes to dev.azure.com', () => {
+      const result = parseRepositoryUrl('https://myorg.visualstudio.com/MyProject/_git/MyRepo')
+      expect(result).toEqual({
+        platform: 'azure-devops',
+        baseUrl: 'https://dev.azure.com/myorg/MyProject/_git/MyRepo',
+      })
+    })
+
+    it('parses Azure DevOps SSH URL', () => {
+      const result = parseRepositoryUrl('git@ssh.dev.azure.com:v3/org/project/repo')
+      expect(result).toEqual({
+        platform: 'azure-devops',
+        baseUrl: 'https://dev.azure.com/org/project/_git/repo',
+      })
+    })
+
+    it('returns null for incomplete Azure DevOps URL', () => {
+      const result = parseRepositoryUrl('https://dev.azure.com/org')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for Azure DevOps URL without _git segment', () => {
+      const result = parseRepositoryUrl('https://dev.azure.com/org/project/repo')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for visualstudio.com URL without _git segment', () => {
+      const result = parseRepositoryUrl('https://myorg.visualstudio.com/MyProject/browse')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for Azure DevOps SSH with incomplete v3 path', () => {
+      const result = parseRepositoryUrl('git@ssh.dev.azure.com:v3/org')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for Azure DevOps URL with _git but invalid structure', () => {
+      // _git at index 1, but gitIndex must be >= 2
+      const result = parseRepositoryUrl('https://dev.azure.com/org/_git/repo')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('self-hosted instances', () => {
+    it('detects GitHub Enterprise', () => {
+      const result = parseRepositoryUrl('https://github.mycompany.com/team/project')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.mycompany.com/team/project',
+      })
+    })
+
+    it('detects GitLab self-hosted', () => {
+      const result = parseRepositoryUrl('https://gitlab.internal.com/group/project')
+      expect(result).toEqual({
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.internal.com/group/project',
+      })
+    })
+
+    it('detects Bitbucket Server', () => {
+      const result = parseRepositoryUrl('https://bitbucket.company.com/scm/team/repo')
+      expect(result).toEqual({
+        platform: 'bitbucket',
+        baseUrl: 'https://bitbucket.company.com/scm/team/repo',
+      })
+    })
+
+    it('detects GitHub Enterprise SSH', () => {
+      const result = parseRepositoryUrl('git@github.enterprise.com:team/project.git')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.enterprise.com/team/project',
+      })
+    })
+  })
+
+  describe('unknown platforms', () => {
+    it('returns unknown for unrecognized platforms', () => {
+      const result = parseRepositoryUrl('https://custom-git.internal/team/project')
+      expect(result).toEqual({
+        platform: 'unknown',
+        baseUrl: 'https://custom-git.internal/team/project',
+      })
+    })
+
+    it('returns unknown for generic git hosts', () => {
+      const result = parseRepositoryUrl('https://git.company.com/repo/project')
+      expect(result).toEqual({
+        platform: 'unknown',
+        baseUrl: 'https://git.company.com/repo/project',
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null for empty string', () => {
+      expect(parseRepositoryUrl('')).toBeNull()
+    })
+
+    it('returns null for whitespace only', () => {
+      expect(parseRepositoryUrl('   ')).toBeNull()
+    })
+
+    it('returns null for null/undefined', () => {
+      expect(parseRepositoryUrl(null as never)).toBeNull()
+      expect(parseRepositoryUrl(undefined as never)).toBeNull()
+    })
+
+    it('returns null for invalid URL', () => {
+      expect(parseRepositoryUrl('not-a-url')).toBeNull()
+    })
+
+    it('returns null for URL with no path', () => {
+      expect(parseRepositoryUrl('https://github.com')).toBeNull()
+    })
+
+    it('returns null for URL with empty path', () => {
+      expect(parseRepositoryUrl('https://github.com/')).toBeNull()
+    })
+
+    it('trims whitespace', () => {
+      const result = parseRepositoryUrl('  https://github.com/owner/repo  ')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'https://github.com/owner/repo',
+      })
+    })
+
+    it('handles http:// (non-secure)', () => {
+      const result = parseRepositoryUrl('http://github.com/owner/repo')
+      expect(result).toEqual({
+        platform: 'github',
+        baseUrl: 'http://github.com/owner/repo',
+      })
+    })
+
+    it('returns null for file:// protocol', () => {
+      expect(parseRepositoryUrl('file:///path/to/repo')).toBeNull()
+    })
+
+    it('returns null for ftp:// protocol', () => {
+      expect(parseRepositoryUrl('ftp://github.com/owner/repo')).toBeNull()
+    })
+
+    it('returns null for SSH URL with empty path', () => {
+      expect(parseRepositoryUrl('git@github.com:.git')).toBeNull()
+    })
+
+    it('returns null for SSH URL with only .git suffix', () => {
+      expect(parseRepositoryUrl('git@github.com:/.git')).toBeNull()
+    })
+  })
+})
+
+describe('createRepositoryConfigFromUrl', () => {
+  it('creates config for GitHub URL', () => {
+    const config = createRepositoryConfigFromUrl('https://github.com/owner/repo')
+    expect(config).toEqual({
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('creates config for GitLab URL', () => {
+    const config = createRepositoryConfigFromUrl('git@gitlab.com:group/project.git')
+    expect(config).toEqual({
+      platform: 'gitlab',
+      baseUrl: 'https://gitlab.com/group/project',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('creates config for Bitbucket URL', () => {
+    const config = createRepositoryConfigFromUrl('https://bitbucket.org/team/repo')
+    expect(config).toEqual({
+      platform: 'bitbucket',
+      baseUrl: 'https://bitbucket.org/team/repo',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('creates config for Azure DevOps URL', () => {
+    const config = createRepositoryConfigFromUrl('https://dev.azure.com/org/proj/_git/repo')
+    expect(config).toEqual({
+      platform: 'azure-devops',
+      baseUrl: 'https://dev.azure.com/org/proj/_git/repo',
+      formatCompareUrl: undefined,
+    })
+  })
+
+  it('returns null for unknown platforms', () => {
+    const config = createRepositoryConfigFromUrl('https://custom-git.internal/team/project')
+    expect(config).toBeNull()
+  })
+
+  it('returns null for invalid URLs', () => {
+    expect(createRepositoryConfigFromUrl('not-a-url')).toBeNull()
+    expect(createRepositoryConfigFromUrl('')).toBeNull()
+  })
+
+  it('creates config for self-hosted instances', () => {
+    const config = createRepositoryConfigFromUrl('https://github.enterprise.com/team/project')
+    expect(config).toEqual({
+      platform: 'github',
+      baseUrl: 'https://github.enterprise.com/team/project',
+      formatCompareUrl: undefined,
+    })
+  })
+})

--- a/libs/versioning/src/repository/parse/url.ts
+++ b/libs/versioning/src/repository/parse/url.ts
@@ -1,0 +1,337 @@
+import type { RepositoryPlatform } from '../models/platform'
+import type { RepositoryConfig } from '../models/repository-config'
+import { min } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
+import { createURL } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
+import { detectPlatformFromHostname } from '../models/platform'
+import { createRepositoryConfig } from '../models/repository-config'
+
+/**
+ * Parsed repository information extracted from a git URL.
+ */
+export interface ParsedRepository {
+  /**
+   * Detected platform type.
+   */
+  readonly platform: RepositoryPlatform
+
+  /**
+   * Base URL for the repository (without trailing slashes or .git suffix).
+   *
+   * @example
+   * - GitHub: `"https://github.com/owner/repo"`
+   * - GitLab: `"https://gitlab.com/group/project"`
+   * - Azure DevOps: `"https://dev.azure.com/org/project/_git/repo"`
+   */
+  readonly baseUrl: string
+}
+
+/**
+ * Parses a git URL and extracts platform and base URL.
+ *
+ * Supports multiple URL formats:
+ * - `https://github.com/owner/repo`
+ * - `https://github.com/owner/repo.git`
+ * - `git+https://github.com/owner/repo.git`
+ * - `git://github.com/owner/repo.git`
+ * - `git@github.com:owner/repo.git` (SSH format)
+ *
+ * Handles self-hosted instances by detecting platform from hostname:
+ * - `github.mycompany.com` → `github`
+ * - `gitlab.internal.com` → `gitlab`
+ *
+ * Handles Azure DevOps URL formats:
+ * - `https://dev.azure.com/org/project/_git/repo`
+ * - `https://org.visualstudio.com/project/_git/repo`
+ *
+ * @param gitUrl - Git repository URL in any supported format
+ * @returns Parsed repository info with platform and base URL, or null if parsing fails
+ *
+ * @example
+ * ```typescript
+ * // GitHub HTTPS
+ * parseRepositoryUrl('https://github.com/owner/repo')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * // SSH format
+ * parseRepositoryUrl('git@github.com:owner/repo.git')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * // Azure DevOps
+ * parseRepositoryUrl('https://dev.azure.com/org/proj/_git/repo')
+ * // → { platform: 'azure-devops', baseUrl: 'https://dev.azure.com/org/proj/_git/repo' }
+ *
+ * // Self-hosted GitLab
+ * parseRepositoryUrl('https://gitlab.mycompany.com/team/project')
+ * // → { platform: 'gitlab', baseUrl: 'https://gitlab.mycompany.com/team/project' }
+ * ```
+ */
+export function parseRepositoryUrl(gitUrl: string): ParsedRepository | null {
+  if (!gitUrl || typeof gitUrl !== 'string') {
+    return null
+  }
+
+  const trimmed = gitUrl.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  // Try SSH format first: git@hostname:path
+  const sshParsed = parseSshUrl(trimmed)
+  if (sshParsed) {
+    return sshParsed
+  }
+
+  // Try HTTP(S) formats
+  const httpParsed = parseHttpUrl(trimmed)
+  if (httpParsed) {
+    return httpParsed
+  }
+
+  return null
+}
+
+/**
+ * Parses an SSH-style git URL.
+ *
+ * @param url - URL to parse (e.g., "git@github.com:owner/repo.git")
+ * @returns Parsed repository or null
+ *
+ * @internal
+ */
+function parseSshUrl(url: string): ParsedRepository | null {
+  // Handle optional ssh:// prefix
+  let remaining = url
+  if (remaining.startsWith('ssh://')) {
+    remaining = remaining.slice(6)
+  }
+
+  // Must start with git@
+  if (!remaining.startsWith('git@')) {
+    return null
+  }
+
+  // Remove git@ prefix
+  remaining = remaining.slice(4)
+
+  // Find the separator (: or /)
+  const colonIndex = remaining.indexOf(':')
+  const slashIndex = remaining.indexOf('/')
+
+  let separatorIndex: number
+  if (colonIndex === -1 && slashIndex === -1) {
+    return null
+  } else if (colonIndex === -1) {
+    separatorIndex = slashIndex
+  } else if (slashIndex === -1) {
+    separatorIndex = colonIndex
+  } else {
+    separatorIndex = min(colonIndex, slashIndex)
+  }
+
+  const hostname = remaining.slice(0, separatorIndex)
+  const pathPart = normalizePathPart(remaining.slice(separatorIndex + 1))
+
+  if (!hostname || !pathPart) {
+    return null
+  }
+
+  const platform = detectPlatformFromHostname(hostname)
+
+  // For Azure DevOps, construct proper base URL
+  if (platform === 'azure-devops') {
+    const baseUrl = constructAzureDevOpsBaseUrl(hostname, pathPart)
+    if (baseUrl) {
+      return { platform, baseUrl }
+    }
+    return null
+  }
+
+  // Standard platforms: https://hostname/path
+  const baseUrl = `https://${hostname}/${pathPart}`
+  return { platform, baseUrl }
+}
+
+/**
+ * Parses an HTTP(S)-style git URL.
+ *
+ * @param url - URL to parse
+ * @returns Parsed repository or null
+ *
+ * @internal
+ */
+function parseHttpUrl(url: string): ParsedRepository | null {
+  // Normalize various git URL prefixes to https://
+  const normalized = url
+    .replace(/^git\+/, '') // git+https:// → https://
+    .replace(/^git:\/\//, 'https://') // git:// → https://
+
+  let parsed: URL
+  try {
+    parsed = createURL(normalized)
+  } catch {
+    return null
+  }
+
+  // Only support http and https protocols
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null
+  }
+
+  const hostname = parsed.hostname.toLowerCase()
+  const platform = detectPlatformFromHostname(hostname)
+  const pathPart = normalizePathPart(parsed.pathname)
+
+  if (!pathPart) {
+    return null
+  }
+
+  // Handle Azure DevOps special URL structure
+  if (platform === 'azure-devops') {
+    const baseUrl = constructAzureDevOpsBaseUrl(hostname, pathPart)
+    if (baseUrl) {
+      return { platform, baseUrl }
+    }
+    // If Azure DevOps URL cannot be parsed properly, return null
+    return null
+  }
+
+  // Standard platforms
+  const baseUrl = `${parsed.protocol}//${hostname}/${pathPart}`
+  return { platform, baseUrl }
+}
+
+/**
+ * Normalizes a path part by removing leading slashes and .git suffix.
+ *
+ * @param path - Path to normalize
+ * @returns Normalized path or null if empty
+ *
+ * @internal
+ */
+function normalizePathPart(path: string): string | null {
+  let normalized = path.trim()
+
+  // Remove leading slashes
+  while (normalized.startsWith('/')) {
+    normalized = normalized.slice(1)
+  }
+
+  // Remove trailing slashes
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1)
+  }
+
+  // Remove .git suffix
+  if (normalized.endsWith('.git')) {
+    normalized = normalized.slice(0, -4)
+  }
+
+  // Validate we have something
+  if (!normalized) {
+    return null
+  }
+
+  return normalized
+}
+
+/**
+ * Constructs the base URL for Azure DevOps repositories.
+ *
+ * Azure DevOps has special URL structures:
+ * - Modern: `https://dev.azure.com/{org}/{project}/_git/{repo}`
+ * - Legacy: `https://{org}.visualstudio.com/{project}/_git/{repo}`
+ * - SSH: `git@ssh.dev.azure.com:v3/{org}/{project}/{repo}`
+ *
+ * @param hostname - Hostname from the URL
+ * @param pathPart - Path portion after hostname
+ * @returns Constructed base URL or null if invalid
+ *
+ * @internal
+ */
+function constructAzureDevOpsBaseUrl(hostname: string, pathPart: string): string | null {
+  const pathParts = pathPart.split('/')
+
+  // dev.azure.com format: org/project/_git/repo
+  if (hostname === 'dev.azure.com' || hostname.endsWith('.azure.com')) {
+    // Need at least: org/project/_git/repo (4 parts)
+    // Or for SSH v3: v3/org/project/repo (4 parts)
+    if (pathParts.length >= 4) {
+      // Check for v3 SSH format
+      if (pathParts[0] === 'v3') {
+        // v3/org/project/repo → https://dev.azure.com/org/project/_git/repo
+        const org = pathParts[1]
+        const project = pathParts[2]
+        const repo = pathParts[3]
+        if (org && project && repo) {
+          return `https://dev.azure.com/${org}/${project}/_git/${repo}`
+        }
+      }
+
+      // Standard format: org/project/_git/repo
+      const gitIndex = pathParts.indexOf('_git')
+      if (gitIndex >= 2 && pathParts[gitIndex + 1]) {
+        const org = pathParts.slice(0, gitIndex - 1).join('/')
+        const project = pathParts[gitIndex - 1]
+        const repo = pathParts[gitIndex + 1]
+        if (org && project && repo) {
+          return `https://dev.azure.com/${org}/${project}/_git/${repo}`
+        }
+      }
+    }
+    return null
+  }
+
+  // visualstudio.com format: {org}.visualstudio.com/project/_git/repo
+  if (hostname.endsWith('.visualstudio.com')) {
+    const org = hostname.replace('.visualstudio.com', '')
+    const gitIndex = pathParts.indexOf('_git')
+
+    if (gitIndex >= 1 && pathParts[gitIndex + 1]) {
+      const project = pathParts.slice(0, gitIndex).join('/')
+      const repo = pathParts[gitIndex + 1]
+      if (project && repo) {
+        // Normalize to dev.azure.com format
+        return `https://dev.azure.com/${org}/${project}/_git/${repo}`
+      }
+    }
+    return null
+  }
+
+  return null
+}
+
+/**
+ * Creates a RepositoryConfig from a git URL.
+ *
+ * This is a convenience function that combines `parseRepositoryUrl` with
+ * `createRepositoryConfig` to produce a ready-to-use configuration.
+ *
+ * @param gitUrl - Git repository URL in any supported format
+ * @returns RepositoryConfig or null if URL cannot be parsed
+ *
+ * @example
+ * ```typescript
+ * const config = createRepositoryConfigFromUrl('https://github.com/owner/repo')
+ * // → { platform: 'github', baseUrl: 'https://github.com/owner/repo' }
+ *
+ * const config = createRepositoryConfigFromUrl('git@gitlab.com:group/project.git')
+ * // → { platform: 'gitlab', baseUrl: 'https://gitlab.com/group/project' }
+ * ```
+ */
+export function createRepositoryConfigFromUrl(gitUrl: string): RepositoryConfig | null {
+  const parsed = parseRepositoryUrl(gitUrl)
+
+  if (!parsed) {
+    return null
+  }
+
+  // Don't create configs for unknown platforms as they can't generate URLs
+  if (parsed.platform === 'unknown') {
+    return null
+  }
+
+  return createRepositoryConfig({
+    platform: parsed.platform,
+    baseUrl: parsed.baseUrl,
+  })
+}

--- a/libs/versioning/src/repository/url/compare.spec.ts
+++ b/libs/versioning/src/repository/url/compare.spec.ts
@@ -1,0 +1,267 @@
+import type { RepositoryConfig } from '../models/repository-config'
+import { createCompareUrl } from './compare'
+
+describe('createCompareUrl', () => {
+  describe('GitHub', () => {
+    const repository: RepositoryConfig = {
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    }
+
+    it('creates compare URL with three dots', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://github.com/owner/repo/compare/v1.0.0...v1.1.0')
+    })
+
+    it('handles tags without v prefix', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: '1.0.0',
+        toTag: '1.1.0',
+      })
+
+      expect(url).toBe('https://github.com/owner/repo/compare/1.0.0...1.1.0')
+    })
+
+    it('handles complex tag formats', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'lib-versioning@0.0.4',
+        toTag: 'lib-versioning@0.1.0',
+      })
+
+      expect(url).toBe('https://github.com/owner/repo/compare/lib-versioning@0.0.4...lib-versioning@0.1.0')
+    })
+  })
+
+  describe('GitLab', () => {
+    const repository: RepositoryConfig = {
+      platform: 'gitlab',
+      baseUrl: 'https://gitlab.com/group/project',
+    }
+
+    it('creates compare URL with /-/ prefix and three dots', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://gitlab.com/group/project/-/compare/v1.0.0...v1.1.0')
+    })
+
+    it('handles nested groups', () => {
+      const nestedRepo: RepositoryConfig = {
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.com/group/subgroup/project',
+      }
+
+      const url = createCompareUrl({
+        repository: nestedRepo,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://gitlab.com/group/subgroup/project/-/compare/v1.0.0...v1.1.0')
+    })
+
+    it('handles self-hosted GitLab', () => {
+      const selfHostedRepo: RepositoryConfig = {
+        platform: 'gitlab',
+        baseUrl: 'https://gitlab.mycompany.com/team/project',
+      }
+
+      const url = createCompareUrl({
+        repository: selfHostedRepo,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://gitlab.mycompany.com/team/project/-/compare/v1.0.0...v1.1.0')
+    })
+  })
+
+  describe('Bitbucket', () => {
+    const repository: RepositoryConfig = {
+      platform: 'bitbucket',
+      baseUrl: 'https://bitbucket.org/owner/repo',
+    }
+
+    it('creates compare URL with reversed order and two dots', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      // Bitbucket uses reversed order: toTag..fromTag
+      expect(url).toBe('https://bitbucket.org/owner/repo/compare/v1.1.0..v1.0.0')
+    })
+
+    it('handles complex tags with reversed order', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'release-1.0.0',
+        toTag: 'release-1.1.0',
+      })
+
+      expect(url).toBe('https://bitbucket.org/owner/repo/compare/release-1.1.0..release-1.0.0')
+    })
+  })
+
+  describe('Azure DevOps', () => {
+    const repository: RepositoryConfig = {
+      platform: 'azure-devops',
+      baseUrl: 'https://dev.azure.com/org/project/_git/repo',
+    }
+
+    it('creates compare URL with query parameters and GT prefix', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://dev.azure.com/org/project/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0')
+    })
+
+    it('URL-encodes special characters in tags', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'release/1.0.0',
+        toTag: 'release/1.1.0',
+      })
+
+      // Slashes should be encoded
+      expect(url).toBe('https://dev.azure.com/org/project/_git/repo/compare?version=GTrelease%2F1.1.0&compareVersion=GTrelease%2F1.0.0')
+    })
+
+    it('handles tags with @ symbol', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'lib-versioning@0.0.4',
+        toTag: 'lib-versioning@0.1.0',
+      })
+
+      // @ should be encoded as %40
+      expect(url).toBe(
+        'https://dev.azure.com/org/project/_git/repo/compare?version=GTlib-versioning%400.1.0&compareVersion=GTlib-versioning%400.0.4'
+      )
+    })
+
+    it('handles legacy visualstudio.com URLs', () => {
+      const legacyRepo: RepositoryConfig = {
+        platform: 'azure-devops',
+        baseUrl: 'https://myorg.visualstudio.com/project/_git/repo',
+      }
+
+      const url = createCompareUrl({
+        repository: legacyRepo,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://myorg.visualstudio.com/project/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0')
+    })
+  })
+
+  describe('Custom platform', () => {
+    it('uses formatCompareUrl when provided', () => {
+      const repository: RepositoryConfig = {
+        platform: 'custom',
+        baseUrl: 'https://my-git.internal/repo',
+        formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`,
+      }
+
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://my-git.internal/diff/v1.0.0/v1.1.0')
+    })
+
+    it('returns null for custom platform without formatter', () => {
+      const repository: RepositoryConfig = {
+        platform: 'custom',
+        baseUrl: 'https://my-git.internal/repo',
+      }
+
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBeNull()
+    })
+  })
+
+  describe('Platform with custom formatter override', () => {
+    it('uses formatCompareUrl over built-in formatter', () => {
+      const repository: RepositoryConfig = {
+        platform: 'github',
+        baseUrl: 'https://github.mycompany.com/team/repo',
+        formatCompareUrl: (from, to) => `https://github.mycompany.com/api/compare/${from}/${to}`,
+      }
+
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBe('https://github.mycompany.com/api/compare/v1.0.0/v1.1.0')
+    })
+  })
+
+  describe('Unknown platform', () => {
+    it('returns null', () => {
+      const repository: RepositoryConfig = {
+        platform: 'unknown',
+        baseUrl: 'https://some-git.internal/repo',
+      }
+
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBeNull()
+    })
+  })
+
+  describe('Invalid inputs', () => {
+    const repository: RepositoryConfig = {
+      platform: 'github',
+      baseUrl: 'https://github.com/owner/repo',
+    }
+
+    it('returns null for empty fromTag', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: '',
+        toTag: 'v1.1.0',
+      })
+
+      expect(url).toBeNull()
+    })
+
+    it('returns null for empty toTag', () => {
+      const url = createCompareUrl({
+        repository,
+        fromTag: 'v1.0.0',
+        toTag: '',
+      })
+
+      expect(url).toBeNull()
+    })
+  })
+})

--- a/libs/versioning/src/repository/url/compare.spec.ts
+++ b/libs/versioning/src/repository/url/compare.spec.ts
@@ -11,8 +11,8 @@ describe('createCompareUrl', () => {
     it('creates compare URL with three dots', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://github.com/owner/repo/compare/v1.0.0...v1.1.0')
@@ -21,8 +21,8 @@ describe('createCompareUrl', () => {
     it('handles tags without v prefix', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: '1.0.0',
-        toTag: '1.1.0',
+        fromCommit: '1.0.0',
+        toCommit: '1.1.0',
       })
 
       expect(url).toBe('https://github.com/owner/repo/compare/1.0.0...1.1.0')
@@ -31,8 +31,8 @@ describe('createCompareUrl', () => {
     it('handles complex tag formats', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'lib-versioning@0.0.4',
-        toTag: 'lib-versioning@0.1.0',
+        fromCommit: 'lib-versioning@0.0.4',
+        toCommit: 'lib-versioning@0.1.0',
       })
 
       expect(url).toBe('https://github.com/owner/repo/compare/lib-versioning@0.0.4...lib-versioning@0.1.0')
@@ -48,8 +48,8 @@ describe('createCompareUrl', () => {
     it('creates compare URL with /-/ prefix and three dots', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://gitlab.com/group/project/-/compare/v1.0.0...v1.1.0')
@@ -63,8 +63,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository: nestedRepo,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://gitlab.com/group/subgroup/project/-/compare/v1.0.0...v1.1.0')
@@ -78,8 +78,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository: selfHostedRepo,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://gitlab.mycompany.com/team/project/-/compare/v1.0.0...v1.1.0')
@@ -95,8 +95,8 @@ describe('createCompareUrl', () => {
     it('creates compare URL with reversed order and two dots', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       // Bitbucket uses reversed order: toTag..fromTag
@@ -106,8 +106,8 @@ describe('createCompareUrl', () => {
     it('handles complex tags with reversed order', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'release-1.0.0',
-        toTag: 'release-1.1.0',
+        fromCommit: 'release-1.0.0',
+        toCommit: 'release-1.1.0',
       })
 
       expect(url).toBe('https://bitbucket.org/owner/repo/compare/release-1.1.0..release-1.0.0')
@@ -123,8 +123,8 @@ describe('createCompareUrl', () => {
     it('creates compare URL with query parameters and GT prefix', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://dev.azure.com/org/project/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0')
@@ -133,8 +133,8 @@ describe('createCompareUrl', () => {
     it('URL-encodes special characters in tags', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'release/1.0.0',
-        toTag: 'release/1.1.0',
+        fromCommit: 'release/1.0.0',
+        toCommit: 'release/1.1.0',
       })
 
       // Slashes should be encoded
@@ -144,8 +144,8 @@ describe('createCompareUrl', () => {
     it('handles tags with @ symbol', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'lib-versioning@0.0.4',
-        toTag: 'lib-versioning@0.1.0',
+        fromCommit: 'lib-versioning@0.0.4',
+        toCommit: 'lib-versioning@0.1.0',
       })
 
       // @ should be encoded as %40
@@ -162,8 +162,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository: legacyRepo,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://myorg.visualstudio.com/project/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0')
@@ -180,8 +180,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://my-git.internal/diff/v1.0.0/v1.1.0')
@@ -195,8 +195,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBeNull()
@@ -213,8 +213,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBe('https://github.mycompany.com/api/compare/v1.0.0/v1.1.0')
@@ -230,8 +230,8 @@ describe('createCompareUrl', () => {
 
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: 'v1.1.0',
+        fromCommit: 'v1.0.0',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBeNull()
@@ -247,8 +247,8 @@ describe('createCompareUrl', () => {
     it('returns null for empty fromTag', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: '',
-        toTag: 'v1.1.0',
+        fromCommit: '',
+        toCommit: 'v1.1.0',
       })
 
       expect(url).toBeNull()
@@ -257,8 +257,8 @@ describe('createCompareUrl', () => {
     it('returns null for empty toTag', () => {
       const url = createCompareUrl({
         repository,
-        fromTag: 'v1.0.0',
-        toTag: '',
+        fromCommit: 'v1.0.0',
+        toCommit: '',
       })
 
       expect(url).toBeNull()

--- a/libs/versioning/src/repository/url/compare.ts
+++ b/libs/versioning/src/repository/url/compare.ts
@@ -12,29 +12,31 @@ export interface CreateCompareUrlOptions {
   readonly repository: RepositoryConfig
 
   /**
-   * Source tag for comparison (older version).
+   * Source commit hash for comparison (older version).
+   * Must be a full or abbreviated commit hash.
    */
-  readonly fromTag: string
+  readonly fromCommit: string
 
   /**
-   * Target tag for comparison (newer version).
+   * Target commit hash for comparison (newer version).
+   * Must be a full or abbreviated commit hash.
    */
-  readonly toTag: string
+  readonly toCommit: string
 }
 
 /**
- * Creates a platform-specific compare URL for viewing changes between two tags.
+ * Creates a platform-specific compare URL for viewing changes between two commits.
  *
  * Each platform has a different URL format:
- * - **GitHub**: `{baseUrl}/compare/{fromTag}...{toTag}` (three dots)
- * - **GitLab**: `{baseUrl}/-/compare/{fromTag}...{toTag}` (three dots, `/-/` prefix)
- * - **Bitbucket**: `{baseUrl}/compare/{toTag}..{fromTag}` (two dots, reversed order)
- * - **Azure DevOps**: `{baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}` (query params)
+ * - **GitHub**: `{baseUrl}/compare/{fromCommit}...{toCommit}` (three dots)
+ * - **GitLab**: `{baseUrl}/-/compare/{fromCommit}...{toCommit}` (three dots, `/-/` prefix)
+ * - **Bitbucket**: `{baseUrl}/compare/{toCommit}..{fromCommit}` (two dots, reversed order)
+ * - **Azure DevOps**: `{baseUrl}/compare?version=GT{toCommit}&compareVersion=GT{fromCommit}` (query params)
  *
  * For `custom` platforms, a `formatCompareUrl` function must be provided in the repository config.
  * For `unknown` platforms, returns `null`.
  *
- * @param options - Compare URL options including repository, fromTag, and toTag
+ * @param options - Compare URL options including repository, fromCommit, and toCommit
  * @returns The compare URL string, or null if URL cannot be generated
  *
  * @example
@@ -42,34 +44,34 @@ export interface CreateCompareUrlOptions {
  * // GitHub
  * createCompareUrl({
  *   repository: { platform: 'github', baseUrl: 'https://github.com/owner/repo' },
- *   fromTag: 'v1.0.0',
- *   toTag: 'v1.1.0'
+ *   fromCommit: 'abc1234',
+ *   toCommit: 'def5678'
  * })
- * // → 'https://github.com/owner/repo/compare/v1.0.0...v1.1.0'
+ * // → 'https://github.com/owner/repo/compare/abc1234...def5678'
  *
  * // GitLab
  * createCompareUrl({
  *   repository: { platform: 'gitlab', baseUrl: 'https://gitlab.com/group/project' },
- *   fromTag: 'v1.0.0',
- *   toTag: 'v1.1.0'
+ *   fromCommit: 'abc1234',
+ *   toCommit: 'def5678'
  * })
- * // → 'https://gitlab.com/group/project/-/compare/v1.0.0...v1.1.0'
+ * // → 'https://gitlab.com/group/project/-/compare/abc1234...def5678'
  *
  * // Bitbucket (reversed order)
  * createCompareUrl({
  *   repository: { platform: 'bitbucket', baseUrl: 'https://bitbucket.org/owner/repo' },
- *   fromTag: 'v1.0.0',
- *   toTag: 'v1.1.0'
+ *   fromCommit: 'abc1234',
+ *   toCommit: 'def5678'
  * })
- * // → 'https://bitbucket.org/owner/repo/compare/v1.1.0..v1.0.0'
+ * // → 'https://bitbucket.org/owner/repo/compare/def5678..abc1234'
  *
  * // Azure DevOps
  * createCompareUrl({
  *   repository: { platform: 'azure-devops', baseUrl: 'https://dev.azure.com/org/proj/_git/repo' },
- *   fromTag: 'v1.0.0',
- *   toTag: 'v1.1.0'
+ *   fromCommit: 'abc1234',
+ *   toCommit: 'def5678'
  * })
- * // → 'https://dev.azure.com/org/proj/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0'
+ * // → 'https://dev.azure.com/org/proj/_git/repo/compare?version=GTdef5678&compareVersion=GTabc1234'
  *
  * // Custom formatter
  * createCompareUrl({
@@ -78,23 +80,23 @@ export interface CreateCompareUrlOptions {
  *     baseUrl: 'https://my-git.internal/repo',
  *     formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`
  *   },
- *   fromTag: 'v1.0.0',
- *   toTag: 'v1.1.0'
+ *   fromCommit: 'abc1234',
+ *   toCommit: 'def5678'
  * })
- * // → 'https://my-git.internal/diff/v1.0.0/v1.1.0'
+ * // → 'https://my-git.internal/diff/abc1234/def5678'
  * ```
  */
 export function createCompareUrl(options: CreateCompareUrlOptions): string | null {
-  const { repository, fromTag, toTag } = options
+  const { repository, fromCommit, toCommit } = options
 
   // Validate inputs
-  if (!repository || !fromTag || !toTag) {
+  if (!repository || !fromCommit || !toCommit) {
     return null
   }
 
   // If custom formatter is provided, use it (works for any platform including overrides)
   if (repository.formatCompareUrl) {
-    return repository.formatCompareUrl(fromTag, toTag)
+    return repository.formatCompareUrl(fromCommit, toCommit)
   }
 
   const { platform, baseUrl } = repository
@@ -111,7 +113,7 @@ export function createCompareUrl(options: CreateCompareUrlOptions): string | nul
 
   // Generate URL for known platforms
   if (isKnownPlatform(platform)) {
-    return formatKnownPlatformCompareUrl(platform, baseUrl, fromTag, toTag)
+    return formatKnownPlatformCompareUrl(platform, baseUrl, fromCommit, toCommit)
   }
 
   return null
@@ -122,29 +124,29 @@ export function createCompareUrl(options: CreateCompareUrlOptions): string | nul
  *
  * @param platform - Known platform type
  * @param baseUrl - Repository base URL
- * @param fromTag - Source tag (older version)
- * @param toTag - Target tag (newer version)
+ * @param fromCommit - Source commit hash (older version)
+ * @param toCommit - Target commit hash (newer version)
  * @returns Formatted compare URL
  *
  * @internal
  */
-function formatKnownPlatformCompareUrl(platform: KnownPlatform, baseUrl: string, fromTag: string, toTag: string): string {
+function formatKnownPlatformCompareUrl(platform: KnownPlatform, baseUrl: string, fromCommit: string, toCommit: string): string {
   switch (platform) {
     case 'github':
-      // GitHub: {baseUrl}/compare/{fromTag}...{toTag}
-      return `${baseUrl}/compare/${fromTag}...${toTag}`
+      // GitHub: {baseUrl}/compare/{fromCommit}...{toCommit}
+      return `${baseUrl}/compare/${fromCommit}...${toCommit}`
 
     case 'gitlab':
-      // GitLab: {baseUrl}/-/compare/{fromTag}...{toTag}
-      return `${baseUrl}/-/compare/${fromTag}...${toTag}`
+      // GitLab: {baseUrl}/-/compare/{fromCommit}...{toCommit}
+      return `${baseUrl}/-/compare/${fromCommit}...${toCommit}`
 
     case 'bitbucket':
-      // Bitbucket: {baseUrl}/compare/{toTag}..{fromTag} (reversed order, two dots)
-      return `${baseUrl}/compare/${toTag}..${fromTag}`
+      // Bitbucket: {baseUrl}/compare/{toCommit}..{fromCommit} (reversed order, two dots)
+      return `${baseUrl}/compare/${toCommit}..${fromCommit}`
 
     case 'azure-devops':
-      // Azure DevOps: {baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}
+      // Azure DevOps: {baseUrl}/compare?version=GT{toCommit}&compareVersion=GT{fromCommit}
       // Use encodeURIComponent for query parameter values
-      return `${baseUrl}/compare?version=GT${encodeURIComponent(toTag)}&compareVersion=GT${encodeURIComponent(fromTag)}`
+      return `${baseUrl}/compare?version=GT${encodeURIComponent(toCommit)}&compareVersion=GT${encodeURIComponent(fromCommit)}`
   }
 }

--- a/libs/versioning/src/repository/url/compare.ts
+++ b/libs/versioning/src/repository/url/compare.ts
@@ -1,0 +1,150 @@
+import type { KnownPlatform } from '../models/platform'
+import type { RepositoryConfig } from '../models/repository-config'
+import { isKnownPlatform } from '../models/platform'
+
+/**
+ * Options for creating a compare URL.
+ */
+export interface CreateCompareUrlOptions {
+  /**
+   * Repository configuration containing platform and base URL.
+   */
+  readonly repository: RepositoryConfig
+
+  /**
+   * Source tag for comparison (older version).
+   */
+  readonly fromTag: string
+
+  /**
+   * Target tag for comparison (newer version).
+   */
+  readonly toTag: string
+}
+
+/**
+ * Creates a platform-specific compare URL for viewing changes between two tags.
+ *
+ * Each platform has a different URL format:
+ * - **GitHub**: `{baseUrl}/compare/{fromTag}...{toTag}` (three dots)
+ * - **GitLab**: `{baseUrl}/-/compare/{fromTag}...{toTag}` (three dots, `/-/` prefix)
+ * - **Bitbucket**: `{baseUrl}/compare/{toTag}..{fromTag}` (two dots, reversed order)
+ * - **Azure DevOps**: `{baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}` (query params)
+ *
+ * For `custom` platforms, a `formatCompareUrl` function must be provided in the repository config.
+ * For `unknown` platforms, returns `null`.
+ *
+ * @param options - Compare URL options including repository, fromTag, and toTag
+ * @returns The compare URL string, or null if URL cannot be generated
+ *
+ * @example
+ * ```typescript
+ * // GitHub
+ * createCompareUrl({
+ *   repository: { platform: 'github', baseUrl: 'https://github.com/owner/repo' },
+ *   fromTag: 'v1.0.0',
+ *   toTag: 'v1.1.0'
+ * })
+ * // → 'https://github.com/owner/repo/compare/v1.0.0...v1.1.0'
+ *
+ * // GitLab
+ * createCompareUrl({
+ *   repository: { platform: 'gitlab', baseUrl: 'https://gitlab.com/group/project' },
+ *   fromTag: 'v1.0.0',
+ *   toTag: 'v1.1.0'
+ * })
+ * // → 'https://gitlab.com/group/project/-/compare/v1.0.0...v1.1.0'
+ *
+ * // Bitbucket (reversed order)
+ * createCompareUrl({
+ *   repository: { platform: 'bitbucket', baseUrl: 'https://bitbucket.org/owner/repo' },
+ *   fromTag: 'v1.0.0',
+ *   toTag: 'v1.1.0'
+ * })
+ * // → 'https://bitbucket.org/owner/repo/compare/v1.1.0..v1.0.0'
+ *
+ * // Azure DevOps
+ * createCompareUrl({
+ *   repository: { platform: 'azure-devops', baseUrl: 'https://dev.azure.com/org/proj/_git/repo' },
+ *   fromTag: 'v1.0.0',
+ *   toTag: 'v1.1.0'
+ * })
+ * // → 'https://dev.azure.com/org/proj/_git/repo/compare?version=GTv1.1.0&compareVersion=GTv1.0.0'
+ *
+ * // Custom formatter
+ * createCompareUrl({
+ *   repository: {
+ *     platform: 'custom',
+ *     baseUrl: 'https://my-git.internal/repo',
+ *     formatCompareUrl: (from, to) => `https://my-git.internal/diff/${from}/${to}`
+ *   },
+ *   fromTag: 'v1.0.0',
+ *   toTag: 'v1.1.0'
+ * })
+ * // → 'https://my-git.internal/diff/v1.0.0/v1.1.0'
+ * ```
+ */
+export function createCompareUrl(options: CreateCompareUrlOptions): string | null {
+  const { repository, fromTag, toTag } = options
+
+  // Validate inputs
+  if (!repository || !fromTag || !toTag) {
+    return null
+  }
+
+  // If custom formatter is provided, use it (works for any platform including overrides)
+  if (repository.formatCompareUrl) {
+    return repository.formatCompareUrl(fromTag, toTag)
+  }
+
+  const { platform, baseUrl } = repository
+
+  // Cannot generate URL for unknown platforms without a formatter
+  if (platform === 'unknown') {
+    return null
+  }
+
+  // Custom platform requires a formatter
+  if (platform === 'custom') {
+    return null
+  }
+
+  // Generate URL for known platforms
+  if (isKnownPlatform(platform)) {
+    return formatKnownPlatformCompareUrl(platform, baseUrl, fromTag, toTag)
+  }
+
+  return null
+}
+
+/**
+ * Formats a compare URL for known platforms.
+ *
+ * @param platform - Known platform type
+ * @param baseUrl - Repository base URL
+ * @param fromTag - Source tag (older version)
+ * @param toTag - Target tag (newer version)
+ * @returns Formatted compare URL
+ *
+ * @internal
+ */
+function formatKnownPlatformCompareUrl(platform: KnownPlatform, baseUrl: string, fromTag: string, toTag: string): string {
+  switch (platform) {
+    case 'github':
+      // GitHub: {baseUrl}/compare/{fromTag}...{toTag}
+      return `${baseUrl}/compare/${fromTag}...${toTag}`
+
+    case 'gitlab':
+      // GitLab: {baseUrl}/-/compare/{fromTag}...{toTag}
+      return `${baseUrl}/-/compare/${fromTag}...${toTag}`
+
+    case 'bitbucket':
+      // Bitbucket: {baseUrl}/compare/{toTag}..{fromTag} (reversed order, two dots)
+      return `${baseUrl}/compare/${toTag}..${fromTag}`
+
+    case 'azure-devops':
+      // Azure DevOps: {baseUrl}/compare?version=GT{toTag}&compareVersion=GT{fromTag}
+      // Use encodeURIComponent for query parameter values
+      return `${baseUrl}/compare?version=GT${encodeURIComponent(toTag)}&compareVersion=GT${encodeURIComponent(fromTag)}`
+  }
+}

--- a/libs/versioning/src/repository/url/index.ts
+++ b/libs/versioning/src/repository/url/index.ts
@@ -1,0 +1,2 @@
+export type { CreateCompareUrlOptions } from './compare'
+export { createCompareUrl } from './compare'

--- a/libs/versioning/src/workspace/discovery/packages.spec.ts
+++ b/libs/versioning/src/workspace/discovery/packages.spec.ts
@@ -1,13 +1,32 @@
 import { discoverPackages, discoverProject, discoverProjectByName } from './packages'
 
-jest.mock('@hyperfrontend/project-scope', () => ({
-  exists: jest.fn(),
-  findFiles: jest.fn(),
+jest.mock('@hyperfrontend/project-scope/project/package', () => ({
   readPackageJson: jest.fn(),
+}))
+
+jest.mock('@hyperfrontend/project-scope/project/root', () => ({
   findWorkspaceRoot: jest.fn(),
 }))
 
-const projectScope = require('@hyperfrontend/project-scope')
+jest.mock('@hyperfrontend/project-scope/project/traversal', () => ({
+  findFiles: jest.fn(),
+}))
+
+jest.mock('@hyperfrontend/project-scope', () => ({
+  exists: jest.fn(),
+}))
+
+const projectScopePackage = require('@hyperfrontend/project-scope/project/package')
+const projectScopeRoot = require('@hyperfrontend/project-scope/project/root')
+const projectScopeTraversal = require('@hyperfrontend/project-scope/project/traversal')
+const projectScopeMain = require('@hyperfrontend/project-scope')
+
+const projectScope = {
+  readPackageJson: projectScopePackage.readPackageJson,
+  findWorkspaceRoot: projectScopeRoot.findWorkspaceRoot,
+  findFiles: projectScopeTraversal.findFiles,
+  exists: projectScopeMain.exists,
+}
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -26,6 +45,41 @@ describe('discoverProject', () => {
     expect(project?.name).toBe('my-package')
     expect(project?.version).toBe('1.0.0')
     expect(project?.path).toBe('/workspace/libs/my-package')
+  })
+
+  it('sets packageJsonPath correctly', () => {
+    projectScope.readPackageJson.mockReturnValue({
+      name: 'my-package',
+      version: '1.0.0',
+    })
+
+    const project = discoverProject('/workspace/libs/my-package')
+
+    expect(project?.packageJsonPath).toBe('/workspace/libs/my-package/package.json')
+  })
+
+  it('preserves packageJson object', () => {
+    const packageJson = {
+      name: 'my-package',
+      version: '1.0.0',
+      dependencies: { lodash: '^4.0.0' },
+    }
+    projectScope.readPackageJson.mockReturnValue(packageJson)
+
+    const project = discoverProject('/workspace/libs/my-package')
+
+    expect(project?.packageJson).toEqual(packageJson)
+  })
+
+  it('sets changelogPath to null', () => {
+    projectScope.readPackageJson.mockReturnValue({
+      name: 'my-package',
+      version: '1.0.0',
+    })
+
+    const project = discoverProject('/workspace/libs/my-package')
+
+    expect(project?.changelogPath).toBeNull()
   })
 
   it('accepts package.json path directly', () => {
@@ -101,6 +155,24 @@ describe('discoverProjectByName', () => {
     projectScope.findWorkspaceRoot.mockReturnValue(null)
 
     expect(() => discoverProjectByName('my-lib')).toThrow(/workspace root/i)
+  })
+
+  it('passes custom options to discoverPackages', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue(['custom/my-lib/package.json'])
+    projectScope.readPackageJson.mockReturnValue({
+      name: 'my-lib',
+      version: '1.0.0',
+    })
+    projectScope.exists.mockReturnValue(false)
+
+    const project = discoverProjectByName('my-lib', {
+      patterns: ['custom/*/package.json'],
+      exclude: ['**/ignored/**'],
+    })
+
+    expect(project).not.toBeNull()
+    expect(projectScope.findFiles).toHaveBeenCalledWith('/workspace', ['custom/*/package.json'], expect.any(Object))
   })
 })
 
@@ -216,5 +288,92 @@ describe('discoverPackages', () => {
     expect(result.projects).toHaveLength(1)
     expect(result.config.patterns).toEqual(['custom/*/package.json'])
     expect(result.config.exclude).toEqual(['**/ignored/**'])
+  })
+
+  it('indexes projects by name in projectMap', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue(['libs/lib-a/package.json', 'libs/lib-b/package.json'])
+    projectScope.readPackageJson
+      .mockReturnValueOnce({ name: 'lib-a', version: '1.0.0' })
+      .mockReturnValueOnce({ name: 'lib-b', version: '2.0.0' })
+    projectScope.exists.mockReturnValue(false)
+
+    const result = discoverPackages()
+
+    expect(result.projectMap.get('lib-a')).toBeDefined()
+    expect(result.projectMap.get('lib-a')?.version).toBe('1.0.0')
+    expect(result.projectMap.get('lib-b')).toBeDefined()
+    expect(result.projectMap.get('lib-b')?.version).toBe('2.0.0')
+    expect(result.projectMap.get('nonexistent')).toBeUndefined()
+  })
+
+  it('sets changelogPath when changelog exists', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue(['libs/lib-a/package.json'])
+    projectScope.readPackageJson.mockReturnValue({ name: 'lib-a', version: '1.0.0' })
+    projectScope.exists.mockReturnValue(true)
+
+    const result = discoverPackages({ includeChangelogs: true })
+
+    expect(result.projects[0].changelogPath).toBe('/workspace/libs/lib-a/CHANGELOG.md')
+  })
+
+  it('tracks internalDependencies correctly', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue(['libs/lib-a/package.json', 'libs/lib-b/package.json'])
+    projectScope.readPackageJson
+      .mockReturnValueOnce({ name: 'lib-a', version: '1.0.0' })
+      .mockReturnValueOnce({ name: 'lib-b', version: '2.0.0', dependencies: { 'lib-a': '^1.0.0' } })
+    projectScope.exists.mockReturnValue(false)
+
+    const result = discoverPackages({ trackDependencies: true })
+
+    const libB = result.projectMap.get('lib-b')
+    expect(libB?.internalDependencies).toContain('lib-a')
+  })
+
+  it('tracks internalDependents correctly', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue(['libs/lib-a/package.json', 'libs/lib-b/package.json'])
+    projectScope.readPackageJson
+      .mockReturnValueOnce({ name: 'lib-a', version: '1.0.0' })
+      .mockReturnValueOnce({ name: 'lib-b', version: '2.0.0', dependencies: { 'lib-a': '^1.0.0' } })
+    projectScope.exists.mockReturnValue(false)
+
+    const result = discoverPackages({ trackDependencies: true })
+
+    const libA = result.projectMap.get('lib-a')
+    expect(libA?.internalDependents).toContain('lib-b')
+  })
+
+  it('returns config with all fields', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue([])
+
+    const result = discoverPackages({
+      patterns: ['libs/*/package.json'],
+      exclude: ['**/test/**'],
+      includeChangelogs: true,
+      trackDependencies: false,
+    })
+
+    expect(result.config).toEqual({
+      patterns: ['libs/*/package.json'],
+      exclude: ['**/test/**'],
+      includeChangelogs: true,
+      trackDependencies: false,
+    })
+  })
+
+  it('uses default config values when options not provided', () => {
+    projectScope.findWorkspaceRoot.mockReturnValue('/workspace')
+    projectScope.findFiles.mockReturnValue([])
+
+    const result = discoverPackages()
+
+    expect(result.config.includeChangelogs).toBe(true)
+    expect(result.config.trackDependencies).toBe(true)
+    expect(result.config.patterns).toBeDefined()
+    expect(result.config.exclude).toBeDefined()
   })
 })

--- a/libs/versioning/src/workspace/discovery/packages.ts
+++ b/libs/versioning/src/workspace/discovery/packages.ts
@@ -1,10 +1,4 @@
-/**
- * Package Discovery
- *
- * Discovers packages within a workspace by finding package.json files
- * and extracting relevant metadata. Uses project-scope for file operations.
- */
-
+/* eslint-disable @nx/enforce-module-boundaries */
 import type { PackageJson } from '@hyperfrontend/project-scope'
 import type { Project, CreateProjectOptions } from '../models/project'
 import type { WorkspaceConfig } from '../models/workspace'
@@ -12,8 +6,9 @@ import { dirname, join } from 'node:path'
 import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
 import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
 import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { findFiles, readPackageJson, findWorkspaceRoot } from '@hyperfrontend/project-scope'
+import { readPackageJson } from '@hyperfrontend/project-scope/project/package'
+import { findWorkspaceRoot } from '@hyperfrontend/project-scope/project/root'
+import { findFiles } from '@hyperfrontend/project-scope/project/traversal'
 import { createProject } from '../models/project'
 import { DEFAULT_WORKSPACE_CONFIG } from '../models/workspace'
 import { findInternalDependencies } from './dependencies'

--- a/nx.json
+++ b/nx.json
@@ -29,6 +29,12 @@
         "tagPrefix": "{projectName}@"
       }
     },
+    "version-check": {
+      "executor": "@hyperfrontend/package:version-check",
+      "options": {
+        "tagPrefix": "{projectName}@"
+      }
+    },
     "build": {
       "cache": true,
       "dependsOn": ["^build"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9198,9 +9198,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,7 +3298,6 @@
       "integrity": "sha512-/hxcdhE+QDalsWEbJurHtZh9aY27taHeImbCVJnogwv85H3RbAE+0YuKXGInutfLszAs7phwzli71yq+d2P45Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@zkochan/js-yaml": "0.0.7",
         "ejs": "^3.1.7",

--- a/tools/eslint-rules/docs/lib-project-version-targets.md
+++ b/tools/eslint-rules/docs/lib-project-version-targets.md
@@ -1,0 +1,62 @@
+# lib-project-version-targets
+
+Require version and version-check targets in publishable library project.json.
+
+## Rule Details
+
+This rule ensures that publishable libraries have both `version` and `version-check` targets configured.
+
+### Why?
+
+- **Automated versioning**: The `version` target enables automated version bumps based on conventional commits
+- **CI validation**: The `version-check` target enables PR validation to ensure version bumps are applied locally before merge
+- **Consistent workflow**: Ensures the versioning system works end-to-end with both bump and validation steps
+- **Early failure detection**: Catches missing configuration during development rather than in CI
+
+## Examples
+
+### ❌ Incorrect
+
+```json
+{
+  "name": "lib-utils",
+  "targets": {
+    "build": {},
+    "publish": {}
+  }
+}
+```
+
+```json
+{
+  "name": "lib-utils",
+  "targets": {
+    "build": {},
+    "publish": {},
+    "version": {}
+  }
+}
+```
+
+### ✅ Correct
+
+```json
+{
+  "name": "lib-utils",
+  "targets": {
+    "build": {},
+    "publish": {},
+    "version": {},
+    "version-check": {}
+  }
+}
+```
+
+## When Not To Use It
+
+If you don't use automated version validation in CI or have a different versioning workflow.
+
+## Related Rules
+
+- [lib-project-metadata](./lib-project-metadata.md)
+- [lib-project-bundle-config](./lib-project-bundle-config.md)

--- a/tools/eslint-rules/src/index.ts
+++ b/tools/eslint-rules/src/index.ts
@@ -12,6 +12,7 @@ import libPkgNoMain, { RULE_NAME as LIB_PKG_NO_MAIN } from './rules/lib-pkg-no-m
 import libPkgPackageJsonExport, { RULE_NAME as LIB_PKG_PACKAGE_JSON_EXPORT } from './rules/lib-pkg-package-json-export'
 import libProjectBundleConfig, { RULE_NAME as LIB_PROJECT_BUNDLE_CONFIG } from './rules/lib-project-bundle-config'
 import libProjectMetadata, { RULE_NAME as LIB_PROJECT_METADATA } from './rules/lib-project-metadata'
+import libProjectVersionTargets, { RULE_NAME as LIB_PROJECT_VERSION_TARGETS } from './rules/lib-project-version-targets'
 import libReadmeStructure, { RULE_NAME as LIB_README_STRUCTURE } from './rules/lib-readme-structure'
 import libTsconfigPaths, { RULE_NAME as LIB_TSCONFIG_PATHS } from './rules/lib-tsconfig-paths'
 import noAsyncFsApi, { RULE_NAME as NO_ASYNC_FS_API } from './rules/no-async-fs-api'
@@ -44,6 +45,7 @@ export const rules: ESLint.Plugin['rules'] = {
   [LIB_PKG_PACKAGE_JSON_EXPORT]: libPkgPackageJsonExport as unknown as Rule.RuleModule,
   [LIB_PROJECT_BUNDLE_CONFIG]: libProjectBundleConfig as unknown as Rule.RuleModule,
   [LIB_PROJECT_METADATA]: libProjectMetadata as unknown as Rule.RuleModule,
+  [LIB_PROJECT_VERSION_TARGETS]: libProjectVersionTargets as unknown as Rule.RuleModule,
   [LIB_README_STRUCTURE]: libReadmeStructure as unknown as Rule.RuleModule,
   [LIB_TSCONFIG_PATHS]: libTsconfigPaths as unknown as Rule.RuleModule,
   [NO_ASYNC_FS_API]: noAsyncFsApi as unknown as Rule.RuleModule,

--- a/tools/eslint-rules/src/rules/lib-project-version-targets.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-project-version-targets.spec.ts
@@ -1,0 +1,187 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RuleTester } from 'eslint'
+import rule from './lib-project-version-targets'
+
+const tempDirs: string[] = []
+
+/**
+ * Creates a temporary project structure for testing.
+ *
+ * @param config - Configuration for the temporary project.
+ * @param config.projectJson - The project.json content.
+ * @returns The path to the temporary project directory.
+ */
+function createTempProject(config: { projectJson: object }): string {
+  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
+  tempDirs.push(testDir)
+
+  writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
+  mkdirSync(join(testDir, 'src'), { recursive: true })
+  return testDir
+}
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('jsonc-eslint-parser'),
+  },
+})
+
+describe('lib-project-version-targets', () => {
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  ruleTester.run('lib-project-version-targets', rule, {
+    valid: [
+      {
+        name: 'skips non-publishable libraries',
+        code: JSON.stringify(
+          {
+            name: 'test',
+            projectType: 'library',
+            targets: { build: {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: { name: 'test', projectType: 'library', targets: { build: {} } },
+          })
+          return join(dir, 'project.json')
+        })(),
+      },
+      {
+        name: 'skips application projects',
+        code: JSON.stringify(
+          {
+            name: 'app-test',
+            projectType: 'application',
+            targets: { build: {}, publish: {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: { name: 'app-test', projectType: 'application', targets: { build: {}, publish: {} } },
+          })
+          return join(dir, 'project.json')
+        })(),
+      },
+      {
+        name: 'passes when both version and version-check exist',
+        code: JSON.stringify(
+          {
+            name: 'lib-test',
+            description: 'Test library',
+            projectType: 'library',
+            tags: ['type:util'],
+            targets: { build: {}, publish: {}, version: {}, 'version-check': {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: {
+              name: 'lib-test',
+              description: 'Test library',
+              projectType: 'library',
+              tags: ['type:util'],
+              targets: { build: {}, publish: {}, version: {}, 'version-check': {} },
+            },
+          })
+          return join(dir, 'project.json')
+        })(),
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports missing version and version-check when neither exists',
+        code: JSON.stringify(
+          {
+            name: 'lib-test',
+            description: 'Test library',
+            projectType: 'library',
+            tags: ['type:util'],
+            targets: { build: {}, publish: {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: {
+              name: 'lib-test',
+              description: 'Test library',
+              projectType: 'library',
+              tags: ['type:util'],
+              targets: { build: {}, publish: {} },
+            },
+          })
+          return join(dir, 'project.json')
+        })(),
+        errors: [{ messageId: 'missingVersion' }, { messageId: 'missingVersionCheck' }],
+      },
+      {
+        name: 'reports missing version-check when only version exists',
+        code: JSON.stringify(
+          {
+            name: 'lib-test',
+            description: 'Test library',
+            projectType: 'library',
+            tags: ['type:util'],
+            targets: { build: {}, publish: {}, version: {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: {
+              name: 'lib-test',
+              description: 'Test library',
+              projectType: 'library',
+              tags: ['type:util'],
+              targets: { build: {}, publish: {}, version: {} },
+            },
+          })
+          return join(dir, 'project.json')
+        })(),
+        errors: [{ messageId: 'missingVersionCheck' }],
+      },
+      {
+        name: 'reports missing version when only version-check exists',
+        code: JSON.stringify(
+          {
+            name: 'lib-test',
+            description: 'Test library',
+            projectType: 'library',
+            tags: ['type:util'],
+            targets: { build: {}, publish: {}, 'version-check': {} },
+          },
+          null,
+          2
+        ),
+        filename: (() => {
+          const dir = createTempProject({
+            projectJson: {
+              name: 'lib-test',
+              description: 'Test library',
+              projectType: 'library',
+              tags: ['type:util'],
+              targets: { build: {}, publish: {}, 'version-check': {} },
+            },
+          })
+          return join(dir, 'project.json')
+        })(),
+        errors: [{ messageId: 'missingVersion' }],
+      },
+    ],
+  })
+})

--- a/tools/eslint-rules/src/rules/lib-project-version-targets.ts
+++ b/tools/eslint-rules/src/rules/lib-project-version-targets.ts
@@ -1,0 +1,97 @@
+import type { Rule } from 'eslint'
+import type { JSONNode, JSONObjectExpression, JSONProperty } from 'jsonc-eslint-parser/lib/parser/ast'
+import { dirname } from 'node:path'
+import { isPublishableLibrary } from '../utils/nx-project'
+
+/**
+ * Rule identifier for the lib-project-version-targets rule.
+ */
+export const RULE_NAME = 'lib-project-version-targets'
+
+/**
+ * Extracts the key name from a JSON property.
+ *
+ * @param prop - The JSON property node.
+ * @returns The key name or null if not extractable.
+ */
+function getKeyName(prop: JSONProperty): string | null {
+  const key = prop.key
+  if (key.type === 'JSONIdentifier') return key.name
+  if (key.type === 'JSONLiteral' && typeof key.value === 'string') return key.value
+  return null
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require version and version-check targets in publishable library project.json',
+      url: 'https://github.com/AndrewRedican/hyperfrontend/blob/main/tools/eslint-rules/docs/lib-project-version-targets.md',
+    },
+    schema: [],
+    messages: {
+      missingVersion: 'Publishable library must have "version" target for automated versioning. Add: "version": {} to targets.',
+      missingVersionCheck: 'Publishable library must have "version-check" target for CI validation. Add: "version-check": {} to targets.',
+    },
+  },
+
+  create(context) {
+    const filePath = context.filename
+    const projectRoot = dirname(filePath)
+
+    /* istanbul ignore next - only publishable libraries are linted via config */
+    if (!isPublishableLibrary(projectRoot)) {
+      return {}
+    }
+
+    let targetsNode: JSONProperty | null = null
+    let hasVersion = false
+    let hasVersionCheck = false
+
+    return {
+      JSONProperty(node: JSONNode) {
+        // istanbul ignore next -- type guard for jsonc-eslint-parser
+        if (node.type !== 'JSONProperty') {
+          return
+        }
+
+        const keyName = getKeyName(node)
+
+        if (keyName === 'targets') {
+          targetsNode = node
+          const value = node.value
+          if (value.type === 'JSONObjectExpression') {
+            const targetsObj = value as JSONObjectExpression
+            const targetNames = targetsObj.properties
+              .filter((prop): prop is JSONProperty => prop.type === 'JSONProperty')
+              .map(getKeyName)
+              .filter((name): name is string => name !== null)
+
+            hasVersion = targetNames.includes('version')
+            hasVersionCheck = targetNames.includes('version-check')
+          }
+        }
+      },
+
+      'Program:exit'(node: JSONNode) {
+        // Check version target exists
+        if (!hasVersion) {
+          context.report({
+            node: (targetsNode ?? node) as unknown as Rule.Node,
+            messageId: 'missingVersion',
+          })
+        }
+
+        // Check version-check target exists
+        if (!hasVersionCheck) {
+          context.report({
+            node: (targetsNode ?? node) as unknown as Rule.Node,
+            messageId: 'missingVersionCheck',
+          })
+        }
+      },
+    } as unknown as Rule.RuleListener
+  },
+}
+
+export default rule

--- a/tools/package/executors.json
+++ b/tools/package/executors.json
@@ -20,6 +20,11 @@
       "schema": "./src/executors/version/schema.json",
       "description": "Versioning executor using @hyperfrontend/versioning. Uses npm registry as source of truth."
     },
+    "version-check": {
+      "implementation": "./src/executors/version-check/executor",
+      "schema": "./src/executors/version-check/schema.json",
+      "description": "Validates version state without changes. Used by CI to verify lefthook versioning."
+    },
     "e2e": {
       "implementation": "./src/executors/e2e/executor",
       "schema": "./src/executors/e2e/schema.json",

--- a/tools/package/src/executors/build/lib/assets.ts
+++ b/tools/package/src/executors/build/lib/assets.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, copyFileSync, readdirSync, readFileSync, writeFi
 import { join, dirname, basename, relative } from 'node:path'
 import { logger, readJsonFile } from '@nx/devkit'
 import { globSync } from 'glob'
+import { parseRepositoryUrl } from '@hyperfrontend/versioning/repository/parse'
 
 /** License information for a third-party dependency */
 export interface ThirdPartyLicenseEntry {
@@ -166,49 +167,7 @@ function findLicenseFile(packageDir: string): string | null {
 }
 
 /**
- * Parses a Git URL to extract repository owner, name, and hosting platform.
- *
- * @param gitUrl - Git repository URL (git+https, git://, or https format)
- * @returns Object with platform, owner and repo, or null if parsing fails
- */
-function parseGitUrl(gitUrl: string): { platform: 'github' | 'gitlab' | 'bitbucket'; owner: string; repo: string } | null {
-  // Normalize git+https:// and git:// to https://
-  let normalizedUrl = gitUrl.replace(/^git\+/, '').replace(/^git:\/\//, 'https://')
-
-  // Handle SSH-style URLs: git@github.com:owner/repo.git
-  if (normalizedUrl.startsWith('git@')) {
-    normalizedUrl = normalizedUrl.replace(/^git@([^:]+):/, 'https://$1/')
-  }
-
-  let parsed: URL
-  try {
-    parsed = new URL(normalizedUrl)
-  } catch {
-    return null
-  }
-
-  const platformMap: Record<string, 'github' | 'gitlab' | 'bitbucket'> = {
-    'github.com': 'github',
-    'gitlab.com': 'gitlab',
-    'bitbucket.org': 'bitbucket',
-  }
-
-  const platform = platformMap[parsed.hostname]
-  if (!platform) {
-    return null
-  }
-
-  // Extract owner/repo from pathname, removing leading slash and .git suffix
-  const pathParts = parsed.pathname.replace(/^\//, '').replace(/\.git$/, '').split('/')
-  if (pathParts.length < 2 || !pathParts[0] || !pathParts[1]) {
-    return null
-  }
-
-  return { platform, owner: pathParts[0], repo: pathParts[1] }
-}
-
-/**
- * Constructs a URL to the license file on GitHub.
+ * Constructs a URL to the license file based on repository URL and platform.
  *
  * @param repositoryUrl - Repository URL from package.json
  * @param licenseFileName - Name of the license file (e.g., 'LICENSE', 'LICENSE.md')
@@ -220,19 +179,20 @@ function constructLicenseUrl(repositoryUrl: string | { type: string; url: string
   }
 
   const url = typeof repositoryUrl === 'string' ? repositoryUrl : repositoryUrl.url
-  const parsed = parseGitUrl(url)
+  const parsed = parseRepositoryUrl(url)
 
   if (!parsed) {
     return null
   }
 
+  // Use the baseUrl from the parsed result and construct platform-specific paths
   switch (parsed.platform) {
     case 'github':
-      return `https://github.com/${parsed.owner}/${parsed.repo}/blob/master/${licenseFileName}`
+      return `${parsed.baseUrl}/blob/master/${licenseFileName}`
     case 'gitlab':
-      return `https://gitlab.com/${parsed.owner}/${parsed.repo}/-/blob/main/${licenseFileName}`
+      return `${parsed.baseUrl}/-/blob/main/${licenseFileName}`
     case 'bitbucket':
-      return `https://bitbucket.org/${parsed.owner}/${parsed.repo}/src/master/${licenseFileName}`
+      return `${parsed.baseUrl}/src/master/${licenseFileName}`
     default:
       return null
   }

--- a/tools/package/src/executors/version-check/README.md
+++ b/tools/package/src/executors/version-check/README.md
@@ -1,0 +1,129 @@
+# Version Check Executor
+
+Validates that version bumps have been correctly applied without making changes.
+
+This executor is used by CI to verify that lefthook versioning ran successfully before push. It compares the expected version state (calculated via dry-run) against actual files on disk.
+
+## Key Features
+
+- **Read-only** — Does NOT modify any files or create commits
+- **Dry-run comparison** — Calculates expected state by running version flow in dry-run mode
+- **Changelog validation** — Uses `@hyperfrontend/versioning` changelog parsing to verify entry content
+- **Clear remediation** — Provides actionable fix instructions on failure
+
+## Usage
+
+```bash
+# Check a single library
+npx nx version-check lib-cryptography
+
+# Check all affected libraries
+npx nx run-many -t=version-check --affected
+
+# Verbose output for debugging
+npx nx version-check lib-cryptography --verbose
+```
+
+## Options
+
+| Option                | Type    | Default    | Description                                 |
+| --------------------- | ------- | ---------- | ------------------------------------------- |
+| `verbose`             | boolean | false      | Enable detailed logging                     |
+| `quiet`               | boolean | false      | Suppress non-error output                   |
+| `skipIfVersionCommit` | boolean | true       | Skip if current commit is a version commit  |
+| `repository`          | string  | 'inferred' | Repository config for changelog URLs        |
+| `scopeFiltering`      | object  | -          | Scope filtering config for commit selection |
+
+## Output
+
+### Success
+
+```
+✅ lib-cryptography: version 2.1.0 matches expected
+```
+
+### Skipped
+
+```
+⏭️  lib-cryptography: No version bump required based on commit analysis
+```
+
+### Failure
+
+```
+❌ lib-cryptography: version mismatch
+
+Expected: 2.1.0 (MINOR bump from 3 commit(s))
+Actual:   2.0.0
+
+Discrepancies:
+  - package.json: version-mismatch
+    Expected: 2.1.0
+    Actual:   2.0.0
+
+Remedy:
+  Run: npx nx version lib-cryptography
+  Or push again to trigger lefthook versioning
+
+To fix this issue:
+  1. Pull latest changes: git pull origin <branch>
+  2. Run versioning: npx nx version lib-cryptography
+  3. Commit the changes: git add . && git commit --amend --no-edit
+  4. Push: git push --force-with-lease
+
+Or push without --no-verify to let lefthook handle versioning automatically.
+```
+
+## When to Use
+
+- **CI validation** — Verify versions were applied by lefthook before merge
+- **Local verification** — Confirm lefthook versioning worked correctly
+- **Debugging** — Understand why version state doesn't match expectations
+
+## How It Works
+
+1. **Calculate expected state** — Run version flow in dry-run mode
+2. **Read actual state** — Parse package.json and CHANGELOG.md from disk
+3. **Compare versions** — Check if `actual.version === expected.nextVersion`
+4. **Compare changelog** — Verify entry exists and content matches using `@hyperfrontend/versioning` comparison utilities
+5. **Return result** — Pass if all match, fail with discrepancy details otherwise
+
+## CI Integration
+
+The version-check executor is called by the `version-check` job in `ci-pr.yml`:
+
+```yaml
+- name: Validate versions
+  run: |
+    for lib in $AFFECTED; do
+      npx nx version-check "$lib"
+    done
+```
+
+If validation fails, CI comments on the PR with:
+
+- Which libraries have version issues
+- Step-by-step remediation instructions
+- Detailed validation output in a collapsible section
+
+## Relationship to Version Executor
+
+The version-check executor shares validation logic with the version executor:
+
+```
+tools/package/src/executors/
+├── version/
+│   └── lib/
+│       └── validate-version-state.ts  ← Shared validation logic
+└── version-check/
+    └── executor.ts                    ← Imports and uses shared logic
+```
+
+This ensures validation in CI matches what the version executor would produce.
+
+## See Also
+
+- [version executor](../version/README.md) — The executor that creates version bumps
+- [version executor ARCHITECTURE.md](../version/ARCHITECTURE.md) — Architecture including CI integration
+- [lefthook.yml](../../../../../lefthook.yml) — Git hooks that run versioning locally
+- [Versioning Strategy Migration](../../../../../roadmap/versioning-strategy-migration.md) — Full migration documentation

--- a/tools/package/src/executors/version-check/executor.ts
+++ b/tools/package/src/executors/version-check/executor.ts
@@ -1,0 +1,110 @@
+import type { ExecutorContext } from '@nx/devkit'
+import type { VersionCheckExecutorSchema } from './schema'
+import { isInUnstableGitState } from '../version/lib/is-in-unstable-git-state'
+import { isVersionCommit } from '../version/lib/is-version-commit'
+import { getLogger } from '../version/lib/logger'
+import { validateVersionState, formatValidationResult } from '../version/lib/validate-version-state'
+
+/**
+ * Nx executor that validates version state without making changes.
+ *
+ * This executor is designed for CI validation to verify that:
+ * 1. The expected version bump (based on conventional commits) has been applied
+ * 2. The package.json version matches the expected version
+ * 3. The CHANGELOG.md contains the correct entry for the version
+ *
+ * Unlike the version executor, this makes NO changes to the repository.
+ * It's a read-only check that provides clear failure messages for remediation.
+ *
+ * Use cases:
+ * - CI pipeline validation (replaces version-validation job)
+ * - Local verification that lefthook versioning worked
+ * - Debugging version discrepancies
+ *
+ * @param options - Configuration options for the version-check executor
+ * @param context - Nx executor context
+ * @returns Success status
+ */
+export default async function versionCheckExecutor(
+  options: VersionCheckExecutorSchema,
+  context: ExecutorContext
+): Promise<{ success: boolean }> {
+  const { projectName, root: workspaceRoot, projectGraph } = context
+  const logger = getLogger()
+  logger.setLogLevel(options)
+  logger.setContextValue('projectName', projectName ?? 'unknown')
+  logger.setContextValue('workspaceRoot', workspaceRoot)
+
+  if (!projectName) {
+    logger.error('Project name is required')
+    return { success: false }
+  }
+
+  logger.debug(`Version check executor started for {projectName}`)
+
+  const projectConfig = projectGraph?.nodes[projectName]?.data
+  if (!projectConfig) {
+    logger.error(`Project not found in project graph`)
+    return { success: false }
+  }
+
+  // === SAFETY CHECKS ===
+  if (options.skipIfVersionCommit !== false) {
+    logger.debug('Checking if current commit is a version/release commit')
+    if (isVersionCommit(workspaceRoot, projectName)) {
+      logger.info('Skipping - current commit is a version/release commit for this project')
+      return { success: true }
+    }
+  }
+
+  // Skip if git is in unstable state (rebase/merge)
+  if (isInUnstableGitState(workspaceRoot)) {
+    logger.info('Skipping - git is in rebase/merge state')
+    return { success: true }
+  }
+
+  const projectRoot = projectConfig.root
+  logger.setContextValue('projectRoot', projectRoot)
+
+  // === VALIDATE VERSION STATE ===
+  logger.info('Validating version state...')
+
+  const result = await validateVersionState({
+    workspaceRoot,
+    projectName,
+    projectRoot,
+    verbose: options.verbose,
+    scopeFiltering: options.scopeFiltering,
+    repository: options.repository,
+  })
+
+  // === FORMAT AND OUTPUT RESULT ===
+  const formatted = formatValidationResult(result)
+
+  switch (result.status) {
+    case 'valid':
+      logger.info(formatted)
+      return { success: true }
+
+    case 'skipped':
+      logger.info(formatted)
+      return { success: true }
+
+    case 'error':
+      logger.error(formatted)
+      return { success: false }
+
+    case 'invalid':
+      // Use console.log for formatted output with proper line breaks
+      console.log(formatted)
+      console.log('')
+      console.log('To fix this issue:')
+      console.log('  1. Pull latest changes: git pull origin <branch>')
+      console.log(`  2. Run versioning: npx nx version ${projectName}`)
+      console.log('  3. Commit the changes: git add . && git commit --amend --no-edit')
+      console.log('  4. Push: git push --force-with-lease')
+      console.log('')
+      console.log('Or push without --no-verify to let lefthook handle versioning automatically.')
+      return { success: false }
+  }
+}

--- a/tools/package/src/executors/version-check/schema.d.ts
+++ b/tools/package/src/executors/version-check/schema.d.ts
@@ -1,0 +1,29 @@
+import type { FlowConfig } from '@hyperfrontend/versioning'
+
+export interface VersionCheckExecutorSchema {
+  /**
+   * Scope filtering configuration for commit classification and changelog generation.
+   *
+   * Controls how commits are filtered and classified for this project:
+   * - `strategy`: Filtering strategy ('hybrid', 'scope-only', 'file-only', 'inferred')
+   * - `includeScopes`: Additional scopes to always include
+   * - `excludeScopes`: Scopes to exclude even if files match
+   * - `trackDependencyChanges`: Include dependency commits as indirect
+   * - `infrastructure`: Infrastructure path and scope tracking
+   */
+  scopeFiltering?: FlowConfig['scopeFiltering']
+  /** Skip validation if the current commit is a version/release commit. */
+  skipIfVersionCommit?: boolean
+  /** Enable verbose output for debugging. Shows additional details about validation. */
+  verbose?: boolean
+  /** Suppress all non-error output. */
+  quiet?: boolean
+  /**
+   * Repository resolution for changelog compare URLs.
+   *
+   * - `'disabled'`: No compare URLs generated
+   * - `'inferred'`: Auto-detect from package.json or git remote (default)
+   * - Object: Fine-grained control with mode and options
+   */
+  repository?: FlowConfig['repository']
+}

--- a/tools/package/src/executors/version-check/schema.json
+++ b/tools/package/src/executors/version-check/schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "title": "Version Check executor schema",
+  "description": "Validates that version bumps have been correctly applied without making changes. Used by CI to verify that lefthook versioning ran successfully.",
+  "properties": {
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose output for debugging. Shows additional details about validation.",
+      "default": false
+    },
+    "quiet": {
+      "type": "boolean",
+      "description": "Suppress all non-error output.",
+      "default": false
+    },
+    "skipIfVersionCommit": {
+      "type": "boolean",
+      "description": "Skip validation if the current commit is a version/release commit.",
+      "default": true
+    },
+    "repository": {
+      "description": "Repository resolution for changelog compare URLs. Options: 'disabled' (no URLs), 'inferred' (auto-detect from package.json or git remote), or an object with mode and options.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["disabled", "inferred"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["disabled", "inferred", "explicit"],
+              "description": "Resolution mode: 'disabled', 'inferred', or 'explicit'"
+            },
+            "inferenceOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["package-json", "git-remote"]
+              },
+              "description": "Order of inference sources when mode is 'inferred'. Default: ['package-json', 'git-remote']"
+            },
+            "platform": {
+              "type": "string",
+              "enum": ["github", "gitlab", "bitbucket", "azure-devops", "custom", "unknown"],
+              "description": "Git platform (for explicit mode)"
+            },
+            "baseUrl": {
+              "type": "string",
+              "description": "Repository base URL (for explicit mode), e.g., 'https://github.com/owner/repo'"
+            }
+          }
+        }
+      ],
+      "default": "inferred"
+    },
+    "scopeFiltering": {
+      "type": "object",
+      "description": "Scope filtering configuration for commit classification.",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["hybrid", "scope-only", "file-only", "inferred"],
+          "description": "Filtering strategy for commit classification."
+        },
+        "includeScopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional scopes to always include."
+        },
+        "excludeScopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Scopes to exclude even if files match."
+        },
+        "trackDependencyChanges": {
+          "type": "boolean",
+          "description": "Include dependency commits as indirect."
+        },
+        "infrastructure": {
+          "type": "object",
+          "description": "Infrastructure path and scope tracking configuration.",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "File paths to track as infrastructure."
+            },
+            "scopes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Scopes to recognize as infrastructure."
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/tools/package/src/executors/version/ARCHITECTURE.md
+++ b/tools/package/src/executors/version/ARCHITECTURE.md
@@ -88,7 +88,7 @@ The flow executes these steps:
 | Step               | Action                           | State Updates                        |
 | ------------------ | -------------------------------- | ------------------------------------ |
 | fetch-registry     | `npm view` for published version | `publishedVersion`, `currentVersion` |
-| analyze-commits    | Parse commits since last release | `commits`, `lastReleaseTag`          |
+| analyze-commits    | Parse commits since last release | `commits`, `effectiveBaseCommit`     |
 | calculate-bump     | Determine major/minor/patch      | `bumpType`, `nextVersion`            |
 | check-idempotency  | Skip if `nextVersion` on npm     | Sets `bumpType: 'none'` if published |
 | generate-changelog | Build entry from commits         | `changelogEntry`                     |

--- a/tools/package/src/executors/version/ARCHITECTURE.md
+++ b/tools/package/src/executors/version/ARCHITECTURE.md
@@ -117,22 +117,50 @@ if (updatedFiles.length > 0 && !options.skipCommit) {
 
 ## CI Integration
 
-### PR Workflow
+### Local Versioning (lefthook)
+
+Version bumps happen **locally** via lefthook pre-push hooks, not in CI:
 
 ```mermaid
 flowchart TD
-    A[PR pushed] --> B[ci-status passes]
-    B --> C[version-validation job]
+    A[Developer commits] --> B[git push]
+    B --> C[lefthook pre-push]
     C --> D[nx version --collectFiles]
-    D --> E["Outputs: MODIFIED:path"]
-    E --> F[git add + commit to PR]
+    D --> E[Stage modified files]
+    E --> F["Commit: chore: update versions for lib-xxx [skip ci]"]
+    F --> G[Push proceeds with version commit]
 ```
 
 The `--collectFiles` flag:
 
 - Implies `skipCommit` and `skipTag`
 - Outputs modified file paths (MODIFIED:path format)
-- CI scripts parse this output to stage files
+- lefthook parses this output to stage files before creating the version commit
+
+### PR Workflow (validation-only)
+
+CI validates that version bumps were correctly applied using the **version-check** executor:
+
+```mermaid
+flowchart TD
+    A[PR pushed<br/>includes version commit] --> B[ci-status passes]
+    B --> C[version-check job]
+    C --> D[nx version-check lib-xxx]
+    D --> E{Versions match?}
+    E -->|Yes| F[✅ Pass]
+    E -->|No| G[❌ Fail + PR comment<br/>with remediation steps]
+```
+
+The version-check executor:
+
+- Runs version flow in **dry-run mode** to calculate expected state
+- Compares expected version/changelog against actual files on disk
+- Returns pass/fail with detailed discrepancy information
+- Does NOT make any changes (read-only)
+
+If a developer bypasses lefthook (`--no-verify`), CI will fail with clear instructions to fix.
+
+See [version-check executor](../version-check/) for implementation details.
 
 ### Main Workflow
 
@@ -151,6 +179,47 @@ Tags are created **after** publish because:
 2. Tags serve as a record of what's published, not a source of truth
 3. Avoids tag manipulation if publish fails
 
+## Version-Check Executor
+
+The `version-check` executor shares validation logic with the version executor:
+
+```
+tools/package/src/executors/
+├── version/
+│   ├── executor.ts
+│   └── lib/
+│       └── validate-version-state.ts  ← Shared validation logic
+└── version-check/
+    ├── executor.ts                    ← Imports shared logic
+    └── schema.json
+```
+
+### Validation Flow
+
+```typescript
+async function validateVersionState(options) {
+  // 1. Run version flow in dry-run mode
+  const flow = createVersionFlow('conventional', { dryRun: true })
+  const result = await executeFlow(flow, projectName, workspaceRoot, { dryRun: true })
+
+  // 2. Read actual state from disk
+  const actualVersion = readPackageJson().version
+  const actualChangelog = parseChangelog(readFile('CHANGELOG.md'))
+
+  // 3. Compare expected vs actual
+  if (actualVersion !== result.state.nextVersion) {
+    return { status: 'invalid', discrepancies: [...] }
+  }
+
+  // 4. Validate changelog entry exists and matches
+  if (!hasVersion(actualChangelog, result.state.nextVersion)) {
+    return { status: 'invalid', discrepancies: [...] }
+  }
+
+  return { status: 'valid' }
+}
+```
+
 ## Error Handling
 
 The executor returns `{ success: false }` when:
@@ -167,4 +236,6 @@ The executor returns `{ success: true }` (skip scenarios):
 ## See Also
 
 - [README.md](./README.md) — Usage and options
+- [version-check executor](../version-check/) — Validation-only executor for CI
 - [@hyperfrontend/versioning](../../../../libs/versioning) — Underlying versioning library
+- [lefthook.yml](../../../../../lefthook.yml) — Git hooks configuration

--- a/tools/package/src/executors/version/README.md
+++ b/tools/package/src/executors/version/README.md
@@ -84,23 +84,44 @@ This is controlled by the `updateDependents` option (default: true).
 
 ### CI Integration
 
-The executor integrates with CI workflows in two modes:
+#### Local Versioning (Primary)
 
-**PR Workflow (version-validation):**
+Version bumps are applied **locally** via lefthook pre-push hooks. When you `git push`:
+
+1. lefthook runs `nx version <lib> --collectFiles` for affected libraries
+2. Package.json and CHANGELOG.md are updated
+3. A version commit is created: `chore: update versions for lib-xxx [skip ci]`
+4. Push proceeds with the version commit included
+
+See [lefthook.yml](../../../../lefthook.yml) for the hook configuration.
+
+#### CI Validation (version-check)
+
+CI validates that version bumps were correctly applied using the **version-check** executor:
 
 ```bash
-npx nx version lib-xxx --collectFiles
-# Outputs: MODIFIED:libs/xxx/package.json
-#          MODIFIED:libs/xxx/CHANGELOG.md
+npx nx version-check lib-xxx
+# Outputs: ✅ lib-xxx: version 2.1.0 matches expected
+# Or:      ❌ lib-xxx: version mismatch (with remediation steps)
 ```
 
-**Main Workflow:**
+This is read-only validation — CI does NOT create commits. If you bypass lefthook with `--no-verify`, CI will fail with instructions to fix.
+
+See [version-check executor](../version-check/README.md) for details.
+
+#### Main Workflow (publish)
+
+After PR merge to main:
 
 1. `publish` job publishes to npm
 2. `push-tags` job creates git tags for published versions
 3. `create-github-release` job creates GitHub releases
 
 Tags are created **after** publish, not during versioning. This is why `skipTag` defaults to `true`.
+
+## Related Executors
+
+- **[version-check](../version-check/README.md)** — Validates version state without making changes (used by CI)
 
 ## Troubleshooting
 

--- a/tools/package/src/executors/version/executor.ts
+++ b/tools/package/src/executors/version/executor.ts
@@ -104,6 +104,7 @@ export default async function versionExecutor(options: VersionExecutorSchema, co
   const flowResult = await executeFlow(flow, projectName, workspaceRoot, {
     dryRun: options.dryRun,
     verbose: options.verbose ?? false,
+    projectRoot,
   })
 
   // === PROCESS RESULT ===

--- a/tools/package/src/executors/version/executor.ts
+++ b/tools/package/src/executors/version/executor.ts
@@ -91,6 +91,7 @@ export default async function versionExecutor(options: VersionExecutorSchema, co
     tagFormat: `${tagPrefix}\${version}`,
     releaseAs: options.releaseAs,
     repository: options.repository ?? 'inferred', // Default to auto-detect for compare URLs
+    scopeFiltering: options.scopeFiltering,
   }
 
   logger.debug(

--- a/tools/package/src/executors/version/executor.ts
+++ b/tools/package/src/executors/version/executor.ts
@@ -90,6 +90,7 @@ export default async function versionExecutor(options: VersionExecutorSchema, co
     trackDeps: options.trackDeps,
     tagFormat: `${tagPrefix}\${version}`,
     releaseAs: options.releaseAs,
+    repository: options.repository ?? 'inferred', // Default to auto-detect for compare URLs
   }
 
   logger.debug(

--- a/tools/package/src/executors/version/lib/replace-dependency-version.ts
+++ b/tools/package/src/executors/version/lib/replace-dependency-version.ts
@@ -1,0 +1,106 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+
+/**
+ * Dependency sections in package.json that can contain version references.
+ */
+const DEPENDENCY_SECTIONS: readonly string[] = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+
+/**
+ * Replaces a dependency version in a package.json file using JSON parsing.
+ * This preserves the original key ordering by using JSON.parse/stringify.
+ *
+ * @param filePath - Path to the package.json file
+ * @param packageName - The npm package name to update
+ * @param newVersion - The new version string to set
+ * @returns true if a replacement was made, false otherwise
+ */
+export function replaceDependencyVersion(filePath: string, packageName: string, newVersion: string): boolean {
+  const content = readFileSync(filePath, 'utf-8')
+  const pkg = <Record<string, unknown>>JSON.parse(content)
+
+  let changed = false
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const deps = <Record<string, string> | undefined>pkg[section]
+    if (deps && packageName in deps && deps[packageName] !== newVersion) {
+      deps[packageName] = newVersion
+      changed = true
+    }
+  }
+
+  if (!changed) {
+    return false
+  }
+
+  const newContent = JSON.stringify(pkg, null, 2) + '\n'
+  writeFileSync(filePath, newContent, 'utf-8')
+  return true
+}
+
+/**
+ * Checks if a version string is a file: reference to a tgz with the given prefix.
+ *
+ * @param value - The dependency version string to check
+ * @param tgzPrefix - The expected tgz filename prefix (e.g., "hyperfrontend-my-package-")
+ * @returns true if the value is a file: reference containing a matching tgz
+ */
+function isTgzReference(value: string, tgzPrefix: string): boolean {
+  return value.startsWith('file:') && value.includes(tgzPrefix) && value.endsWith('.tgz')
+}
+
+/**
+ * Replaces a tgz filename in a file: dependency reference.
+ *
+ * @param value - The full dependency value (e.g., "file:../../packs/hyperfrontend-my-package-1.0.0.tgz")
+ * @param tgzPrefix - The tgz filename prefix to look for
+ * @param newTgzName - The new tgz filename to use
+ * @returns The updated value with the new tgz filename
+ */
+function replaceTgzInValue(value: string, tgzPrefix: string, newTgzName: string): string {
+  // Find the start of the tgz filename (after the last / or after "file:")
+  const lastSlashIndex = value.lastIndexOf('/')
+  const tgzStartIndex = lastSlashIndex >= 0 ? lastSlashIndex + 1 : value.indexOf(':') + 1
+
+  // Extract the path prefix and replace the tgz filename
+  const pathPrefix = value.substring(0, tgzStartIndex)
+  return pathPrefix + newTgzName
+}
+
+/**
+ * Replaces a file: dependency reference (tgz path) in a package.json file.
+ * This preserves the original key ordering by using JSON.parse/stringify.
+ *
+ * @param filePath - Path to the package.json file
+ * @param packageName - The npm package name to update
+ * @param tgzPrefix - The tgz filename prefix to match (e.g., "hyperfrontend-my-package-")
+ * @param newTgzName - The new tgz filename to use
+ * @returns true if a replacement was made, false otherwise
+ */
+export function replaceTgzReference(filePath: string, packageName: string, tgzPrefix: string, newTgzName: string): boolean {
+  const content = readFileSync(filePath, 'utf-8')
+  const pkg = <Record<string, unknown>>JSON.parse(content)
+
+  let changed = false
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const deps = <Record<string, string> | undefined>pkg[section]
+    if (deps && packageName in deps) {
+      const currentValue = deps[packageName]
+      if (typeof currentValue === 'string' && isTgzReference(currentValue, tgzPrefix)) {
+        const newValue = replaceTgzInValue(currentValue, tgzPrefix, newTgzName)
+        if (newValue !== currentValue) {
+          deps[packageName] = newValue
+          changed = true
+        }
+      }
+    }
+  }
+
+  if (!changed) {
+    return false
+  }
+
+  const newContent = JSON.stringify(pkg, null, 2) + '\n'
+  writeFileSync(filePath, newContent, 'utf-8')
+  return true
+}

--- a/tools/package/src/executors/version/lib/update-dependent-versions.ts
+++ b/tools/package/src/executors/version/lib/update-dependent-versions.ts
@@ -1,9 +1,9 @@
 import { relative } from 'node:path'
 import { join } from 'node:path'
-import { writeJsonFile } from '@hyperfrontend/project-scope/core/fs'
 import { getProductionDependencies, getPeerDependencies, readPackageJsonIfExists } from '@hyperfrontend/project-scope/project/package'
 import { findFiles } from '@hyperfrontend/project-scope/project/traversal'
 import { getLogger } from './logger'
+import { replaceDependencyVersion } from './replace-dependency-version'
 
 /**
  * Helper to convert absolute path to relative path for cleaner logging
@@ -62,27 +62,24 @@ export function updateDependentVersions(
       }
 
       logger.item(`"${rel(packageJsonPath)}"`)
-      let modified = false
       const currentDepVersion = getProductionDependencies(pkg)[packageName]
       const currentPeerVersion = getPeerDependencies(pkg)[packageName]
+      const relativePath = relative(workspaceRoot, packageJsonPath)
 
-      if (currentDepVersion !== undefined && currentDepVersion !== newVersion) {
+      const needsDepUpdate = currentDepVersion !== undefined && currentDepVersion !== newVersion
+      const needsPeerUpdate = currentPeerVersion !== undefined && currentPeerVersion !== newVersion
+
+      if (needsDepUpdate) {
         logger.item(`  updating dependency "${packageName}" from "${currentDepVersion}" to "${newVersion}"`)
-        pkg.dependencies = { ...pkg.dependencies, [packageName]: newVersion }
-        modified = true
       }
-
-      if (currentPeerVersion !== undefined && currentPeerVersion !== newVersion) {
+      if (needsPeerUpdate) {
         logger.item(`  updating peerDependency "${packageName}" from "${currentPeerVersion}" to "${newVersion}"`)
-        pkg.peerDependencies = { ...pkg.peerDependencies, [packageName]: newVersion }
-        modified = true
       }
 
-      if (modified) {
-        const relativePath = relative(workspaceRoot, packageJsonPath)
+      if (needsDepUpdate || needsPeerUpdate) {
         if (!dryRun) {
-          logger.item(`  writing updated package.json to "${rel(packageJsonPath)}"`)
-          writeJsonFile(packageJsonPath, pkg)
+          replaceDependencyVersion(packageJsonPath, packageName, newVersion)
+          logger.item(`  updated "${relativePath}"`)
         } else {
           logger.item(`  dry run - would update "${relativePath}"`)
         }

--- a/tools/package/src/executors/version/lib/update-e2e-dependencies.ts
+++ b/tools/package/src/executors/version/lib/update-e2e-dependencies.ts
@@ -1,9 +1,8 @@
 import { join, relative } from 'node:path'
-import { createRegExp } from '@hyperfrontend/immutable-api-utils/built-in-copy/regexp'
-import { writeJsonFile } from '@hyperfrontend/project-scope/core/fs'
 import { getProductionDependencies, readPackageJsonIfExists } from '@hyperfrontend/project-scope/project/package'
 import { findFiles } from '@hyperfrontend/project-scope/project/traversal'
 import { getLogger } from './logger'
+import { replaceTgzReference } from './replace-dependency-version'
 
 /**
  * Helper to convert absolute path to relative path for cleaner logging
@@ -13,6 +12,31 @@ import { getLogger } from './logger'
  * @returns The relative path, or '.' if the path equals the workspace root
  */
 const toRelative = (absolutePath: string, workspaceRoot: string): string => relative(workspaceRoot, absolutePath) || '.'
+
+/**
+ * Checks if a dependency value is a file: reference to a tgz with the expected prefix.
+ *
+ * @param value - The dependency value to check
+ * @param tgzPrefix - The expected tgz filename prefix
+ * @returns true if the value matches the expected tgz pattern
+ */
+function isTgzDependency(value: string, tgzPrefix: string): boolean {
+  return value.startsWith('file:') && value.includes(tgzPrefix) && value.endsWith('.tgz')
+}
+
+/**
+ * Replaces a tgz filename in a file: dependency value string.
+ *
+ * @param value - The full dependency value (e.g., "file:../../packs/hyperfrontend-my-package-1.0.0.tgz")
+ * @param tgzPrefix - The tgz filename prefix
+ * @param newTgzName - The new tgz filename
+ * @returns The updated value with the new tgz filename
+ */
+function updateTgzInValue(value: string, tgzPrefix: string, newTgzName: string): string {
+  const lastSlashIndex = value.lastIndexOf('/')
+  const tgzStartIndex = lastSlashIndex >= 0 ? lastSlashIndex + 1 : value.indexOf(':') + 1
+  return value.substring(0, tgzStartIndex) + newTgzName
+}
 
 /**
  * Updates e2e app dependencies when library version bumps.
@@ -41,11 +65,10 @@ export function updateE2eDependencies(packageName: string, newVersion: string, w
       return updatedFiles
     }
     logger.step(`found ${packageJsonFiles.length} package.json files to check`)
-    const packageSlug = packageName.replace(/^@hyperfrontend\//, '')
-    // eslint-disable-next-line workspace/no-unsafe-regex -- packageSlug is derived from controlled package names
-    const tgzPattern = createRegExp(`hyperfrontend-${packageSlug}-\\d+\\.\\d+\\.\\d+\\.tgz`)
+    const packageSlug = packageName.startsWith('@hyperfrontend/') ? packageName.slice('@hyperfrontend/'.length) : packageName
+    const tgzPrefix = `hyperfrontend-${packageSlug}-`
     const newTgzName = `hyperfrontend-${packageSlug}-${newVersion}.tgz`
-    logger.step(`looking for tgz references matching pattern "${tgzPattern.source}" to replace with "${newTgzName}"`)
+    logger.step(`looking for tgz references with prefix "${tgzPrefix}" to replace with "${newTgzName}"`)
     logger.step('checking files')
 
     for (const packageJsonPath of packageJsonFiles) {
@@ -56,27 +79,21 @@ export function updateE2eDependencies(packageName: string, newVersion: string, w
       }
 
       logger.item(`"${rel(packageJsonPath)}"`)
-      let modified = false
       const currentValue = getProductionDependencies(pkg)[packageName]
 
-      if (typeof currentValue === 'string' && currentValue.startsWith('file:') && tgzPattern.test(currentValue)) {
-        const newValue = currentValue.replace(tgzPattern, newTgzName)
+      if (typeof currentValue === 'string' && isTgzDependency(currentValue, tgzPrefix)) {
+        const newValue = updateTgzInValue(currentValue, tgzPrefix, newTgzName)
         if (newValue !== currentValue) {
+          const relativePath = relative(workspaceRoot, packageJsonPath)
           logger.item(`  updating tgz reference from "${currentValue}" to "${newValue}"`)
-          pkg.dependencies = { ...pkg.dependencies, [packageName]: newValue }
-          modified = true
+          if (!dryRun) {
+            replaceTgzReference(packageJsonPath, packageName, tgzPrefix, newTgzName)
+            logger.item(`  updated "${relativePath}"`)
+          } else {
+            logger.item(`  dry run - would update "${relativePath}"`)
+          }
+          updatedFiles.push(relativePath)
         }
-      }
-
-      if (modified) {
-        const relativePath = relative(workspaceRoot, packageJsonPath)
-        if (!dryRun) {
-          logger.item(`  writing updated package.json to "${rel(packageJsonPath)}"`)
-          writeJsonFile(packageJsonPath, pkg)
-        } else {
-          logger.item(`  dry run - would update "${relativePath}"`)
-        }
-        updatedFiles.push(relativePath)
       }
     }
 

--- a/tools/package/src/executors/version/lib/validate-version-state.ts
+++ b/tools/package/src/executors/version/lib/validate-version-state.ts
@@ -1,0 +1,321 @@
+import type { ChangelogEntry, FlowConfig, FlowResult } from '@hyperfrontend/versioning'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { readPackageJsonIfExists } from '@hyperfrontend/project-scope/project/package'
+import { parseChangelog, isEntryEqual, hasVersion, getEntryByVersion } from '@hyperfrontend/versioning'
+import { createVersionFlow } from '@hyperfrontend/versioning/flow'
+import { executeFlow } from '@hyperfrontend/versioning/flow/executor'
+
+/**
+ * Type of discrepancy discovered during validation.
+ */
+export type DiscrepancyType = 'version-mismatch' | 'changelog-missing' | 'changelog-mismatch' | 'unexpected-state'
+
+/**
+ * Details about a specific validation discrepancy.
+ */
+export interface Discrepancy {
+  /** The file where the discrepancy was found */
+  readonly file: string
+  /** Type of discrepancy */
+  readonly type: DiscrepancyType
+  /** Expected value */
+  readonly expected: string
+  /** Actual value found */
+  readonly actual: string
+  /** Human-readable remediation instruction */
+  readonly remedy: string
+}
+
+/**
+ * Expected version state calculated from commit analysis.
+ */
+export interface ExpectedVersionState {
+  /** Expected next version */
+  readonly version: string
+  /** Type of version bump */
+  readonly bumpType: 'major' | 'minor' | 'patch' | 'none'
+  /** Expected changelog entry (if applicable) */
+  readonly changelogEntry?: ChangelogEntry
+  /** Commits analyzed */
+  readonly commitCount: number
+}
+
+/**
+ * Actual version state read from disk.
+ */
+export interface ActualVersionState {
+  /** Actual version in package.json */
+  readonly version: string
+  /** Whether changelog contains expected version entry */
+  readonly hasVersionEntry: boolean
+  /** The actual changelog entry (if exists) */
+  readonly changelogEntry?: ChangelogEntry
+}
+
+/**
+ * Result of version state validation.
+ */
+export interface VersionValidationResult {
+  /** Validation status */
+  readonly status: 'valid' | 'invalid' | 'skipped' | 'error'
+  /** Library/project name */
+  readonly library: string
+  /** Reason for skipping (if status is 'skipped') */
+  readonly skipReason?: string
+  /** Error message (if status is 'error') */
+  readonly errorMessage?: string
+  /** Expected state (if validation ran) */
+  readonly expected?: ExpectedVersionState
+  /** Actual state (if validation ran) */
+  readonly actual?: ActualVersionState
+  /** List of discrepancies found */
+  readonly discrepancies: readonly Discrepancy[]
+}
+
+/**
+ * Options for version validation.
+ */
+export interface ValidateVersionStateOptions {
+  /** Workspace root path */
+  readonly workspaceRoot: string
+  /** Project/library name */
+  readonly projectName: string
+  /** Project root relative to workspace */
+  readonly projectRoot: string
+  /** Enable verbose output */
+  readonly verbose?: boolean
+  /** Scope filtering configuration */
+  readonly scopeFiltering?: FlowConfig['scopeFiltering']
+  /** Repository configuration */
+  readonly repository?: FlowConfig['repository']
+}
+
+/**
+ * Validates that a library's version state matches what's expected based on
+ * conventional commit analysis. This is used by the version-check executor
+ * to verify that lefthook has properly updated versions before CI validation.
+ *
+ * The validation process:
+ * 1. Runs the version flow in dry-run mode to calculate expected state
+ * 2. Reads actual state from disk (package.json, CHANGELOG.md)
+ * 3. Compares expected vs actual versions and changelog entries
+ * 4. Returns detailed discrepancies if mismatches found
+ *
+ * @param options - Validation options including paths and configuration
+ * @returns Validation result with status and any discrepancies found
+ */
+export async function validateVersionState(options: ValidateVersionStateOptions): Promise<VersionValidationResult> {
+  const { workspaceRoot, projectName, projectRoot, verbose, scopeFiltering, repository } = options
+  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json')
+  const changelogPath = join(workspaceRoot, projectRoot, 'CHANGELOG.md')
+
+  // === CALCULATE EXPECTED STATE ===
+  const flowConfig: Partial<FlowConfig> = {
+    dryRun: true, // Critical: calculate without making changes
+    skipGit: true,
+    skipTag: true,
+    skipChangelog: false,
+    repository: repository ?? 'inferred',
+    scopeFiltering,
+  }
+
+  let flowResult: FlowResult
+  try {
+    const flow = createVersionFlow('conventional', flowConfig)
+    flowResult = await executeFlow(flow, projectName, workspaceRoot, {
+      dryRun: true,
+      verbose: verbose ?? false,
+      projectRoot,
+    })
+  } catch (error) {
+    return {
+      status: 'error',
+      library: projectName,
+      errorMessage: `Failed to execute version flow: ${error instanceof Error ? error.message : String(error)}`,
+      discrepancies: [],
+    }
+  }
+
+  // === HANDLE SKIP/FAILURE CASES ===
+  if (flowResult.status === 'skipped') {
+    return {
+      status: 'skipped',
+      library: projectName,
+      skipReason: flowResult.summary || 'No version bump needed or already published',
+      discrepancies: [],
+    }
+  }
+
+  if (flowResult.status === 'failed') {
+    return {
+      status: 'error',
+      library: projectName,
+      errorMessage: flowResult.summary || 'Version flow failed',
+      discrepancies: [],
+    }
+  }
+
+  const { state } = flowResult
+
+  // No bump needed
+  if (state.bumpType === 'none' || !state.nextVersion) {
+    return {
+      status: 'skipped',
+      library: projectName,
+      skipReason: 'No version bump required based on commit analysis',
+      discrepancies: [],
+    }
+  }
+
+  // === BUILD EXPECTED STATE ===
+  const expected: ExpectedVersionState = {
+    version: state.nextVersion,
+    bumpType: <'major' | 'minor' | 'patch' | 'none'>state.bumpType,
+    changelogEntry: state.changelogEntry,
+    commitCount: state.commits?.length ?? 0,
+  }
+
+  // === READ ACTUAL STATE ===
+  const pkg = readPackageJsonIfExists(packageJsonPath)
+  if (!pkg) {
+    return {
+      status: 'error',
+      library: projectName,
+      errorMessage: `Cannot read package.json at ${packageJsonPath}`,
+      discrepancies: [],
+    }
+  }
+
+  // Parse changelog if it exists
+  let actualHasVersionEntry = false
+  let actualChangelogEntry: ChangelogEntry | undefined
+  if (existsSync(changelogPath)) {
+    try {
+      const changelogContent = readFileSync(changelogPath, 'utf-8')
+      const actualChangelog = parseChangelog(changelogContent)
+      actualHasVersionEntry = hasVersion(actualChangelog, expected.version)
+      actualChangelogEntry = getEntryByVersion(actualChangelog, expected.version) ?? undefined
+    } catch {
+      // Changelog parsing failed - will be reported as discrepancy
+    }
+  }
+
+  const actual: ActualVersionState = {
+    version: pkg.version ?? '0.0.0',
+    hasVersionEntry: actualHasVersionEntry,
+    changelogEntry: actualChangelogEntry,
+  }
+
+  // === COMPARE STATES ===
+  const discrepancies: Discrepancy[] = []
+
+  // Check version match
+  if (actual.version !== expected.version) {
+    discrepancies.push({
+      file: 'package.json',
+      type: 'version-mismatch',
+      expected: expected.version,
+      actual: actual.version,
+      remedy: `Run: npx nx version ${projectName}\nOr push again to trigger lefthook versioning`,
+    })
+  }
+
+  // Check changelog entry exists
+  if (!actual.hasVersionEntry) {
+    discrepancies.push({
+      file: 'CHANGELOG.md',
+      type: 'changelog-missing',
+      expected: `Entry for version ${expected.version}`,
+      actual: 'No entry found',
+      remedy: `Run: npx nx version ${projectName}\nThis will generate the changelog entry`,
+    })
+  } else if (expected.changelogEntry && actual.changelogEntry) {
+    // Check changelog entry content matches
+    if (!isEntryEqual(expected.changelogEntry, actual.changelogEntry)) {
+      discrepancies.push({
+        file: 'CHANGELOG.md',
+        type: 'changelog-mismatch',
+        expected: 'Changelog entry generated from current commits',
+        actual: 'Existing entry differs from expected',
+        remedy: 'Re-run versioning to regenerate changelog entry',
+      })
+    }
+  }
+
+  // === RETURN RESULT ===
+  if (discrepancies.length === 0) {
+    return {
+      status: 'valid',
+      library: projectName,
+      expected,
+      actual,
+      discrepancies: [],
+    }
+  }
+
+  return {
+    status: 'invalid',
+    library: projectName,
+    expected,
+    actual,
+    discrepancies,
+  }
+}
+
+/**
+ * Formats a validation result as a user-friendly string.
+ *
+ * @param result - The validation result to format
+ * @returns Formatted string for console output
+ */
+export function formatValidationResult(result: VersionValidationResult): string {
+  const lines: string[] = []
+
+  switch (result.status) {
+    case 'valid':
+      lines.push(`✅ ${result.library}: version ${result.expected?.version} matches expected`)
+      break
+
+    case 'skipped':
+      lines.push(`⏭️  ${result.library}: ${result.skipReason}`)
+      break
+
+    case 'error':
+      lines.push(`⚠️  ${result.library}: ${result.errorMessage}`)
+      break
+
+    case 'invalid':
+      lines.push(`❌ ${result.library}: version mismatch`)
+      lines.push('')
+      if (result.expected) {
+        lines.push(
+          `Expected: ${result.expected.version} (${result.expected.bumpType.toUpperCase()} bump from ${result.expected.commitCount} commit(s))`
+        )
+      }
+      if (result.actual) {
+        lines.push(`Actual:   ${result.actual.version}`)
+      }
+      lines.push('')
+      lines.push('Discrepancies:')
+      for (const d of result.discrepancies) {
+        lines.push(`  - ${d.file}: ${d.type}`)
+        lines.push(`    Expected: ${d.expected}`)
+        lines.push(`    Actual:   ${d.actual}`)
+      }
+      lines.push('')
+      lines.push('Remedy:')
+      // Use the first discrepancy's remedy (they should be similar)
+      if (result.discrepancies.length > 0) {
+        lines.push(
+          result.discrepancies[0].remedy
+            .split('\n')
+            .map((l) => `  ${l}`)
+            .join('\n')
+        )
+      }
+      break
+  }
+
+  return lines.join('\n')
+}

--- a/tools/package/src/executors/version/schema.d.ts
+++ b/tools/package/src/executors/version/schema.d.ts
@@ -3,6 +3,17 @@ import type { FlowConfig } from '@hyperfrontend/versioning'
 export interface VersionExecutorSchema {
   /** See what commands would be run, without committing to git or updating files. */
   dryRun?: boolean
+  /**
+   * Scope filtering configuration for commit classification and changelog generation.
+   *
+   * Controls how commits are filtered and classified for this project:
+   * - `strategy`: Filtering strategy ('hybrid', 'scope-only', 'file-only', 'inferred')
+   * - `includeScopes`: Additional scopes to always include
+   * - `excludeScopes`: Scopes to exclude even if files match
+   * - `trackDependencyChanges`: Include dependency commits as indirect
+   * - `infrastructure`: Infrastructure path and scope tracking
+   */
+  scopeFiltering?: FlowConfig['scopeFiltering']
   /** Manually increment the version by that keyword (major, minor, patch). */
   releaseAs?: 'major' | 'minor' | 'patch'
   /** Version tag prefix. Default is '{projectName}@' in independent mode. */

--- a/tools/package/src/executors/version/schema.d.ts
+++ b/tools/package/src/executors/version/schema.d.ts
@@ -1,3 +1,5 @@
+import type { FlowConfig } from '@hyperfrontend/versioning'
+
 export interface VersionExecutorSchema {
   /** See what commands would be run, without committing to git or updating files. */
   dryRun?: boolean
@@ -26,4 +28,12 @@ export interface VersionExecutorSchema {
   verbose?: boolean
   /** Suppress all non-error output. */
   quiet?: boolean
+  /**
+   * Repository resolution for changelog compare URLs.
+   *
+   * - `'disabled'`: No compare URLs generated
+   * - `'inferred'`: Auto-detect from package.json or git remote (default)
+   * - Object: Fine-grained control with mode and options
+   */
+  repository?: FlowConfig['repository']
 }

--- a/tools/package/src/executors/version/schema.json
+++ b/tools/package/src/executors/version/schema.json
@@ -99,6 +99,47 @@
         }
       ],
       "default": "inferred"
+    },
+    "scopeFiltering": {
+      "type": "object",
+      "description": "Scope filtering configuration for commit classification and changelog generation.",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["hybrid", "scope-only", "file-only", "inferred"],
+          "description": "Filtering strategy. Default: 'hybrid'"
+        },
+        "includeScopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional scopes to include as direct commits"
+        },
+        "excludeScopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Scopes to exclude even if files match"
+        },
+        "trackDependencyChanges": {
+          "type": "boolean",
+          "description": "Include commits that touch dependency packages as indirect commits"
+        },
+        "infrastructure": {
+          "type": "object",
+          "description": "Infrastructure tracking configuration",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Git paths to track as infrastructure (e.g., 'tools/', '.github/')"
+            },
+            "scopes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Scopes indicating infrastructure changes (e.g., 'ci', 'build')"
+            }
+          }
+        }
+      }
     }
   },
   "required": []

--- a/tools/package/src/executors/version/schema.json
+++ b/tools/package/src/executors/version/schema.json
@@ -62,6 +62,43 @@
       "type": "boolean",
       "description": "Suppress all non-error output.",
       "default": false
+    },
+    "repository": {
+      "description": "Repository resolution for changelog compare URLs. Options: 'disabled' (no URLs), 'inferred' (auto-detect from package.json or git remote), or an object with mode and options.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["disabled", "inferred"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["disabled", "inferred", "explicit"],
+              "description": "Resolution mode: 'disabled', 'inferred', or 'explicit'"
+            },
+            "inferenceOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["package-json", "git-remote"]
+              },
+              "description": "Order of inference sources when mode is 'inferred'. Default: ['package-json', 'git-remote']"
+            },
+            "platform": {
+              "type": "string",
+              "enum": ["github", "gitlab", "bitbucket", "azure-devops", "custom", "unknown"],
+              "description": "Git platform (for explicit mode)"
+            },
+            "baseUrl": {
+              "type": "string",
+              "description": "Repository base URL (for explicit mode), e.g., 'https://github.com/owner/repo'"
+            }
+          }
+        }
+      ],
+      "default": "inferred"
     }
   },
   "required": []

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -149,6 +149,7 @@
       "@hyperfrontend/versioning/changelog/parse": ["libs/versioning/src/changelog/parse/index.ts"],
       "@hyperfrontend/versioning/changelog/serialize": ["libs/versioning/src/changelog/serialize/index.ts"],
       "@hyperfrontend/versioning/commits": ["libs/versioning/src/commits/index.ts"],
+      "@hyperfrontend/versioning/commits/classify": ["libs/versioning/src/commits/classify/index.ts"],
       "@hyperfrontend/versioning/commits/models": ["libs/versioning/src/commits/models/index.ts"],
       "@hyperfrontend/versioning/commits/parse": ["libs/versioning/src/commits/parse/index.ts"],
       "@hyperfrontend/versioning/flow": ["libs/versioning/src/flow/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -162,6 +162,8 @@
       "@hyperfrontend/versioning/registry": ["libs/versioning/src/registry/index.ts"],
       "@hyperfrontend/versioning/registry/models": ["libs/versioning/src/registry/models/index.ts"],
       "@hyperfrontend/versioning/registry/npm": ["libs/versioning/src/registry/npm/index.ts"],
+      "@hyperfrontend/versioning/repository": ["libs/versioning/src/repository/index.ts"],
+      "@hyperfrontend/versioning/repository/models": ["libs/versioning/src/repository/models/index.ts"],
       "@hyperfrontend/versioning/semver": ["libs/versioning/src/semver/index.ts"],
       "@hyperfrontend/versioning/semver/compare": ["libs/versioning/src/semver/compare/index.ts"],
       "@hyperfrontend/versioning/semver/format": ["libs/versioning/src/semver/format/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -165,6 +165,7 @@
       "@hyperfrontend/versioning/repository": ["libs/versioning/src/repository/index.ts"],
       "@hyperfrontend/versioning/repository/models": ["libs/versioning/src/repository/models/index.ts"],
       "@hyperfrontend/versioning/repository/parse": ["libs/versioning/src/repository/parse/index.ts"],
+      "@hyperfrontend/versioning/repository/url": ["libs/versioning/src/repository/url/index.ts"],
       "@hyperfrontend/versioning/semver": ["libs/versioning/src/semver/index.ts"],
       "@hyperfrontend/versioning/semver/compare": ["libs/versioning/src/semver/compare/index.ts"],
       "@hyperfrontend/versioning/semver/format": ["libs/versioning/src/semver/format/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -164,6 +164,7 @@
       "@hyperfrontend/versioning/registry/npm": ["libs/versioning/src/registry/npm/index.ts"],
       "@hyperfrontend/versioning/repository": ["libs/versioning/src/repository/index.ts"],
       "@hyperfrontend/versioning/repository/models": ["libs/versioning/src/repository/models/index.ts"],
+      "@hyperfrontend/versioning/repository/parse": ["libs/versioning/src/repository/parse/index.ts"],
       "@hyperfrontend/versioning/semver": ["libs/versioning/src/semver/index.ts"],
       "@hyperfrontend/versioning/semver/compare": ["libs/versioning/src/semver/compare/index.ts"],
       "@hyperfrontend/versioning/semver/format": ["libs/versioning/src/semver/format/index.ts"],


### PR DESCRIPTION
## Description

This PR completes the post-migration fixes and enhancements following the shift of the versioning strategy from CI-driven (write) to developer-local (pre-push hook) with CI acting as a read-only validator. It also significantly expands `lib-versioning` with a commit classification engine, repository platform support, and commit-hash-based comparison URLs.

## Related Issue

## Type of Change

<!-- ♻️ Refactor | ✨ Feature | 🔧 Build/Config | 📝 Docs | 🔒 Security -->

♻️ Refactor | ✨ Feature | 🔧 Build/Config | 📝 Docs | 🔒 Security

## Changes Made

### New: `version-check` executor (`tools/package`)

- Added a new read-only Nx executor (`version-check`) that validates version state without modifying any files
- Checks that the expected version bump (based on conventional commits) has been applied to `package.json` and `CHANGELOG.md`
- Introduced `validate-version-state.ts` — core validation logic shared by the executor and CI
- Added `schema.json` / `schema.d.ts` and registered the executor in `executors.json`

### Refactor: CI PR workflow (`.github/workflows/ci-pr.yml`)

- Renamed `version-validation` job to `version-check`
- Downgraded permissions to `contents: read` — no PAT required, no git commits made by CI
- Replaced the mutating `nx version` call with the new `nx version-check` executor
- CI now posts remediation instructions as a PR comment when validation fails
- Removed git config, `git checkout .` cleanup, and `contents: write` logic

### New: Commit classification engine (`libs/versioning/src/commits/classify/`)

- Core `classifyCommit` / `classifyCommits` functions (hybrid strategy: scope → file-touch → dependency-touch → infrastructure → excluded)
- `infrastructure.ts` — detects indirect infra changes that may warrant a version bump
- `project-scopes.ts` — scope matching/exclusion rules
- `models.ts` — `ClassifiedCommit`, `ClassificationContext`, `ClassificationResult` types
- Comprehensive unit test coverage (`classifier.spec.ts`, `infrastructure.spec.ts`, `models.spec.ts`, `project-scopes.spec.ts`)

### New: Repository module (`libs/versioning/src/repository/`)

- Platform detection for GitHub, GitLab, Azure DevOps, Bitbucket, and Gitea (`models/platform.ts`)
- Git remote URL parsing for HTTPS and SSH formats (`parse/url.ts`)
- `package.json` repository field parsing (`parse/package-json.ts`)
- `RepositoryConfig` model with builder (`models/repository-config.ts`)
- Resolution result models (`models/resolution.ts`)
- Compare-URL generation using commit hashes instead of tags (`url/compare.ts`)
- Full spec coverage for all new modules

### New: `resolve-repository` flow step (`libs/versioning/src/flow/steps/`)

- All versioning flows now share a `resolve-repository` step to obtain canonical repo info
- Drives commit-hash-based compare URL generation throughout the changelog pipeline

### Refactor: existing `lib-versioning` modules

- `fetch-registry` — now retrieves the published commit hash (`gitHead`) alongside the version
- `analyze-commits` — integrates the full commit classification pipeline; tracks dependency and infra commits
- `generate-changelog` — uses compare URLs based on commit hashes
- `git/factory.ts` — added `getRemoteUrl` support; extended git client abstraction
- `git/operations/log.ts` — new `git log` operation
- `registry/models/version-info.ts` — extended with `gitHead` field
- `flow/models/types.ts` — extended flow model types
- `flow/presets` — updated conventional, independent, and synced presets to pass repository config

### Refactor: `tool-package` version executor

- Updated executor options schema (`schema.json` / `schema.d.ts`)
- `update-e2e-dependencies.ts` — improved e2e package dependency update handling
- `replace-dependency-version.ts` — new helper for precise dependency version replacement
- `update-dependent-versions.ts` — refactored to use the new helper
- Project root is now explicitly passed to all flow steps
- Repository configuration is resolved and forwarded to the versioning flow
- `build` executor now uses `lib-versioning` to parse the repository URL

### Developer workflow & documentation

- `lefthook.yml` — clarified that pre-push hooks are the source of truth for version bumps; CI validates, never writes; improved failure messages with actionable remediation steps
- `CONTRIBUTING.md` — rewrote versioning section to reflect the pre-push hook workflow
- `.github/workflows/README.md` — updated workflow documentation
- `libs/versioning/ARCHITECTURE.md` — added commit classification pipeline diagram and repository/flow details
- `libs/versioning/README.md` — updated to reflect scope classification
- `tools/package` version executor `README.md` / `ARCHITECTURE.md` — updated options and flow

### Changelog corrections & version bumps

- Corrected recent changelog entries for `lib-nexus`, `lib-network-protocol`, `lib-cryptography`, `lib-project-scope`, `lib-state-machine`, `lib-logging`, and `lib-versioning`
- Bumped versions for all affected libraries: `lib-versioning`, `lib-random-generator-utils`, `lib-network-protocol`, `lib-nexus`, `lib-cryptography`, `lib-ui-utils`, `lib-immutable-api-utils`, `lib-project-scope`, `lib-state-machine`, `lib-string-utils`, `lib-data-utils`, `lib-list-utils`, `lib-logging`, `lib-json-utils`, `lib-time-utils`, `lib-function-utils`

### Security

- Bumped a transitive dependency (`package-lock.json`) to patch a known vulnerability

## Testing

- Unit tests added/updated for all new `lib-versioning` modules (commit classifier, repository models, URL parsing, flow steps, git log operation)
- `resolve-repository` step: 1073-line spec file covering multi-strategy resolution
- `analyze-commits` step: 1002-line spec file covering classification integration
- `generate-changelog` step: 546-line spec file covering commit-hash URL generation
- `version-check` executor: validated locally via `npx nx version-check <lib>` against affected libraries

## Screenshots/Videos

N/A — no UI changes.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

**Versioning strategy summary (post-migration):**

| Step             | Who                      | Action                                             |
| ---------------- | ------------------------ | -------------------------------------------------- |
| Developer pushes | lefthook pre-push        | Runs `nx version <lib>`, creates version commit    |
| CI (`ci-pr.yml`) | `version-check` executor | Validates versions are correct — read-only, no PAT |
| PR merge         | CI                       | Publishing flow triggered on `main`                |

If a developer bypasses lefthook with `--no-verify`, CI will fail and post a comment with remediation instructions (run `npx nx version <lib>` locally, commit, and push).

**Breaking changes:** None — the change to CI `contents: read` is transparent to contributors; behavior is the same when following the normal workflow.

**Security note:** The CI job no longer requires a `PR_PAT` secret with write access for the version-validation step, reducing the blast radius of any token compromise.
