### PR TITLE
Local versioning strategy polish and new @hyperfrontend/versioning capabilities

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -10,6 +10,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure Nx Cloud
+      shell: bash
+      run: |
+        [[ $(jq -r '.neverConnectToCloud // false' nx.json) == "true" ]] && echo "NX_NO_CLOUD=true" >> $GITHUB_ENV
+
     - name: Setup Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,9 +269,9 @@ Output goes to `dist/libs/<library>/` with ESM + CJS formats.
 Version bumps happen automatically via **lefthook pre-push hooks**. When you `git push`:
 
 1. lefthook runs typecheck, lint, and tests
-2. For each affected library, it runs `nx version <lib> --collectFiles`
-3. Package.json and CHANGELOG.md are updated
-4. A version commit is created: `chore: update versions for lib-xxx [skip ci]`
+2. The `version-batch` executor detects affected libraries
+3. For each affected library, versioning runs (package.json, CHANGELOG.md updated)
+4. A single batch commit is created: `chore: update versions for lib-a, lib-b`
 5. Push proceeds with both your changes and the version commit
 
 **What this means for you:**
@@ -290,10 +290,13 @@ git push --no-verify
 **To manually version (rarely needed):**
 
 ```bash
-# Preview version changes (dry run)
+# Preview batch version changes (dry run)
+npx nx version-batch --dryRun
+
+# Preview single library version changes
 npx nx version lib-nexus --dryRun
 
-# Manually run versioning
+# Manually run versioning for a single library
 npx nx version lib-nexus
 
 # Validate version state (what CI runs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,7 +269,7 @@ Output goes to `dist/libs/<library>/` with ESM + CJS formats.
 Version bumps happen automatically via **lefthook pre-push hooks**. When you `git push`:
 
 1. lefthook runs typecheck, lint, and tests
-2. The `version-batch` executor detects affected libraries
+2. The `version:all` target detects affected libraries
 3. For each affected library, versioning runs (package.json, CHANGELOG.md updated)
 4. A single batch commit is created: `chore: update versions for lib-a, lib-b`
 5. Push proceeds with both your changes and the version commit
@@ -291,7 +291,7 @@ git push --no-verify
 
 ```bash
 # Preview batch version changes (dry run)
-npx nx version-batch --dryRun
+npx nx version:all --dryRun
 
 # Preview single library version changes
 npx nx version lib-nexus --dryRun

--- a/apps/package-e2e/versioning/package.json
+++ b/apps/package-e2e/versioning/package.json
@@ -6,7 +6,7 @@
     "pack-install": "cd ../../../dist/libs/versioning && npm pack && cd - && npm install ../../../dist/libs/versioning/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.4.0.tgz"
+    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.0.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,3 +55,6 @@ pre-push:
         Please check the output above for details.
         If you need to skip versioning temporarily, use: git push --no-verify
         Note: CI will fail if versions are not properly applied.
+    push:
+      priority: 7
+      run: git push --no-verify

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,122 +50,20 @@ pre-push:
     # =========================================================================
     # Version Command - SOURCE OF TRUTH for version bumps
     # =========================================================================
-    # This command calculates and applies version bumps based on conventional
-    # commits. It runs AFTER all other pre-push checks (typecheck, lint, test).
+    # Uses the version-batch executor which:
+    #   - Skips on main branch
+    #   - Detects affected libraries programmatically
+    #   - Runs versioning for each affected library
+    #   - Creates a single batch commit: "chore: update versions for lib-x, lib-y"
+    #   - Handles interrupts and failures with cleanup/rollback
     #
-    # What it does:
-    #   - Detects affected libraries via `nx show projects --affected`
-    #   - Runs `nx version $lib --collectFiles` for each
-    #   - Updates package.json, CHANGELOG.md, and dependent package refs
-    #   - Creates a version commit: "chore: update versions for lib-x"
-    #
-    # CI validates this with `version-check` - it does NOT create version commits.
-    # If you skip this hook (--no-verify), CI will fail and guide you to fix it.
+    # CI validates with `version-check` - it does NOT create version commits.
     # =========================================================================
     version:
-      run: |
-        # Skip versioning when pushing to main - CI handles main branch
-        BRANCH=$(git branch --show-current)
-        if [ "$BRANCH" = "main" ]; then
-          echo "⏭️ Skipping versioning on main branch (CI will handle)"
-          exit 0
-        fi
-
-        # Get affected library projects that have a version target
-        AFFECTED=$(npx nx show projects --affected --base=origin/main --head=HEAD --type=lib --with-target=version 2>/dev/null | tr '\n' ' ')
-
-        if [ -z "$AFFECTED" ]; then
-          echo "✅ No affected libraries to version"
-          exit 0
-        fi
-
-        echo "📦 Versioning affected libraries: $AFFECTED"
-
-        # Capture tags before versioning to enable cleanup on interrupt
-        TAGS_BEFORE_FILE=$(mktemp)
-        git tag | grep -E "^lib-" | sort > "$TAGS_BEFORE_FILE"
-        cleanup_tags() {
-          echo ""
-          echo "⚠️  Interrupted! Cleaning up tags created during this session..."
-          TAGS_AFTER_FILE=$(mktemp)
-          git tag | grep -E "^lib-" | sort > "$TAGS_AFTER_FILE"
-          NEW_TAGS=$(comm -23 "$TAGS_AFTER_FILE" "$TAGS_BEFORE_FILE")
-          rm -f "$TAGS_AFTER_FILE"
-          if [ -n "$NEW_TAGS" ]; then
-            echo "$NEW_TAGS" | xargs -I {} git tag -d {}
-            echo "✓ Cleaned up tags. Run 'git checkout .' to discard file changes if needed."
-          fi
-          rm -f "$TAGS_BEFORE_FILE"
-          exit 1
-        }
-        trap cleanup_tags INT TERM
-
-        # Run versioning for each library with --collectFiles
-        # --collectFiles: Outputs modified files without staging, implies skipCommit/skipTag
-        # Track which libs were actually bumped and collect all modified files
-        BUMPED=""
-        ALL_FILES=""
-        FAILED=""
-
-        for lib in $AFFECTED; do
-          echo "  → Checking $lib..."
-          RESULT=$(npx nx version "$lib" --collectFiles 2>&1)
-          EXIT_CODE=$?
-
-          if [ $EXIT_CODE -ne 0 ]; then
-            FAILED="$FAILED $lib"
-            echo "    ✗ failed"
-            continue
-          fi
-
-          if echo "$RESULT" | grep -qE "Flow success"; then
-            if [ -z "$BUMPED" ]; then BUMPED="$lib"; else BUMPED="$BUMPED, $lib"; fi
-            # Collect modified files from MODIFIED: lines
-            FILES=$(echo "$RESULT" | grep "^MODIFIED:" | cut -d: -f2 | tr '\n' ' ')
-            ALL_FILES="$ALL_FILES $FILES"
-            echo "    ✓ version updated"
-          elif echo "$RESULT" | grep -qE "No release needed|already published"; then
-            echo "    ○ already versioned"
-          elif echo "$RESULT" | grep -q "Skipping"; then
-            echo "    ○ skipped (version commit or git state)"
-          else
-            echo "    ○ no version change needed"
-          fi
-        done
-
-        # Handle failures - abort cleanly by discarding all changes
-        if [ -n "$FAILED" ]; then
-          echo "❌ Version failed for:$FAILED"
-          echo "Discarding all changes..."
-          git checkout .
-          rm -f "$TAGS_BEFORE_FILE"
-          exit 1
-        fi
-
-        # Stage all collected files at once (only if all succeeded)
-        if [ -n "$ALL_FILES" ]; then
-          git add $ALL_FILES
-
-          # Commit message matches executor's isVersionCommit() Pattern 2: chore: update versions for lib-a, lib-b
-          if [ -n "$BUMPED" ]; then
-            git commit -m "chore: update versions for $BUMPED" --no-verify
-          else
-            git commit -m "chore: update versions for affected libs" --no-verify
-          fi
-          echo "✅ Version updates committed"
-        else
-          echo "✅ No version changes needed"
-        fi
-        rm -f "$TAGS_BEFORE_FILE"
+      run: npx nx version-batch
       fail_text: |
-        ❌ Version bump failed during pre-push.
+        ❌ Version batch processing failed.
 
-        How to fix:
-        1. Check the error output above for details
-        2. If there are conflicts, resolve them first
-        3. Run versioning manually: npx nx version <lib-name> --verbose
-        4. Stage and commit the changes
-        5. Push again
-
-        If you need to bypass (not recommended): git push --no-verify
+        Please check the output above for details.
+        If you need to skip versioning temporarily, use: git push --no-verify
         Note: CI will fail if versions are not properly applied.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,7 +44,7 @@ pre-push:
       fail_text: 'Tests failed. Fix failing tests before pushing.'
     build:
       priority: 5
-      run: CI=1 npx nx affected -t=build
+      run: CI=1 NODE_OPTIONS="--expose-gc --max-old-space-size=4096" npx nx affected -t=build
       fail_text: 'Build failed. Fix build errors before pushing.'
     version:
       priority: 6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,19 +1,14 @@
 # Lefthook Configuration
 # See: https://github.com/evilmartians/lefthook
-#
-# Versioning Strategy:
-# ====================
-# Version bumps are applied locally via the pre-push `version` command below.
-# This is the SOURCE OF TRUTH for version bumps - CI only validates, it does NOT
-# create version commits. The workflow is:
-#
-#   1. Developer commits changes
-#   2. On `git push`, lefthook runs versioning for affected libraries
-#   3. Version commit is created automatically: "chore: update versions for lib-x"
-#   4. Push proceeds with both commits
-#   5. CI runs `version-check` to validate versions are correct
-#
-# If you bypass lefthook with --no-verify, CI will fail with remediation instructions.
+
+# Show output in real-time instead of buffering until completion
+output:
+  - meta # Show command names
+  - summary # Show summary at end
+  - success # Show successful commands
+  - failure # Show failed commands
+  - execution # Show command execution output in real-time
+  - execution_info # Show execution details
 
 pre-commit:
   parallel: false
@@ -46,21 +41,8 @@ pre-push:
     build:
       run: CI=1 npx nx run-many -t=build --skip-nx-cache
       fail_text: 'Build failed. Fix build errors before pushing.'
-
-    # =========================================================================
-    # Version Command - SOURCE OF TRUTH for version bumps
-    # =========================================================================
-    # Uses the version-batch executor which:
-    #   - Skips on main branch
-    #   - Detects affected libraries programmatically
-    #   - Runs versioning for each affected library
-    #   - Creates a single batch commit: "chore: update versions for lib-x, lib-y"
-    #   - Handles interrupts and failures with cleanup/rollback
-    #
-    # CI validates with `version-check` - it does NOT create version commits.
-    # =========================================================================
     version:
-      run: npx nx version-batch
+      run: npx nx version:all --verbose
       fail_text: |
         ❌ Version batch processing failed.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,9 +55,3 @@ pre-push:
         Please check the output above for details.
         If you need to skip versioning temporarily, use: git push --no-verify
         Note: CI will fail if versions are not properly applied.
-    push:
-      priority: 7
-      # Push version commits, then exit 1 to prevent the original git push from
-      # racing to update the same ref (causes "cannot lock ref" error otherwise)
-      run: git push origin HEAD --no-verify && exit 1
-      fail_text: ''

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,4 +57,7 @@ pre-push:
         Note: CI will fail if versions are not properly applied.
     push:
       priority: 7
-      run: git push origin HEAD --no-verify
+      # Push version commits, then exit 1 to prevent the original git push from
+      # racing to update the same ref (causes "cannot lock ref" error otherwise)
+      run: git push origin HEAD --no-verify && exit 1
+      fail_text: ''

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,19 +32,19 @@ pre-push:
       fail_text: 'Security audit failed. Run "npm audit" to see vulnerabilities and "npm audit fix" to resolve them.'
     typecheck:
       priority: 2
-      run: CI=1 npx nx run-many -t=typecheck --skip-nx-cache
+      run: CI=1 npx nx affected -t=typecheck
       fail_text: 'Typecheck failed. Fix type errors before pushing.'
     lint:
       priority: 3
-      run: CI=1 npx nx run-many -t=lint --skip-nx-cache
+      run: CI=1 npx nx affected -t=lint
       fail_text: 'Lint failed. Fix lint errors before pushing.'
     test:
       priority: 4
-      run: CI=1 npx nx run-many -t=test --skip-nx-cache
+      run: CI=1 npx nx affected -t=test
       fail_text: 'Tests failed. Fix failing tests before pushing.'
     build:
       priority: 5
-      run: CI=1 npx nx run-many -t=build --skip-nx-cache
+      run: CI=1 npx nx affected -t=build
       fail_text: 'Build failed. Fix build errors before pushing.'
     version:
       priority: 6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,7 +24,7 @@ commit-msg:
       fail_text: 'Your commit message does not follow the standard conventional commit format. See https://www.conventionalcommits.org/en/v1.0.0/'
 
 pre-push:
-  parallel: false
+  piped: true # Run sequentially AND stop on first failure
   commands:
     audit:
       priority: 1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,21 +27,27 @@ pre-push:
   parallel: false
   commands:
     audit:
+      priority: 1
       run: npm audit --audit-level=high
       fail_text: 'Security audit failed. Run "npm audit" to see vulnerabilities and "npm audit fix" to resolve them.'
     typecheck:
+      priority: 2
       run: CI=1 npx nx run-many -t=typecheck --skip-nx-cache
       fail_text: 'Typecheck failed. Fix type errors before pushing.'
     lint:
+      priority: 3
       run: CI=1 npx nx run-many -t=lint --skip-nx-cache
       fail_text: 'Lint failed. Fix lint errors before pushing.'
     test:
+      priority: 4
       run: CI=1 npx nx run-many -t=test --skip-nx-cache
       fail_text: 'Tests failed. Fix failing tests before pushing.'
     build:
+      priority: 5
       run: CI=1 npx nx run-many -t=build --skip-nx-cache
       fail_text: 'Build failed. Fix build errors before pushing.'
     version:
+      priority: 6
       run: npx nx version:all --verbose
       fail_text: |
         ❌ Version batch processing failed.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,4 +57,4 @@ pre-push:
         Note: CI will fail if versions are not properly applied.
     push:
       priority: 7
-      run: git push --no-verify
+      run: git push origin HEAD --no-verify

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...9e27e0e3fc0e62ef0a94bfa9268c73bab1177e32) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...8d5ee9fb4d6edec6a974ab31145931171c50e19d) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...edbf05933e1dfddf14fadc627f652f3ac3462373) - 2026-03-26
+
+### Features
+
+- support various files changed detection strategies
+- support unstable git state detection
+- add support to discard git changes
+
 ## [0.4.0](https://github.com/AndrewRedican/hyperfrontend/compare/b8e66fb435b8c25cabc5360d735852bffc721916...9380caeb9549901e3803bd6836dfe21a49ff32d8) - 2026-03-22
 
 ### Features

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...8b80cdeb6bfdcb9eb5515d78e48433b0c7eae1a0) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...a8669717c4ef95172355bd9abbf7798c155fd307) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...c6d1570441639355f8a97db169756a9c326621d6) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...30e27859c02da55be208428775062288cf1dab92) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...edbf05933e1dfddf14fadc627f652f3ac3462373) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...9e27e0e3fc0e62ef0a94bfa9268c73bab1177e32) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...30e27859c02da55be208428775062288cf1dab92) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...8b80cdeb6bfdcb9eb5515d78e48433b0c7eae1a0) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...8d5ee9fb4d6edec6a974ab31145931171c50e19d) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...c6d1570441639355f8a97db169756a9c326621d6) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...a8669717c4ef95172355bd9abbf7798c155fd307) - 2026-03-26
+## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...3d23dade0efa7172d5311a8676cfe0d52dbe749d) - 2026-03-26
 
 ### Features
 

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperfrontend/versioning",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Versioning library with changelog parsing, conventional commits, and semver flow orchestration.",
   "dependencies": {
     "@hyperfrontend/immutable-api-utils": "0.1.2",

--- a/libs/versioning/src/git/README.md
+++ b/libs/versioning/src/git/README.md
@@ -29,6 +29,7 @@ flowchart TB
         TAG[tag.ts]
         CMT[commit.ts]
         STS[status.ts]
+        OPS[operation-state.ts]
     end
 
     subgraph Models
@@ -51,7 +52,8 @@ flowchart TB
     TAG --> EXEC --> GT
     CMT --> EXEC --> GC
     STS --> EXEC
-    CLIENT --> LOG & TAG & CMT & STS
+    OPS --> EXEC
+    CLIENT --> LOG & TAG & CMT & STS & OPS
     LOG --> GR
 ```
 
@@ -172,6 +174,15 @@ flowchart TB
 | `getModifiedFiles()`  | Get list of modified files        | [status.ts](./operations/status.ts)       |
 | `getUntrackedFiles()` | Get list of untracked files       | [status.ts](./operations/status.ts)       |
 
+### Operation State
+
+| Function                  | Description                                                     | Implementation                                        |
+| ------------------------- | --------------------------------------------------------------- | ----------------------------------------------------- |
+| `getOperationState()`     | Detect if git is mid-operation                                  | [operation-state.ts](./operations/operation-state.ts) |
+| `isOperationInProgress()` | Check if rebase/merge is in progress                            | [operation-state.ts](./operations/operation-state.ts) |
+| `GitOperationState`       | Result with inProgress, reason, details                         | [operation-state.ts](./operations/operation-state.ts) |
+| `GitOperationStateReason` | `'rebase-interactive' \| 'rebase-apply' \| 'merge-in-progress'` | [operation-state.ts](./operations/operation-state.ts) |
+
 ### Security Utilities
 
 | Function                | Description                                  | Implementation             |
@@ -203,6 +214,12 @@ const newCommits = git.getCommitsSince('v1.0.0')
 if (git.isClean()) {
   // Create a tag
   git.createTag('v1.1.0', { message: 'Release v1.1.0' })
+}
+
+// Check for in-progress operations before committing
+const state = git.getOperationState()
+if (state.inProgress) {
+  console.warn(`Cannot proceed: git ${state.reason} in progress`)
 }
 ```
 

--- a/libs/versioning/src/git/README.md
+++ b/libs/versioning/src/git/README.md
@@ -26,6 +26,7 @@ flowchart TB
 
     subgraph Operations
         LOG[log.ts]
+        DIFF[diff.ts]
         TAG[tag.ts]
         CMT[commit.ts]
         STS[status.ts]
@@ -45,15 +46,16 @@ flowchart TB
     REF --> ESC1
     PATH --> ESC2
     MSG --> ESC3
-    ESC1 --> LOG & TAG
+    ESC1 --> LOG & TAG & DIFF
     ESC2 --> CMT
     ESC3 --> CMT & TAG
     LOG --> EXEC --> GC
+    DIFF --> EXEC
     TAG --> EXEC --> GT
     CMT --> EXEC --> GC
     STS --> EXEC
     OPS --> EXEC
-    CLIENT --> LOG & TAG & CMT & STS & OPS
+    CLIENT --> LOG & TAG & CMT & STS & OPS & DIFF
     LOG --> GR
 ```
 
@@ -61,16 +63,19 @@ flowchart TB
 
 ### Models
 
-| Export             | Description                                             | Implementation                      |
-| ------------------ | ------------------------------------------------------- | ----------------------------------- |
-| `GitCommit`        | Commit with hash, author, date, subject, body, refs     | [commit.ts](./models/commit.ts)     |
-| `GitTag`           | Tag with name, commitHash, type (lightweight/annotated) | [tag.ts](./models/tag.ts)           |
-| `GitTagType`       | `'lightweight' \| 'annotated'`                          | [tag.ts](./models/tag.ts)           |
-| `GitRef`           | Reference with fullName, name, type, commitHash         | [ref.ts](./models/ref.ts)           |
-| `GitRefType`       | `'branch' \| 'tag' \| 'remote' \| 'head' \| 'stash'`    | [ref.ts](./models/ref.ts)           |
-| `RepositoryStatus` | Full repository status with branch, staged, modified    | [status.ts](./operations/status.ts) |
-| `FileStatus`       | `'added' \| 'modified' \| 'deleted' \| 'renamed' ...`   | [status.ts](./operations/status.ts) |
-| `FileStatusEntry`  | File path with its status                               | [status.ts](./operations/status.ts) |
+| Export               | Description                                             | Implementation                      |
+| -------------------- | ------------------------------------------------------- | ----------------------------------- |
+| `GitCommit`          | Commit with hash, author, date, subject, body, refs     | [commit.ts](./models/commit.ts)     |
+| `GitTag`             | Tag with name, commitHash, type (lightweight/annotated) | [tag.ts](./models/tag.ts)           |
+| `GitTagType`         | `'lightweight' \| 'annotated'`                          | [tag.ts](./models/tag.ts)           |
+| `GitRef`             | Reference with fullName, name, type, commitHash         | [ref.ts](./models/ref.ts)           |
+| `GitRefType`         | `'branch' \| 'tag' \| 'remote' \| 'head' \| 'stash'`    | [ref.ts](./models/ref.ts)           |
+| `RepositoryStatus`   | Full repository status with branch, staged, modified    | [status.ts](./operations/status.ts) |
+| `FileStatus`         | `'added' \| 'modified' \| 'deleted' \| 'renamed' ...`   | [status.ts](./operations/status.ts) |
+| `FileStatusEntry`    | File path with its status                               | [status.ts](./operations/status.ts) |
+| `FileChange`         | File change with path, status, and optional oldPath     | [diff.ts](./operations/diff.ts)     |
+| `FileChangeStatus`   | `'added' \| 'modified' \| 'deleted' \| 'renamed' ...`   | [diff.ts](./operations/diff.ts)     |
+| `GitCommitWithFiles` | GitCommit extended with changed files                   | [diff.ts](./operations/diff.ts)     |
 
 ### Model Factories
 
@@ -123,6 +128,14 @@ flowchart TB
 | `getCommitsSince()`   | Get commits since a ref      | [log.ts](./operations/log.ts) |
 | `getCommit(hash)`     | Get single commit by hash    | [log.ts](./operations/log.ts) |
 | `commitExists(hash)`  | Check if commit exists       | [log.ts](./operations/log.ts) |
+
+### Diff Operations
+
+| Function                             | Description                         | Implementation                  |
+| ------------------------------------ | ----------------------------------- | ------------------------------- |
+| `getChangedFilesBetween()`           | Get file paths changed between refs | [diff.ts](./operations/diff.ts) |
+| `getChangedFilesBetweenWithStatus()` | Get files with status (add/mod/del) | [diff.ts](./operations/diff.ts) |
+| `getCommitWithFiles(hash)`           | Get commit with its changed files   | [diff.ts](./operations/diff.ts) |
 
 ### Tag Operations
 
@@ -210,6 +223,18 @@ const commits = git.getCommitLog({ maxCount: 10 })
 // Get commits since last release
 const newCommits = git.getCommitsSince('v1.0.0')
 
+// Get files changed between refs
+const changedFiles = git.getChangedFilesBetween('origin/main', 'HEAD')
+const changesWithStatus = git.getChangedFilesBetweenWithStatus('v1.0.0', 'v2.0.0')
+
+// Get commit with file details
+const commitWithFiles = git.getCommitWithFiles('abc1234')
+if (commitWithFiles) {
+  for (const file of commitWithFiles.files) {
+    console.log(`${file.status}: ${file.path}`)
+  }
+}
+
 // Check repository state
 if (git.isClean()) {
   // Create a tag
@@ -226,11 +251,36 @@ if (state.inProgress) {
 ### Standalone Operations
 
 ```typescript
-import { getCommitsBetween, getTags, getLatestTag, commit, stage } from '@hyperfrontend/versioning'
+import {
+  getCommitsBetween,
+  getTags,
+  getLatestTag,
+  commit,
+  stage,
+  getChangedFilesBetween,
+  getChangedFilesBetweenWithStatus,
+  getCommitWithFiles,
+} from '@hyperfrontend/versioning'
 
 // Get commits between tags
 const commits = getCommitsBetween('v1.0.0', 'v2.0.0')
 console.log(`${commits.length} commits between releases`)
+
+// Get files changed since main
+const changedFiles = getChangedFilesBetween('origin/main', 'HEAD')
+console.log(`${changedFiles.length} files changed`)
+
+// Get files with status information
+const changes = getChangedFilesBetweenWithStatus('v1.0.0', 'v2.0.0')
+const added = changes.filter((c) => c.status === 'added')
+const deleted = changes.filter((c) => c.status === 'deleted')
+console.log(`${added.length} added, ${deleted.length} deleted`)
+
+// Get commit with file details for changelog attribution
+const commitWithFiles = getCommitWithFiles('abc1234')
+if (commitWithFiles) {
+  console.log(`${commitWithFiles.subject} touched ${commitWithFiles.files.length} files`)
+}
 
 // Find latest version tag
 const latest = getLatestTag({ pattern: '@scope/pkg@' })
@@ -318,11 +368,13 @@ git/
 │   └── ref.ts            # GitRef type & factories
 └── operations/           # Git command wrappers
     ├── log.ts            # Commit log queries
+    ├── diff.ts           # File change detection
     ├── query-tags.ts     # Tag listing & queries
     ├── manage-tags.ts    # Tag create/delete/push
     ├── commit.ts         # Commit creation
     ├── stage.ts          # File staging
     ├── status.ts         # Repository status
+    ├── operation-state.ts # Git operation state
     └── head-info.ts      # HEAD information
 ```
 

--- a/libs/versioning/src/git/README.md
+++ b/libs/versioning/src/git/README.md
@@ -147,9 +147,11 @@ flowchart TB
 | `createEmptyCommit()`  | Create an empty commit       | [commit.ts](./operations/commit.ts)       |
 | `getHead()`            | Get HEAD commit hash         | [head-info.ts](./operations/head-info.ts) |
 | `getCurrentBranch()`   | Get current branch name      | [head-info.ts](./operations/head-info.ts) |
-| `hasStagedChanges()`   | Check for staged changes     | [status.ts](./operations/status.ts)       |
-| `hasUnstagedChanges()` | Check for unstaged changes   | [status.ts](./operations/status.ts)       |
-| `hasUntrackedFiles()`  | Check for untracked files    | [status.ts](./operations/status.ts)       |
+| `hasStagedChanges()`   | Check for staged changes     | [stage.ts](./operations/stage.ts)         |
+| `hasUnstagedChanges()` | Check for unstaged changes   | [stage.ts](./operations/stage.ts)         |
+| `hasUntrackedFiles()`  | Check for untracked files    | [head-info.ts](./operations/head-info.ts) |
+| `discardChanges()`     | Discard uncommitted changes  | [stage.ts](./operations/stage.ts)         |
+| `discardAllChanges()`  | Discard and unstage all      | [stage.ts](./operations/stage.ts)         |
 
 ### Status Operations
 

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -75,6 +75,13 @@ jest.mock('./operations/manage-tags', () => ({
   deleteTag: jest.fn().mockReturnValue(true),
   pushTag: jest.fn().mockReturnValue(true),
 }))
+jest.mock('./operations/operation-state', () => ({
+  ...jest.requireActual('./operations/operation-state'),
+  getOperationState: jest
+    .fn()
+    .mockReturnValue({ inProgress: false, reason: null, details: { rebaseMerge: false, rebaseApply: false, mergeHead: false } }),
+  isOperationInProgress: jest.fn().mockReturnValue(false),
+}))
 
 describe('createGitClient', () => {
   beforeEach(() => {
@@ -440,6 +447,24 @@ describe('createGitClient', () => {
       const result = client.getUntrackedFiles()
 
       expect(result).toEqual([])
+    })
+  })
+
+  describe('operation state', () => {
+    it('provides getOperationState method', () => {
+      const client = createGitClient()
+
+      const result = client.getOperationState()
+
+      expect(result).toEqual(expect.objectContaining({ inProgress: false, reason: null }))
+    })
+
+    it('provides isOperationInProgress method', () => {
+      const client = createGitClient()
+
+      const result = client.isOperationInProgress()
+
+      expect(result).toBe(false)
     })
   })
 

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -35,6 +35,12 @@ jest.mock('./operations/log', () => ({
   commitExists: jest.fn().mockReturnValue(false),
   commitReachableFromHead: jest.fn().mockReturnValue(false),
 }))
+jest.mock('./operations/diff', () => ({
+  ...jest.requireActual('./operations/diff'),
+  getChangedFilesBetween: jest.fn().mockReturnValue([]),
+  getChangedFilesBetweenWithStatus: jest.fn().mockReturnValue([]),
+  getCommitWithFiles: jest.fn().mockReturnValue(null),
+}))
 jest.mock('./operations/status', () => ({
   getStatus: jest.fn().mockReturnValue({
     branch: 'main',
@@ -161,6 +167,48 @@ describe('createGitClient', () => {
       const result = client.commitReachableFromHead('abc123')
 
       expect(result).toBe(false)
+    })
+  })
+
+  describe('diff operations', () => {
+    it('provides getChangedFilesBetween method', () => {
+      const client = createGitClient()
+
+      const result = client.getChangedFilesBetween('origin/main')
+
+      expect(result).toEqual([])
+    })
+
+    it('provides getChangedFilesBetween with custom head', () => {
+      const client = createGitClient()
+
+      const result = client.getChangedFilesBetween('v1.0.0', 'v2.0.0')
+
+      expect(result).toEqual([])
+    })
+
+    it('provides getChangedFilesBetweenWithStatus method', () => {
+      const client = createGitClient()
+
+      const result = client.getChangedFilesBetweenWithStatus('origin/main')
+
+      expect(result).toEqual([])
+    })
+
+    it('provides getChangedFilesBetweenWithStatus with custom head', () => {
+      const client = createGitClient()
+
+      const result = client.getChangedFilesBetweenWithStatus('v1.0.0', 'v2.0.0')
+
+      expect(result).toEqual([])
+    })
+
+    it('provides getCommitWithFiles method', () => {
+      const client = createGitClient()
+
+      const result = client.getCommitWithFiles('abc123')
+
+      expect(result).toBeNull()
     })
   })
 

--- a/libs/versioning/src/git/factory.spec.ts
+++ b/libs/versioning/src/git/factory.spec.ts
@@ -17,6 +17,8 @@ jest.mock('./operations/stage', () => ({
   stageAll: jest.fn().mockReturnValue(true),
   hasStagedChanges: jest.fn().mockReturnValue(false),
   hasUnstagedChanges: jest.fn().mockReturnValue(false),
+  discardChanges: jest.fn().mockReturnValue(true),
+  discardAllChanges: jest.fn().mockReturnValue(true),
 }))
 jest.mock('./operations/head-info', () => ({
   ...jest.requireActual('./operations/head-info'),
@@ -300,6 +302,22 @@ describe('createGitClient', () => {
       const result = client.hasUnstagedChanges()
 
       expect(result).toBe(false)
+    })
+
+    it('provides discardChanges method', () => {
+      const client = createGitClient()
+
+      const result = client.discardChanges()
+
+      expect(result).toBe(true)
+    })
+
+    it('provides discardAllChanges method', () => {
+      const client = createGitClient()
+
+      const result = client.discardAllChanges()
+
+      expect(result).toBe(true)
     })
 
     it('provides hasUntrackedFiles method', () => {

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -5,7 +5,7 @@ import type { CreateCommitOptions } from './operations/commit'
 import type { GitLogOptions } from './operations/log'
 import type { CreateTagOptions } from './operations/manage-tags'
 import type { ListTagsOptions } from './operations/query-tags'
-import type { StageOptions } from './operations/stage'
+import type { StageOptions, DiscardChangesOptions } from './operations/stage'
 import type { RepositoryStatus } from './operations/status'
 import { execFileSync } from 'node:child_process'
 import { createGitRef } from './models/ref'
@@ -14,7 +14,7 @@ import { getHead, getCurrentBranch, hasUntrackedFiles } from './operations/head-
 import { getCommitLog, getCommitsBetween, getCommitsSince, getCommit, commitExists, commitReachableFromHead } from './operations/log'
 import { createTag, deleteTag, pushTag } from './operations/manage-tags'
 import { getTags, getTag, tagExists, getLatestTag, getTagsForPackage } from './operations/query-tags'
-import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges } from './operations/stage'
+import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges, discardChanges, discardAllChanges } from './operations/stage'
 import {
   getStatus,
   isClean,
@@ -231,6 +231,20 @@ export interface GitClient {
   hasUnstagedChanges(): boolean
 
   /**
+   * Discards uncommitted changes to tracked files.
+   *
+   * **Warning:** Destructive operation — discarded changes cannot be recovered.
+   */
+  discardChanges(options?: Omit<DiscardChangesOptions, 'cwd'>): boolean
+
+  /**
+   * Discards all changes and unstages all files.
+   *
+   * **Warning:** Destructive operation — discarded changes cannot be recovered.
+   */
+  discardAllChanges(): boolean
+
+  /**
    * Checks if there are untracked files.
    */
   hasUntrackedFiles(): boolean
@@ -407,6 +421,8 @@ export function createGitClient(config: GitClientConfig = {}): GitClient {
     getCurrentBranch: () => getCurrentBranch(opts),
     hasStagedChanges: () => hasStagedChanges(opts),
     hasUnstagedChanges: () => hasUnstagedChanges(opts),
+    discardChanges: (options) => discardChanges({ ...opts, ...options }),
+    discardAllChanges: () => discardAllChanges(opts),
     hasUntrackedFiles: () => hasUntrackedFiles(opts),
 
     // Status operations

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -2,6 +2,7 @@ import type { GitCommit } from './models/commit'
 import type { GitRef } from './models/ref'
 import type { GitTag } from './models/tag'
 import type { CreateCommitOptions } from './operations/commit'
+import type { FileChange, GitCommitWithFiles } from './operations/diff'
 import type { GitLogOptions } from './operations/log'
 import type { CreateTagOptions } from './operations/manage-tags'
 import type { GitOperationState } from './operations/operation-state'
@@ -11,6 +12,7 @@ import type { RepositoryStatus } from './operations/status'
 import { execFileSync } from 'node:child_process'
 import { createGitRef } from './models/ref'
 import { commit, amendCommit, createEmptyCommit } from './operations/commit'
+import { getChangedFilesBetween, getChangedFilesBetweenWithStatus, getCommitWithFiles } from './operations/diff'
 import { getHead, getCurrentBranch, hasUntrackedFiles } from './operations/head-info'
 import { getCommitLog, getCommitsBetween, getCommitsSince, getCommit, commitExists, commitReachableFromHead } from './operations/log'
 import { createTag, deleteTag, pushTag } from './operations/manage-tags'
@@ -137,6 +139,23 @@ export interface GitClient {
    * range queries. Detects if history was rewritten after the reference was recorded.
    */
   commitReachableFromHead(hash: string): boolean
+
+  // ========== Diff Operations ==========
+
+  /**
+   * Gets files changed between two refs.
+   */
+  getChangedFilesBetween(base: string, head?: string): readonly string[]
+
+  /**
+   * Gets files changed between two refs with status.
+   */
+  getChangedFilesBetweenWithStatus(base: string, head?: string): readonly FileChange[]
+
+  /**
+   * Gets a commit with its changed files.
+   */
+  getCommitWithFiles(hash: string): GitCommitWithFiles | null
 
   // ========== Tag Operations ==========
 
@@ -416,6 +435,11 @@ export function createGitClient(config: GitClientConfig = {}): GitClient {
     getCommit: (hash) => getCommit(hash, opts),
     commitExists: (hash) => commitExists(hash, opts),
     commitReachableFromHead: (hash) => commitReachableFromHead(hash, opts),
+
+    // Diff operations
+    getChangedFilesBetween: (base, head) => getChangedFilesBetween(base, head, opts),
+    getChangedFilesBetweenWithStatus: (base, head) => getChangedFilesBetweenWithStatus(base, head, opts),
+    getCommitWithFiles: (hash) => getCommitWithFiles(hash, opts),
 
     // Tag operations
     getTags: (options) => getTags({ ...opts, ...options }),

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -4,6 +4,7 @@ import type { GitTag } from './models/tag'
 import type { CreateCommitOptions } from './operations/commit'
 import type { GitLogOptions } from './operations/log'
 import type { CreateTagOptions } from './operations/manage-tags'
+import type { GitOperationState } from './operations/operation-state'
 import type { ListTagsOptions } from './operations/query-tags'
 import type { StageOptions, DiscardChangesOptions } from './operations/stage'
 import type { RepositoryStatus } from './operations/status'
@@ -13,6 +14,7 @@ import { commit, amendCommit, createEmptyCommit } from './operations/commit'
 import { getHead, getCurrentBranch, hasUntrackedFiles } from './operations/head-info'
 import { getCommitLog, getCommitsBetween, getCommitsSince, getCommit, commitExists, commitReachableFromHead } from './operations/log'
 import { createTag, deleteTag, pushTag } from './operations/manage-tags'
+import { getOperationState, isOperationInProgress } from './operations/operation-state'
 import { getTags, getTag, tagExists, getLatestTag, getTagsForPackage } from './operations/query-tags'
 import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges, discardChanges, discardAllChanges } from './operations/stage'
 import {
@@ -321,6 +323,21 @@ export interface GitClient {
    */
   getUntrackedFiles(): readonly string[]
 
+  // ========== Operation State ==========
+
+  /**
+   * Gets the current git operation state.
+   *
+   * Detects if git is in the middle of an incomplete operation such as
+   * a rebase or merge.
+   */
+  getOperationState(): GitOperationState
+
+  /**
+   * Checks if an operation (rebase, merge) is in progress.
+   */
+  isOperationInProgress(): boolean
+
   // ========== Ref Operations ==========
 
   /**
@@ -440,6 +457,10 @@ export function createGitClient(config: GitClientConfig = {}): GitClient {
     getStagedFiles: () => getStagedFiles(opts),
     getModifiedFiles: () => getModifiedFiles(opts),
     getUntrackedFiles: () => getUntrackedFiles(opts),
+
+    // Operation state
+    getOperationState: () => getOperationState(opts),
+    isOperationInProgress: () => isOperationInProgress(opts),
 
     // Ref operations
     getRefs: () => getRefs(opts),

--- a/libs/versioning/src/git/operations/diff.spec.ts
+++ b/libs/versioning/src/git/operations/diff.spec.ts
@@ -1,0 +1,443 @@
+import { execFileSync } from 'node:child_process'
+import { getChangedFilesBetween, getChangedFilesBetweenWithStatus, getCommitWithFiles, DEFAULT_DIFF_OPTIONS } from './diff'
+import { getCommit } from './log'
+
+jest.mock('node:child_process')
+jest.mock('./log', () => ({
+  ...jest.requireActual('./log'),
+  getCommit: jest.fn(),
+}))
+
+const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>
+const mockGetCommit = getCommit as jest.MockedFunction<typeof getCommit>
+
+describe('DEFAULT_DIFF_OPTIONS', () => {
+  it('has expected default values', () => {
+    expect(DEFAULT_DIFF_OPTIONS.timeout).toBe(30000)
+  })
+})
+
+describe('getChangedFilesBetween', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns empty array for empty output', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = getChangedFilesBetween('origin/main')
+
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only output', () => {
+    mockExecFileSync.mockReturnValue('   \n\t  ')
+
+    const result = getChangedFilesBetween('origin/main')
+
+    expect(result).toEqual([])
+  })
+
+  it('parses single file', () => {
+    mockExecFileSync.mockReturnValue('src/index.ts\n')
+
+    const result = getChangedFilesBetween('origin/main')
+
+    expect(result).toEqual(['src/index.ts'])
+  })
+
+  it('parses multiple files', () => {
+    mockExecFileSync.mockReturnValue('src/index.ts\nlibs/utils/helper.ts\nREADME.md\n')
+
+    const result = getChangedFilesBetween('origin/main')
+
+    expect(result).toEqual(['src/index.ts', 'libs/utils/helper.ts', 'README.md'])
+  })
+
+  it('handles files without trailing newline', () => {
+    mockExecFileSync.mockReturnValue('src/index.ts\nlibs/utils/helper.ts')
+
+    const result = getChangedFilesBetween('origin/main')
+
+    expect(result).toEqual(['src/index.ts', 'libs/utils/helper.ts'])
+  })
+
+  it('calls git diff with correct arguments', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getChangedFilesBetween('origin/main', 'HEAD')
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-only', 'origin/main...HEAD'],
+      expect.objectContaining({
+        encoding: 'utf-8',
+        timeout: 30000,
+      })
+    )
+  })
+
+  it('uses custom head reference', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getChangedFilesBetween('v1.0.0', 'v2.0.0')
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['diff', '--name-only', 'v1.0.0...v2.0.0'], expect.anything())
+  })
+
+  it('uses custom cwd option', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getChangedFilesBetween('origin/main', 'HEAD', { cwd: '/custom/path' })
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.anything(),
+      expect.objectContaining({
+        cwd: '/custom/path',
+      })
+    )
+  })
+
+  it('uses custom timeout option', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getChangedFilesBetween('origin/main', 'HEAD', { timeout: 5000 })
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.anything(),
+      expect.objectContaining({
+        timeout: 5000,
+      })
+    )
+  })
+
+  it('returns empty array on git error', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: bad object')
+    })
+
+    const result = getChangedFilesBetween('nonexistent-ref')
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('getChangedFilesBetweenWithStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns empty array for empty output', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([])
+  })
+
+  it('parses added file', () => {
+    mockExecFileSync.mockReturnValue('A\tsrc/new-file.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/new-file.ts', status: 'added' }])
+  })
+
+  it('parses modified file', () => {
+    mockExecFileSync.mockReturnValue('M\tsrc/index.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/index.ts', status: 'modified' }])
+  })
+
+  it('parses deleted file', () => {
+    mockExecFileSync.mockReturnValue('D\tsrc/old-file.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/old-file.ts', status: 'deleted' }])
+  })
+
+  it('parses renamed file', () => {
+    mockExecFileSync.mockReturnValue('R100\tsrc/old-name.ts\tsrc/new-name.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([
+      {
+        path: 'src/new-name.ts',
+        status: 'renamed',
+        oldPath: 'src/old-name.ts',
+      },
+    ])
+  })
+
+  it('parses copied file', () => {
+    mockExecFileSync.mockReturnValue('C100\tsrc/original.ts\tsrc/copy.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([
+      {
+        path: 'src/copy.ts',
+        status: 'copied',
+        oldPath: 'src/original.ts',
+      },
+    ])
+  })
+
+  it('parses renamed file with partial similarity', () => {
+    mockExecFileSync.mockReturnValue('R095\tsrc/old.ts\tsrc/new.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([
+      {
+        path: 'src/new.ts',
+        status: 'renamed',
+        oldPath: 'src/old.ts',
+      },
+    ])
+  })
+
+  it('parses multiple files with different statuses', () => {
+    mockExecFileSync.mockReturnValue('A\tsrc/new.ts\nM\tsrc/index.ts\nD\tsrc/old.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([
+      { path: 'src/new.ts', status: 'added' },
+      { path: 'src/index.ts', status: 'modified' },
+      { path: 'src/old.ts', status: 'deleted' },
+    ])
+  })
+
+  it('calls git diff with correct arguments', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    getChangedFilesBetweenWithStatus('origin/main', 'HEAD')
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-status', '-M', 'origin/main...HEAD'],
+      expect.objectContaining({
+        encoding: 'utf-8',
+        timeout: 30000,
+      })
+    )
+  })
+
+  it('returns empty array on git error', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: bad object')
+    })
+
+    const result = getChangedFilesBetweenWithStatus('nonexistent-ref')
+
+    expect(result).toEqual([])
+  })
+
+  it('skips invalid lines', () => {
+    mockExecFileSync.mockReturnValue('invalid line\nM\tsrc/valid.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/valid.ts', status: 'modified' }])
+  })
+
+  it('skips unknown status codes', () => {
+    mockExecFileSync.mockReturnValue('X\tsrc/unknown.ts\nM\tsrc/valid.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/valid.ts', status: 'modified' }])
+  })
+
+  it('handles renamed file without second tab (malformed output)', () => {
+    mockExecFileSync.mockReturnValue('R100\tsrc/file.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/file.ts', status: 'renamed' }])
+  })
+
+  it('handles copied file without second tab (malformed output)', () => {
+    mockExecFileSync.mockReturnValue('C100\tsrc/file.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([{ path: 'src/file.ts', status: 'copied' }])
+  })
+
+  it('handles empty lines in output', () => {
+    mockExecFileSync.mockReturnValue('A\tsrc/new.ts\n\nM\tsrc/index.ts\n')
+
+    const result = getChangedFilesBetweenWithStatus('origin/main')
+
+    expect(result).toEqual([
+      { path: 'src/new.ts', status: 'added' },
+      { path: 'src/index.ts', status: 'modified' },
+    ])
+  })
+})
+
+describe('getCommitWithFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns null if commit not found', () => {
+    mockGetCommit.mockReturnValue(null)
+
+    const result = getCommitWithFiles('nonexistent')
+
+    expect(result).toBeNull()
+    expect(mockExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('returns commit with empty files if diff-tree fails', () => {
+    mockGetCommit.mockReturnValue({
+      hash: 'abc1234567890def1234567890abc1234567890de',
+      shortHash: 'abc1234',
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      authorDate: '2026-03-12T10:00:00Z',
+      committerName: 'John Doe',
+      committerEmail: 'john@example.com',
+      commitDate: '2026-03-12T10:00:00Z',
+      subject: 'feat: test commit',
+      body: '',
+      message: 'feat: test commit',
+      parents: [],
+      refs: [],
+    })
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: bad object')
+    })
+
+    const result = getCommitWithFiles('abc1234')
+
+    expect(result).not.toBeNull()
+    expect(result?.files).toEqual([])
+    expect(result?.hash).toBe('abc1234567890def1234567890abc1234567890de')
+  })
+
+  it('returns commit with files', () => {
+    mockGetCommit.mockReturnValue({
+      hash: 'abc1234567890def1234567890abc1234567890de',
+      shortHash: 'abc1234',
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      authorDate: '2026-03-12T10:00:00Z',
+      committerName: 'John Doe',
+      committerEmail: 'john@example.com',
+      commitDate: '2026-03-12T10:00:00Z',
+      subject: 'feat: add feature',
+      body: '',
+      message: 'feat: add feature',
+      parents: [],
+      refs: [],
+    })
+    mockExecFileSync.mockReturnValue('A\tsrc/new.ts\nM\tsrc/index.ts\n')
+
+    const result = getCommitWithFiles('abc1234')
+
+    expect(result).not.toBeNull()
+    expect(result?.subject).toBe('feat: add feature')
+    expect(result?.files).toEqual([
+      { path: 'src/new.ts', status: 'added' },
+      { path: 'src/index.ts', status: 'modified' },
+    ])
+  })
+
+  it('calls git diff-tree with correct arguments', () => {
+    mockGetCommit.mockReturnValue({
+      hash: 'abc1234567890def1234567890abc1234567890de',
+      shortHash: 'abc1234',
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      authorDate: '2026-03-12T10:00:00Z',
+      committerName: 'John Doe',
+      committerEmail: 'john@example.com',
+      commitDate: '2026-03-12T10:00:00Z',
+      subject: 'feat: test',
+      body: '',
+      message: 'feat: test',
+      parents: [],
+      refs: [],
+    })
+    mockExecFileSync.mockReturnValue('')
+
+    getCommitWithFiles('abc1234')
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['diff-tree', '--no-commit-id', '-r', '--name-status', '-M', 'abc1234'],
+      expect.objectContaining({
+        encoding: 'utf-8',
+      })
+    )
+  })
+
+  it('uses custom cwd option', () => {
+    mockGetCommit.mockReturnValue({
+      hash: 'abc1234567890def1234567890abc1234567890de',
+      shortHash: 'abc1234',
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      authorDate: '2026-03-12T10:00:00Z',
+      committerName: 'John Doe',
+      committerEmail: 'john@example.com',
+      commitDate: '2026-03-12T10:00:00Z',
+      subject: 'feat: test',
+      body: '',
+      message: 'feat: test',
+      parents: [],
+      refs: [],
+    })
+    mockExecFileSync.mockReturnValue('')
+
+    getCommitWithFiles('abc1234', { cwd: '/custom/path' })
+
+    expect(mockGetCommit).toHaveBeenCalledWith('abc1234', expect.objectContaining({ cwd: '/custom/path' }))
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.anything(),
+      expect.objectContaining({
+        cwd: '/custom/path',
+      })
+    )
+  })
+
+  it('handles renamed files in commit', () => {
+    mockGetCommit.mockReturnValue({
+      hash: 'abc1234567890def1234567890abc1234567890de',
+      shortHash: 'abc1234',
+      authorName: 'John Doe',
+      authorEmail: 'john@example.com',
+      authorDate: '2026-03-12T10:00:00Z',
+      committerName: 'John Doe',
+      committerEmail: 'john@example.com',
+      commitDate: '2026-03-12T10:00:00Z',
+      subject: 'refactor: rename file',
+      body: '',
+      message: 'refactor: rename file',
+      parents: [],
+      refs: [],
+    })
+    mockExecFileSync.mockReturnValue('R100\tsrc/old.ts\tsrc/new.ts\n')
+
+    const result = getCommitWithFiles('abc1234')
+
+    expect(result?.files).toEqual([
+      {
+        path: 'src/new.ts',
+        status: 'renamed',
+        oldPath: 'src/old.ts',
+      },
+    ])
+  })
+})

--- a/libs/versioning/src/git/operations/diff.ts
+++ b/libs/versioning/src/git/operations/diff.ts
@@ -1,0 +1,384 @@
+import type { GitCommit } from '../models/commit'
+import { execFileSync } from 'node:child_process'
+import { escapeGitRef } from './log'
+import { getCommit } from './log'
+
+/**
+ * File change status codes matching git conventions.
+ */
+export type FileChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'copied'
+
+/**
+ * A file changed in a commit or between refs.
+ */
+export interface FileChange {
+  /** File path relative to repository root */
+  readonly path: string
+
+  /** Type of change */
+  readonly status: FileChangeStatus
+
+  /** Original path for renames/copies */
+  readonly oldPath?: string
+}
+
+/**
+ * Options for diff-based queries.
+ */
+export interface DiffOptions {
+  /** Working directory (defaults to cwd) */
+  readonly cwd?: string
+
+  /** Timeout in milliseconds */
+  readonly timeout?: number
+}
+
+/**
+ * A git commit with file change information.
+ */
+export interface GitCommitWithFiles extends GitCommit {
+  /** Files changed in this commit */
+  readonly files: readonly FileChange[]
+}
+
+/**
+ * Default diff options.
+ */
+export const DEFAULT_DIFF_OPTIONS: Required<Omit<DiffOptions, 'cwd'>> = {
+  timeout: 30000,
+}
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Gets files changed between two git refs.
+ *
+ * Uses `git diff --name-only base...head` which computes the merge-base
+ * internally, giving files changed in `head` since diverging from `base`.
+ *
+ * @param base - Base reference (e.g., 'origin/main', 'v1.0.0')
+ * @param head - Head reference (defaults to 'HEAD')
+ * @param options - Additional options
+ * @returns Deduplicated list of changed file paths (relative to repo root)
+ *
+ * @example
+ * // Files changed since diverging from main
+ * const files = getChangedFilesBetween('origin/main')
+ *
+ * // Files changed between two tags
+ * const files = getChangedFilesBetween('v1.0.0', 'v2.0.0')
+ */
+export function getChangedFilesBetween(base: string, head = 'HEAD', options: DiffOptions = {}): readonly string[] {
+  const opts = { ...DEFAULT_DIFF_OPTIONS, ...options }
+  const safeBase = escapeGitRef(base)
+  const safeHead = escapeGitRef(head)
+
+  try {
+    const output = execFileSync('git', ['diff', '--name-only', `${safeBase}...${safeHead}`], {
+      encoding: 'utf-8',
+      cwd: opts.cwd,
+      timeout: opts.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 50 * 1024 * 1024, // 50MB
+    })
+
+    return parseFileList(output)
+  } catch {
+    // Return empty array if refs don't exist or diff fails
+    return []
+  }
+}
+
+/**
+ * Gets files changed between two refs with status information.
+ *
+ * @param base - Base reference
+ * @param head - Head reference (defaults to 'HEAD')
+ * @param options - Additional options
+ * @returns Array of file changes with status
+ *
+ * @example
+ * const changes = getChangedFilesBetweenWithStatus('v1.0.0', 'v2.0.0')
+ * const added = changes.filter(c => c.status === 'added')
+ */
+export function getChangedFilesBetweenWithStatus(base: string, head = 'HEAD', options: DiffOptions = {}): readonly FileChange[] {
+  const opts = { ...DEFAULT_DIFF_OPTIONS, ...options }
+  const safeBase = escapeGitRef(base)
+  const safeHead = escapeGitRef(head)
+
+  try {
+    // Use --name-status to get status codes
+    // Use -M for rename detection
+    const output = execFileSync('git', ['diff', '--name-status', '-M', `${safeBase}...${safeHead}`], {
+      encoding: 'utf-8',
+      cwd: opts.cwd,
+      timeout: opts.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 50 * 1024 * 1024, // 50MB
+    })
+
+    return parseNameStatusOutput(output)
+  } catch {
+    // Return empty array if refs don't exist or diff fails
+    return []
+  }
+}
+
+/**
+ * Gets a commit with its changed files.
+ *
+ * Uses `git diff-tree` to retrieve file changes for a single commit.
+ * More efficient than fetching files for all commits when only
+ * specific commits need file attribution.
+ *
+ * @param hash - Commit hash (full or abbreviated)
+ * @param options - Additional options
+ * @returns Commit with files, or null if not found
+ *
+ * @example
+ * const commit = getCommitWithFiles('abc123')
+ * if (commit) {
+ *   console.log(`${commit.subject} touched ${commit.files.length} files`)
+ * }
+ */
+export function getCommitWithFiles(hash: string, options: DiffOptions = {}): GitCommitWithFiles | null {
+  const opts = { ...DEFAULT_DIFF_OPTIONS, ...options }
+
+  // Get the commit metadata
+  const commit = getCommit(hash, { cwd: opts.cwd, timeout: opts.timeout })
+  if (!commit) {
+    return null
+  }
+
+  // Get the files changed in this commit
+  const files = getCommitFiles(hash, opts)
+
+  return {
+    ...commit,
+    files,
+  }
+}
+
+/**
+ * Gets the files changed in a specific commit.
+ *
+ * @param hash - Commit hash (full or abbreviated)
+ * @param options - Configuration including timeout and working directory
+ * @returns Array of file changes
+ */
+function getCommitFiles(hash: string, options: Required<Omit<DiffOptions, 'cwd'>> & { cwd?: string }): readonly FileChange[] {
+  const safeHash = escapeGitRef(hash)
+
+  try {
+    // git diff-tree --no-commit-id -r --name-status -M <hash>
+    // --no-commit-id: suppress the commit hash line
+    // -r: recurse into subtrees
+    // --name-status: show status codes
+    // -M: detect renames
+    const output = execFileSync('git', ['diff-tree', '--no-commit-id', '-r', '--name-status', '-M', safeHash], {
+      encoding: 'utf-8',
+      cwd: options.cwd,
+      timeout: options.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024, // 10MB
+    })
+
+    return parseNameStatusOutput(output)
+  } catch {
+    return []
+  }
+}
+
+// ============================================================================
+// Parsing Helpers
+// ============================================================================
+
+/**
+ * Parses file list output (from --name-only).
+ *
+ * @param output - Raw git output
+ * @returns Array of file paths
+ */
+function parseFileList(output: string): readonly string[] {
+  const trimmed = output.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  const files: string[] = []
+  let current = ''
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i]
+    if (char === '\n') {
+      const file = current.trim()
+      if (file) {
+        files.push(file)
+      }
+      current = ''
+    } else {
+      current += char
+    }
+  }
+
+  // Handle last line
+  const lastFile = current.trim()
+  if (lastFile) {
+    files.push(lastFile)
+  }
+
+  return files
+}
+
+/**
+ * Parses name-status output (from --name-status).
+ *
+ * Format: <status>\t<path> or <status>\t<oldPath>\t<newPath> for renames
+ *
+ * @param output - Raw git output
+ * @returns Array of file changes
+ */
+function parseNameStatusOutput(output: string): readonly FileChange[] {
+  const trimmed = output.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  const changes: FileChange[] = []
+  const lines = splitLines(trimmed)
+
+  for (const line of lines) {
+    const change = parseNameStatusLine(line)
+    if (change) {
+      changes.push(change)
+    }
+  }
+
+  return changes
+}
+
+/**
+ * Parses a single name-status line.
+ *
+ * @param line - Single line from name-status output
+ * @returns FileChange or null if line is invalid
+ */
+function parseNameStatusLine(line: string): FileChange | null {
+  const trimmed = line.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  // Find first tab to split status from path(s)
+  const tabIndex = findChar(trimmed, '\t')
+  if (tabIndex === -1) {
+    return null
+  }
+
+  const statusCode = trimmed.slice(0, tabIndex)
+  const pathPart = trimmed.slice(tabIndex + 1)
+
+  const status = parseStatusCode(statusCode)
+  if (!status) {
+    return null
+  }
+
+  // Check for rename/copy (has two paths)
+  if (status === 'renamed' || status === 'copied') {
+    const secondTabIndex = findChar(pathPart, '\t')
+    if (secondTabIndex !== -1) {
+      const oldPath = pathPart.slice(0, secondTabIndex)
+      const newPath = pathPart.slice(secondTabIndex + 1)
+      return {
+        path: newPath,
+        status,
+        oldPath,
+      }
+    }
+  }
+
+  return {
+    path: pathPart,
+    status,
+  }
+}
+
+/**
+ * Parses a git status code to FileChangeStatus.
+ *
+ * @param code - Git status code (A, M, D, R, C, or with percentage for R/C)
+ * @returns FileChangeStatus or null if unknown
+ */
+function parseStatusCode(code: string): FileChangeStatus | null {
+  if (!code) {
+    return null
+  }
+
+  const firstChar = code[0]
+
+  // Handle rename/copy with percentage (e.g., R100, C95)
+  if (firstChar === 'R') {
+    return 'renamed'
+  }
+  if (firstChar === 'C') {
+    return 'copied'
+  }
+
+  // Simple status codes
+  switch (firstChar) {
+    case 'A':
+      return 'added'
+    case 'M':
+      return 'modified'
+    case 'D':
+      return 'deleted'
+    default:
+      return null
+  }
+}
+
+/**
+ * Splits string into lines (no regex).
+ *
+ * @param str - String to split
+ * @returns Array of lines
+ */
+function splitLines(str: string): string[] {
+  const lines: string[] = []
+  let current = ''
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i]
+    if (char === '\n') {
+      lines.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+
+  // Handle last line
+  if (current) {
+    lines.push(current)
+  }
+
+  return lines
+}
+
+/**
+ * Finds character position (no regex).
+ *
+ * @param str - String to search
+ * @param char - Character to find
+ * @returns Position or -1 if not found
+ */
+function findChar(str: string, char: string): number {
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === char) {
+      return i
+    }
+  }
+  return -1
+}

--- a/libs/versioning/src/git/operations/index.ts
+++ b/libs/versioning/src/git/operations/index.ts
@@ -5,6 +5,7 @@ export type { GitCommitOptions, CreateCommitOptions } from './commit'
 export type { StageOptions, DiscardChangesOptions } from './stage'
 export type { GitStatusOptions, FileStatus, FileStatusEntry, RepositoryStatus } from './status'
 export type { GitOperationStateReason, GitOperationState, GitOperationStateOptions } from './operation-state'
+export type { FileChangeStatus, FileChange, DiffOptions, GitCommitWithFiles } from './diff'
 export {
   DEFAULT_LOG_OPTIONS,
   getCommitLog,
@@ -40,3 +41,4 @@ export {
   getModifiedFiles,
   getUntrackedFiles,
 } from './status'
+export { DEFAULT_DIFF_OPTIONS, getChangedFilesBetween, getChangedFilesBetweenWithStatus, getCommitWithFiles } from './diff'

--- a/libs/versioning/src/git/operations/index.ts
+++ b/libs/versioning/src/git/operations/index.ts
@@ -2,7 +2,7 @@ export type { GitLogOptions } from './log'
 export type { GitTagOptions, ListTagsOptions } from './query-tags'
 export type { CreateTagOptions } from './manage-tags'
 export type { GitCommitOptions, CreateCommitOptions } from './commit'
-export type { StageOptions } from './stage'
+export type { StageOptions, DiscardChangesOptions } from './stage'
 export type { GitStatusOptions, FileStatus, FileStatusEntry, RepositoryStatus } from './status'
 export {
   DEFAULT_LOG_OPTIONS,
@@ -19,7 +19,7 @@ export {
 export { DEFAULT_TAG_OPTIONS, getTags, getTag, tagExists, getLatestTag, getTagsForPackage, escapeGitTagPattern } from './query-tags'
 export { createTag, deleteTag, pushTag, escapeGitMessage } from './manage-tags'
 export { DEFAULT_COMMIT_OPTIONS, commit, amendCommit, amendCommitNoEdit, createEmptyCommit, escapeFilePath, escapeAuthor } from './commit'
-export { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges } from './stage'
+export { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges, discardChanges, discardAllChanges } from './stage'
 export { getHead, getCurrentBranch, hasUntrackedFiles } from './head-info'
 export {
   DEFAULT_STATUS_OPTIONS,

--- a/libs/versioning/src/git/operations/index.ts
+++ b/libs/versioning/src/git/operations/index.ts
@@ -4,6 +4,7 @@ export type { CreateTagOptions } from './manage-tags'
 export type { GitCommitOptions, CreateCommitOptions } from './commit'
 export type { StageOptions, DiscardChangesOptions } from './stage'
 export type { GitStatusOptions, FileStatus, FileStatusEntry, RepositoryStatus } from './status'
+export type { GitOperationStateReason, GitOperationState, GitOperationStateOptions } from './operation-state'
 export {
   DEFAULT_LOG_OPTIONS,
   getCommitLog,
@@ -21,6 +22,7 @@ export { createTag, deleteTag, pushTag, escapeGitMessage } from './manage-tags'
 export { DEFAULT_COMMIT_OPTIONS, commit, amendCommit, amendCommitNoEdit, createEmptyCommit, escapeFilePath, escapeAuthor } from './commit'
 export { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges, discardChanges, discardAllChanges } from './stage'
 export { getHead, getCurrentBranch, hasUntrackedFiles } from './head-info'
+export { DEFAULT_OPERATION_STATE_OPTIONS, getOperationState, isOperationInProgress } from './operation-state'
 export {
   DEFAULT_STATUS_OPTIONS,
   getStatus,

--- a/libs/versioning/src/git/operations/operation-state.spec.ts
+++ b/libs/versioning/src/git/operations/operation-state.spec.ts
@@ -1,0 +1,246 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { getOperationState, isOperationInProgress, DEFAULT_OPERATION_STATE_OPTIONS } from './operation-state'
+
+jest.mock('node:child_process')
+jest.mock('node:fs')
+
+const mockExecFileSync = <jest.MockedFunction<typeof execFileSync>>execFileSync
+const mockExistsSync = <jest.MockedFunction<typeof existsSync>>existsSync
+
+describe('getOperationState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('rebase-interactive detection', () => {
+    it('returns rebase-interactive when rebase-merge exists', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockImplementation((path) => {
+        return String(path).includes('rebase-merge')
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: true,
+          reason: 'rebase-interactive',
+          details: { rebaseMerge: true, rebaseApply: false, mergeHead: false },
+        })
+      )
+    })
+  })
+
+  describe('rebase-apply detection', () => {
+    it('returns rebase-apply when rebase-apply exists', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockImplementation((path) => {
+        return String(path).includes('rebase-apply')
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: true,
+          reason: 'rebase-apply',
+          details: { rebaseMerge: false, rebaseApply: true, mergeHead: false },
+        })
+      )
+    })
+  })
+
+  describe('merge-in-progress detection', () => {
+    it('returns merge-in-progress when MERGE_HEAD exists', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockImplementation((path) => {
+        return String(path).includes('MERGE_HEAD')
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: true,
+          reason: 'merge-in-progress',
+          details: { rebaseMerge: false, rebaseApply: false, mergeHead: true },
+        })
+      )
+    })
+  })
+
+  describe('stable state', () => {
+    it('returns stable state when no operation files exist', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockReturnValue(false)
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: false,
+          reason: null,
+          details: { rebaseMerge: false, rebaseApply: false, mergeHead: false },
+        })
+      )
+    })
+  })
+
+  describe('exit-early pattern', () => {
+    it('returns first detected reason (rebase-interactive) when multiple states exist', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      // All three exist
+      mockExistsSync.mockReturnValue(true)
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: true,
+          reason: 'rebase-interactive',
+          details: { rebaseMerge: true, rebaseApply: true, mergeHead: true },
+        })
+      )
+    })
+
+    it('returns rebase-apply when rebase-merge does not exist but rebase-apply does', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockImplementation((path) => {
+        const pathStr = String(path)
+        return pathStr.includes('rebase-apply') || pathStr.includes('MERGE_HEAD')
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(expect.objectContaining({ inProgress: true, reason: 'rebase-apply' }))
+    })
+  })
+
+  describe('error handling', () => {
+    it('returns stable state when git command fails', () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('Not a git repository')
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          inProgress: false,
+          reason: null,
+          details: { rebaseMerge: false, rebaseApply: false, mergeHead: false },
+        })
+      )
+    })
+
+    it('returns stable state when git is not installed', () => {
+      mockExecFileSync.mockImplementation(() => {
+        const error = new Error('ENOENT') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      })
+
+      const state = getOperationState()
+
+      expect(state).toEqual(expect.objectContaining({ inProgress: false, reason: null }))
+    })
+  })
+
+  describe('worktree support', () => {
+    it('uses git dir path from rev-parse for worktree', () => {
+      // Worktrees return a different git directory path
+      mockExecFileSync.mockReturnValue('/path/to/main/.git/worktrees/feature\n')
+      mockExistsSync.mockImplementation((path) => {
+        // Should check in the worktree git dir
+        return String(path).includes('/path/to/main/.git/worktrees/feature/rebase-merge')
+      })
+
+      const state = getOperationState({ cwd: '/path/to/worktree' })
+
+      expect(state).toEqual(expect.objectContaining({ inProgress: true, reason: 'rebase-interactive' }))
+    })
+  })
+
+  describe('options', () => {
+    it('uses custom cwd', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockReturnValue(false)
+
+      getOperationState({ cwd: '/custom/path' })
+
+      expect(mockExecFileSync).toHaveBeenCalledWith('git', ['rev-parse', '--git-dir'], expect.objectContaining({ cwd: '/custom/path' }))
+    })
+
+    it('uses custom timeout', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockReturnValue(false)
+
+      getOperationState({ timeout: 5000 })
+
+      expect(mockExecFileSync).toHaveBeenCalledWith('git', ['rev-parse', '--git-dir'], expect.objectContaining({ timeout: 5000 }))
+    })
+
+    it('uses default timeout from DEFAULT_OPERATION_STATE_OPTIONS', () => {
+      mockExecFileSync.mockReturnValue('.git\n')
+      mockExistsSync.mockReturnValue(false)
+
+      getOperationState()
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--git-dir'],
+        expect.objectContaining({ timeout: DEFAULT_OPERATION_STATE_OPTIONS.timeout })
+      )
+    })
+  })
+})
+
+describe('isOperationInProgress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true when operation is in progress', () => {
+    mockExecFileSync.mockReturnValue('.git\n')
+    mockExistsSync.mockImplementation((path) => {
+      return String(path).includes('MERGE_HEAD')
+    })
+
+    const result = isOperationInProgress()
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false when no operation is in progress', () => {
+    mockExecFileSync.mockReturnValue('.git\n')
+    mockExistsSync.mockReturnValue(false)
+
+    const result = isOperationInProgress()
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false on error', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('Not a git repository')
+    })
+
+    const result = isOperationInProgress()
+
+    expect(result).toBe(false)
+  })
+
+  it('passes options through to getOperationState', () => {
+    mockExecFileSync.mockReturnValue('.git\n')
+    mockExistsSync.mockReturnValue(false)
+
+    isOperationInProgress({ cwd: '/test', timeout: 1000 })
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', '--git-dir'],
+      expect.objectContaining({ cwd: '/test', timeout: 1000 })
+    )
+  })
+})

--- a/libs/versioning/src/git/operations/operation-state.ts
+++ b/libs/versioning/src/git/operations/operation-state.ts
@@ -1,0 +1,130 @@
+import type { GitCommitOptions } from './commit'
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { DEFAULT_COMMIT_OPTIONS } from './commit'
+
+/**
+ * Reasons why git may be in an unstable operation state.
+ *
+ * These correspond to state files that git creates during multi-step operations:
+ *
+ * - `'rebase-interactive'`: `.git/rebase-merge` exists (interactive rebase paused)
+ * - `'rebase-apply'`: `.git/rebase-apply` exists (mailbox-based rebase or `git am`)
+ * - `'merge-in-progress'`: `.git/MERGE_HEAD` exists (merge awaiting conflict resolution)
+ */
+export type GitOperationStateReason =
+  | 'rebase-interactive' // .git/rebase-merge exists (interactive rebase)
+  | 'rebase-apply' // .git/rebase-apply exists (am/apply rebase)
+  | 'merge-in-progress' // .git/MERGE_HEAD exists
+
+/**
+ * Result of checking git's operation state.
+ */
+export interface GitOperationState {
+  /** True if git is mid-operation (rebase, merge, etc.) */
+  readonly inProgress: boolean
+
+  /**
+   * Which operation is in progress, if any.
+   * Returns the first detected state (exit-early pattern).
+   */
+  readonly reason: GitOperationStateReason | null
+
+  /**
+   * Detailed state for each check performed.
+   * Useful for diagnostics or when multiple states could theoretically overlap.
+   */
+  readonly details: {
+    readonly rebaseMerge: boolean
+    readonly rebaseApply: boolean
+    readonly mergeHead: boolean
+  }
+}
+
+/**
+ * Options for operation state check.
+ */
+export type GitOperationStateOptions = GitCommitOptions
+
+/**
+ * Default options for operation state checks.
+ */
+export const DEFAULT_OPERATION_STATE_OPTIONS: Required<Omit<GitOperationStateOptions, 'cwd'>> = {
+  timeout: DEFAULT_COMMIT_OPTIONS.timeout,
+}
+
+/**
+ * Detects if git is mid-operation (rebase, merge, patch apply).
+ *
+ * Uses filesystem checks on `.git/` state files rather than git commands.
+ * This is more reliable because file existence checks are atomic OS syscalls
+ * that work even when the git index is corrupted or git commands would hang.
+ *
+ * Handles worktrees, submodules, and `$GIT_DIR` overrides via `git rev-parse --git-dir`.
+ *
+ * @param options - Configuration for the state check
+ * @returns Operation state with reason if in progress
+ *
+ * @example
+ * const state = getOperationState()
+ * if (state.inProgress) {
+ *   console.warn(`Cannot proceed: git ${state.reason} in progress`)
+ * }
+ */
+export function getOperationState(options: GitOperationStateOptions = {}): GitOperationState {
+  const opts = { ...DEFAULT_OPERATION_STATE_OPTIONS, ...options }
+
+  try {
+    // Get git directory (handles worktrees, submodules, GIT_DIR override)
+    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
+      cwd: opts.cwd,
+      encoding: 'utf-8',
+      timeout: opts.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+
+    const basePath = opts.cwd ?? process.cwd()
+    const rebaseMerge = existsSync(join(basePath, gitDir, 'rebase-merge'))
+    const rebaseApply = existsSync(join(basePath, gitDir, 'rebase-apply'))
+    const mergeHead = existsSync(join(basePath, gitDir, 'MERGE_HEAD'))
+
+    // Exit-early pattern: return first detected reason
+    let reason: GitOperationStateReason | null = null
+    if (rebaseMerge) reason = 'rebase-interactive'
+    else if (rebaseApply) reason = 'rebase-apply'
+    else if (mergeHead) reason = 'merge-in-progress'
+
+    return {
+      inProgress: reason !== null,
+      reason,
+      details: { rebaseMerge, rebaseApply, mergeHead },
+    }
+  } catch {
+    // Not a repo or git unavailable — assume no operation in progress (non-blocking)
+    return {
+      inProgress: false,
+      reason: null,
+      details: { rebaseMerge: false, rebaseApply: false, mergeHead: false },
+    }
+  }
+}
+
+/**
+ * Checks if git is in the middle of an incomplete operation.
+ *
+ * Convenience wrapper around `getOperationState()` for simple checks.
+ * Use `getOperationState()` directly when you need to know *which*
+ * operation is in progress.
+ *
+ * @param options - Configuration for the state check
+ * @returns True if rebase, merge, or other operation is incomplete
+ *
+ * @example
+ * if (isOperationInProgress()) {
+ *   throw new Error('Complete or abort the current git operation first')
+ * }
+ */
+export function isOperationInProgress(options: GitOperationStateOptions = {}): boolean {
+  return getOperationState(options).inProgress
+}

--- a/libs/versioning/src/git/operations/stage.spec.ts
+++ b/libs/versioning/src/git/operations/stage.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges } from './stage'
+import { stage, unstage, stageAll, hasStagedChanges, hasUnstagedChanges, discardChanges, discardAllChanges } from './stage'
 
 jest.mock('node:child_process')
 
@@ -187,6 +187,107 @@ describe('hasUnstagedChanges', () => {
     mockExecFileSync.mockReturnValue('')
 
     hasUnstagedChanges({ cwd: '/custom', timeout: 5000 })
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', expect.any(Array), expect.objectContaining({ cwd: '/custom', timeout: 5000 }))
+  })
+})
+
+describe('discardChanges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('discards all changes when no files specified', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = discardChanges()
+
+    expect(result).toBe(true)
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['checkout', '--', '.'], expect.any(Object))
+  })
+
+  it('discards specific files when files provided', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = discardChanges({ files: ['package.json', 'CHANGELOG.md'] })
+
+    expect(result).toBe(true)
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['checkout', '--', 'package.json', 'CHANGELOG.md'], expect.any(Object))
+  })
+
+  it('discards files with empty array (all changes)', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = discardChanges({ files: [] })
+
+    expect(result).toBe(true)
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['checkout', '--', '.'], expect.any(Object))
+  })
+
+  it('returns false on error', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('No changes to discard')
+    })
+
+    const result = discardChanges()
+
+    expect(result).toBe(false)
+  })
+
+  it('uses custom options', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    discardChanges({ cwd: '/custom', timeout: 5000 })
+
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', expect.any(Array), expect.objectContaining({ cwd: '/custom', timeout: 5000 }))
+  })
+})
+
+describe('discardAllChanges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls discardChanges and unstage', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const result = discardAllChanges()
+
+    expect(result).toBe(true)
+    // Should call git checkout -- .
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['checkout', '--', '.'], expect.any(Object))
+    // Should call git reset HEAD -- .
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['reset', 'HEAD', '--', '.'], expect.any(Object))
+  })
+
+  it('returns false if discardChanges fails', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('Discard failed')
+      })
+      .mockReturnValue('')
+
+    const result = discardAllChanges()
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false if unstage fails', () => {
+    mockExecFileSync
+      .mockReturnValueOnce('') // discardChanges succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('Unstage failed')
+      })
+
+    const result = discardAllChanges()
+
+    expect(result).toBe(false)
+  })
+
+  it('uses custom options', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    discardAllChanges({ cwd: '/custom', timeout: 5000 })
 
     expect(mockExecFileSync).toHaveBeenCalledWith('git', expect.any(Array), expect.objectContaining({ cwd: '/custom', timeout: 5000 }))
   })

--- a/libs/versioning/src/git/operations/stage.ts
+++ b/libs/versioning/src/git/operations/stage.ts
@@ -3,6 +3,17 @@ import { execFileSync } from 'node:child_process'
 import { DEFAULT_COMMIT_OPTIONS, escapeFilePath } from './commit'
 
 /**
+ * Options for discarding changes.
+ */
+export interface DiscardChangesOptions extends GitCommitOptions {
+  /**
+   * Files or directories to discard. If empty/undefined, discards ALL changes.
+   * Paths are relative to the working directory.
+   */
+  readonly files?: readonly string[]
+}
+
+/**
  * Options for staging files.
  */
 export interface StageOptions extends GitCommitOptions {
@@ -155,4 +166,76 @@ export function hasUnstagedChanges(options: GitCommitOptions = {}): boolean {
     // Exit code 1 means there are changes
     return true
   }
+}
+
+/**
+ * Discards uncommitted changes to tracked files.
+ *
+ * Uses `git checkout -- <files>` to restore files from HEAD.
+ * Returns true if successful, false otherwise (silent failure pattern).
+ *
+ * **Warning:** Destructive operation — discarded changes cannot be recovered.
+ *
+ * @param options - Configuration including optional file list
+ * @returns True if discard succeeded
+ *
+ * @example
+ * // Discard all changes
+ * discardChanges()
+ *
+ * // Discard specific files
+ * discardChanges({ files: ['package.json', 'CHANGELOG.md'] })
+ *
+ * @example
+ * // Typical rollback pattern
+ * if (hasUnstagedChanges()) {
+ *   discardChanges()
+ * }
+ * if (hasStagedChanges()) {
+ *   unstage(['.'])
+ * }
+ */
+export function discardChanges(options: DiscardChangesOptions = {}): boolean {
+  const opts = { ...DEFAULT_COMMIT_OPTIONS, ...options }
+
+  // Build args: git checkout -- [files...]
+  const args: string[] = ['checkout', '--']
+
+  if (opts.files && opts.files.length > 0) {
+    // Selective discard
+    for (const file of opts.files) {
+      args.push(escapeFilePath(file))
+    }
+  } else {
+    // Discard all: git checkout -- .
+    args.push('.')
+  }
+
+  try {
+    execFileSync('git', args, {
+      encoding: 'utf-8',
+      cwd: opts.cwd,
+      timeout: opts.timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Discards all uncommitted changes and unstages all files.
+ *
+ * Combines `discardChanges()` + `unstage(['.'])` for complete working tree reset.
+ *
+ * **Warning:** Destructive operation — discarded changes cannot be recovered.
+ *
+ * @param options - Configuration for the operation
+ * @returns True if both operations succeeded
+ */
+export function discardAllChanges(options: GitCommitOptions = {}): boolean {
+  const discarded = discardChanges(options)
+  const unstaged = unstage(['.'], options)
+  return discarded && unstaged
 }

--- a/libs/versioning/src/index.ts
+++ b/libs/versioning/src/index.ts
@@ -395,6 +395,10 @@ export {
 export type { GitOperationState, GitOperationStateReason, GitOperationStateOptions } from './git/operations/operation-state'
 export { getOperationState, isOperationInProgress, DEFAULT_OPERATION_STATE_OPTIONS } from './git/operations/operation-state'
 
+// Git Operations - Diff
+export type { FileChangeStatus, FileChange, DiffOptions, GitCommitWithFiles } from './git/operations/diff'
+export { DEFAULT_DIFF_OPTIONS, getChangedFilesBetween, getChangedFilesBetweenWithStatus, getCommitWithFiles } from './git/operations/diff'
+
 // Git Client Factory
 export type { GitClient, GitClientConfig } from './git/factory'
 export { createGitClient, DEFAULT_GIT_CLIENT_CONFIG } from './git/factory'

--- a/libs/versioning/src/index.ts
+++ b/libs/versioning/src/index.ts
@@ -391,6 +391,10 @@ export {
   getUntrackedFiles,
 } from './git/operations/status'
 
+// Git Operations - Operation State
+export type { GitOperationState, GitOperationStateReason, GitOperationStateOptions } from './git/operations/operation-state'
+export { getOperationState, isOperationInProgress, DEFAULT_OPERATION_STATE_OPTIONS } from './git/operations/operation-state'
+
 // Git Client Factory
 export type { GitClient, GitClientConfig } from './git/factory'
 export { createGitClient, DEFAULT_GIT_CLIENT_CONFIG } from './git/factory'

--- a/nx.json
+++ b/nx.json
@@ -97,5 +97,6 @@
       "exclude": ["**/*-e2e/**/*"]
     }
   ],
-  "nxCloudId": "6991685ccc04119366337805"
+  "nxCloudId": "6991685ccc04119366337805",
+  "neverConnectToCloud": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "yaml-eslint-parser": "2.0.0"
       },
       "engines": {
-        "node": "24.13.0",
+        "node": ">=24.13.0",
         "npm": ">=10.0.0"
       },
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,19 +6236,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -6621,9 +6608,9 @@
       }
     },
     "node_modules/babel-plugin-macros/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -12993,19 +12980,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -14012,9 +13986,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15364,19 +15338,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -16547,9 +16508,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://hyperfrontend.dev"
   },
   "engines": {
-    "node": "24.13.0",
+    "node": ">=24.13.0",
     "npm": ">=10.0.0"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "diff": "8.0.3",
     "lodash": "4.17.23",
     "minimatch": "10.2.3",
+    "picomatch": "4.0.4",
     "qs": "6.14.2",
     "test-exclude": "7.0.1",
     "tmp": "0.2.5"

--- a/project.json
+++ b/project.json
@@ -22,6 +22,13 @@
         "maxWarnings": 0,
         "errorOnUnmatchedPattern": false
       }
+    },
+    "version:all": {
+      "executor": "@hyperfrontend/package:version-batch",
+      "options": {
+        "base": "origin/main",
+        "head": "HEAD"
+      }
     }
   }
 }

--- a/tools/package/README.md
+++ b/tools/package/README.md
@@ -4,13 +4,14 @@ Nx plugin providing executors for building, type-checking, versioning, and publi
 
 ## Executors
 
-| Executor    | Description                                                       | Docs                                        |
-| ----------- | ----------------------------------------------------------------- | ------------------------------------------- |
-| `build`     | Format-centric build with explicit ESM/CJS/IIFE/UMD configuration | [README](./src/executors/build/README.md)   |
-| `typecheck` | TypeScript type checking without emitting files                   | -                                           |
-| `version`   | Zero-dependency conventional commits versioning (npm as source)   | [README](./src/executors/version/README.md) |
-| `publish`   | Publish to npm with dry-run support                               | [README](./src/executors/publish/README.md) |
-| `e2e`       | Test package outputs via npm pack + tarball install               | -                                           |
+| Executor        | Description                                                       | Docs                                        |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| `build`         | Format-centric build with explicit ESM/CJS/IIFE/UMD configuration | [README](./src/executors/build/README.md)   |
+| `typecheck`     | TypeScript type checking without emitting files                   | -                                           |
+| `version`       | Zero-dependency conventional commits versioning (npm as source)   | [README](./src/executors/version/README.md) |
+| `version-batch` | Batch versioning for all affected libraries                       | -                                           |
+| `publish`       | Publish to npm with dry-run support                               | [README](./src/executors/publish/README.md) |
+| `e2e`           | Test package outputs via npm pack + tarball install               | -                                           |
 
 ## Quick Start
 
@@ -61,6 +62,34 @@ Idempotent version executor using `@hyperfrontend/versioning` - a zero-dependenc
 - **Dependent updates** — automatically updates version references in dependent packages
 
 **Full documentation:** [src/executors/version/README.md](./src/executors/version/README.md) | [Architecture](./src/executors/version/ARCHITECTURE.md)
+
+### version-batch
+
+Batch versioning executor for all affected libraries. This is the recommended approach for batch operations and is automatically invoked by lefthook on git push.
+
+- **Affected detection** — programmatically detects libraries changed between base and head refs
+- **Batch commit** — creates a single commit for all version updates
+- **Rollback on failure** — automatically rolls back changes if any library fails
+- **Signal handling** — cleans up properly on interruption (Ctrl+C)
+
+**Options:**
+
+| Option      | Description                         | Default       |
+| ----------- | ----------------------------------- | ------------- |
+| `--base`    | Base git ref for affected detection | `origin/main` |
+| `--head`    | Head git ref for affected detection | `HEAD`        |
+| `--dryRun`  | Preview without making changes      | `false`       |
+| `--verbose` | Enable verbose logging              | `false`       |
+
+**Usage:**
+
+```bash
+# Preview batch version changes
+npx nx version-batch --dryRun
+
+# Run batch versioning (typically done by lefthook)
+npx nx version-batch
+```
 
 ### publish
 
@@ -127,11 +156,19 @@ src/executors/
 │   ├── executor.ts
 │   ├── schema.json
 │   └── README.md
-└── version/         # Semver version executor
+├── version/         # Semver version executor
+│   ├── executor.ts
+│   ├── schema.json
+│   ├── README.md
+│   ├── ARCHITECTURE.md
+│   └── lib/         # Version utilities
+├── version-batch/   # Batch versioning executor
+│   ├── executor.ts
+│   ├── schema.json
+│   └── lib/         # Batch utilities
+└── version-check/   # Version validation executor
     ├── executor.ts
-    ├── schema.json
-    ├── README.md
-    └── ARCHITECTURE.md
+    └── schema.json
 ```
 
 ---

--- a/tools/package/README.md
+++ b/tools/package/README.md
@@ -4,14 +4,14 @@ Nx plugin providing executors for building, type-checking, versioning, and publi
 
 ## Executors
 
-| Executor        | Description                                                       | Docs                                        |
-| --------------- | ----------------------------------------------------------------- | ------------------------------------------- |
-| `build`         | Format-centric build with explicit ESM/CJS/IIFE/UMD configuration | [README](./src/executors/build/README.md)   |
-| `typecheck`     | TypeScript type checking without emitting files                   | -                                           |
-| `version`       | Zero-dependency conventional commits versioning (npm as source)   | [README](./src/executors/version/README.md) |
-| `version-batch` | Batch versioning for all affected libraries                       | -                                           |
-| `publish`       | Publish to npm with dry-run support                               | [README](./src/executors/publish/README.md) |
-| `e2e`           | Test package outputs via npm pack + tarball install               | -                                           |
+| Executor      | Description                                                       | Docs                                        |
+| ------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| `build`       | Format-centric build with explicit ESM/CJS/IIFE/UMD configuration | [README](./src/executors/build/README.md)   |
+| `typecheck`   | TypeScript type checking without emitting files                   | -                                           |
+| `version`     | Zero-dependency conventional commits versioning (npm as source)   | [README](./src/executors/version/README.md) |
+| `version:all` | Batch versioning for all affected libraries                       | -                                           |
+| `publish`     | Publish to npm with dry-run support                               | [README](./src/executors/publish/README.md) |
+| `e2e`         | Test package outputs via npm pack + tarball install               | -                                           |
 
 ## Quick Start
 

--- a/tools/package/executors.json
+++ b/tools/package/executors.json
@@ -20,6 +20,11 @@
       "schema": "./src/executors/version/schema.json",
       "description": "Versioning executor using @hyperfrontend/versioning. Uses npm registry as source of truth."
     },
+    "version-batch": {
+      "implementation": "./src/executors/version-batch/executor",
+      "schema": "./src/executors/version-batch/schema.json",
+      "description": "Run versioning for all affected libraries and create a single batch commit."
+    },
     "version-check": {
       "implementation": "./src/executors/version-check/executor",
       "schema": "./src/executors/version-check/schema.json",

--- a/tools/package/src/executors/version-batch/executor.ts
+++ b/tools/package/src/executors/version-batch/executor.ts
@@ -3,6 +3,7 @@ import type { VersionBatchExecutorSchema } from './schema'
 import { createProjectGraphAsync } from '@nx/devkit'
 import { getCurrentBranch } from '@hyperfrontend/versioning/git/operations'
 import { isInUnstableGitState } from '../version/lib/is-in-unstable-git-state'
+import { getLogger } from '../version/lib/logger'
 import { runVersionForProject } from '../version/lib/run-version-for-project'
 import { createBatchCommit } from './lib/create-batch-commit'
 import { getAffectedLibraries } from './lib/get-affected-libraries'
@@ -41,21 +42,14 @@ export default async function versionBatchExecutor(
   const workspaceRoot = context.root
   const { base = 'origin/main', head = 'HEAD', dryRun = false, verbose = false } = options
 
-  const log = (message: string) => {
-    console.log(message)
-  }
-
-  const verboseLog = (message: string) => {
-    if (verbose) {
-      console.log(`[verbose] ${message}`)
-    }
-  }
+  const logger = getLogger()
+  logger.setLogLevel({ verbose, quiet: false })
 
   // Set up interrupt handlers for cleanup
   let interrupted = false
   const cleanupAndExit = async () => {
     interrupted = true
-    console.log('\nInterrupted, cleaning up...')
+    logger.log('\nInterrupted, cleaning up...')
     await rollbackChanges(workspaceRoot)
     process.exit(1)
   }
@@ -67,37 +61,37 @@ export default async function versionBatchExecutor(
     // Prerequisite: Check if on main branch (skip versioning on main)
     const currentBranch = getCurrentBranch({ cwd: workspaceRoot })
     if (currentBranch === 'main') {
-      log('On main branch, skipping version-batch')
+      logger.log('On main branch, skipping version-batch')
       return { success: true }
     }
 
-    verboseLog(`Current branch: ${currentBranch ?? 'unknown'}`)
-    verboseLog(`Base: ${base}, Head: ${head}`)
+    logger.debug(`Current branch: ${currentBranch ?? 'unknown'}`)
+    logger.debug(`Base: ${base}, Head: ${head}`)
 
     // Prerequisite: Check for unstable git state
     if (isInUnstableGitState(workspaceRoot)) {
-      console.error('Git is in an unstable state (rebase/merge in progress). Aborting.')
+      logger.error('Git is in an unstable state (rebase/merge in progress). Aborting.')
       return { success: false }
     }
 
     // Get project graph
     const projectGraph = await createProjectGraphAsync()
-    verboseLog(`Loaded project graph with ${Object.keys(projectGraph.nodes).length} nodes`)
+    logger.debug(`Loaded project graph with ${Object.keys(projectGraph.nodes).length} nodes`)
 
     // Detect affected libraries
     const affectedLibraries = await getAffectedLibraries(workspaceRoot, projectGraph, base, head)
 
     if (affectedLibraries.length === 0) {
-      log('No affected libraries with version target found')
+      logger.log('No affected libraries with version target found')
       return { success: true }
     }
 
-    log(`Found ${affectedLibraries.length} affected libraries: ${affectedLibraries.join(', ')}`)
+    logger.log(`Found ${affectedLibraries.length} affected libraries: ${affectedLibraries.join(', ')}`)
 
     if (dryRun) {
-      log('[dry-run] Would version the following libraries:')
+      logger.log('[dry-run] Would version the following libraries:')
       for (const lib of affectedLibraries) {
-        log(`  - ${lib}`)
+        logger.log(`  - ${lib}`)
       }
       return { success: true }
     }
@@ -113,11 +107,11 @@ export default async function versionBatchExecutor(
 
       const project = projectGraph.nodes[lib]
       if (!project) {
-        console.warn(`Project ${lib} not found in graph, skipping`)
+        logger.warn(`Project ${lib} not found in graph, skipping`)
         continue
       }
 
-      verboseLog(`Processing ${lib}...`)
+      logger.debug(`Processing ${lib}...`)
 
       try {
         const result = await runVersionForProject({
@@ -135,15 +129,15 @@ export default async function versionBatchExecutor(
         if (result.success && result.bumped) {
           bumpedLibs.push(lib)
           allModifiedFiles.push(...result.modifiedFiles)
-          log(`  ✓ ${lib}: ${result.previousVersion} → ${result.newVersion}`)
+          logger.log(`  ✓ ${lib}: ${result.previousVersion} → ${result.newVersion}`)
         } else if (result.success) {
-          verboseLog(`  - ${lib}: no version bump needed`)
+          logger.debug(`  - ${lib}: no version bump needed`)
         } else {
-          console.error(`  ✗ ${lib}: ${result.error ?? 'unknown error'}`)
+          logger.error(`  ✗ ${lib}: ${result.error ?? 'unknown error'}`)
           // Continue with other libraries, don't fail entire batch
         }
       } catch (error) {
-        console.error(`  ✗ ${lib}: ${error instanceof Error ? error.message : error}`)
+        logger.error(`  ✗ ${lib}: ${error instanceof Error ? error.message : error}`)
         // Continue with other libraries
       }
     }
@@ -154,23 +148,23 @@ export default async function versionBatchExecutor(
 
     // Create batch commit if any libraries were bumped
     if (bumpedLibs.length > 0) {
-      log(`\nCreating batch commit for ${bumpedLibs.length} libraries...`)
+      logger.log(`\nCreating batch commit for ${bumpedLibs.length} libraries...`)
 
       const commitHash = await createBatchCommit(workspaceRoot, allModifiedFiles, bumpedLibs)
 
-      log(`Created commit: ${commitHash.slice(0, 8)}`)
-      log(`Bumped: ${bumpedLibs.join(', ')}`)
+      logger.log(`Created commit: ${commitHash.slice(0, 8)}`)
+      logger.log(`Bumped: ${bumpedLibs.join(', ')}`)
     } else {
-      log('\nNo version bumps needed')
+      logger.log('\nNo version bumps needed')
     }
 
     return { success: true }
   } catch (error) {
-    console.error('version-batch failed:', error instanceof Error ? error.message : error)
+    logger.error(`version-batch failed: ${error instanceof Error ? error.message : error}`)
 
     // Rollback on failure
     if (!dryRun) {
-      log('Rolling back changes...')
+      logger.log('Rolling back changes...')
       await rollbackChanges(workspaceRoot)
     }
 

--- a/tools/package/src/executors/version-batch/executor.ts
+++ b/tools/package/src/executors/version-batch/executor.ts
@@ -1,0 +1,183 @@
+import type { ExecutorContext } from '@nx/devkit'
+import type { VersionBatchExecutorSchema } from './schema'
+import { createProjectGraphAsync } from '@nx/devkit'
+import { getCurrentBranch } from '@hyperfrontend/versioning/git/operations'
+import { isInUnstableGitState } from '../version/lib/is-in-unstable-git-state'
+import { runVersionForProject } from '../version/lib/run-version-for-project'
+import { createBatchCommit } from './lib/create-batch-commit'
+import { getAffectedLibraries } from './lib/get-affected-libraries'
+import { rollbackChanges } from './lib/rollback-changes'
+
+/**
+ * Result of version-batch executor.
+ */
+export interface VersionBatchResult {
+  success: boolean
+  /** Libraries that were actually bumped */
+  bumpedLibraries: string[]
+  /** Commit hash if a batch commit was created */
+  commitHash?: string
+  /** Error message if operation failed */
+  error?: string
+}
+
+/**
+ * version-batch executor
+ *
+ * Consolidates all batch versioning orchestration logic into TypeScript.
+ * This executor:
+ * 1. Detects affected libraries programmatically
+ * 2. Runs versioning for each affected library
+ * 3. Creates a single batch commit
+ *
+ * @param options - Executor options from schema
+ * @param context - Nx executor context
+ * @returns Executor result with success status
+ */
+export default async function versionBatchExecutor(
+  options: VersionBatchExecutorSchema,
+  context: ExecutorContext
+): Promise<{ success: boolean }> {
+  const workspaceRoot = context.root
+  const { base = 'origin/main', head = 'HEAD', dryRun = false, verbose = false } = options
+
+  const log = (message: string) => {
+    console.log(message)
+  }
+
+  const verboseLog = (message: string) => {
+    if (verbose) {
+      console.log(`[verbose] ${message}`)
+    }
+  }
+
+  // Set up interrupt handlers for cleanup
+  let interrupted = false
+  const cleanupAndExit = async () => {
+    interrupted = true
+    console.log('\nInterrupted, cleaning up...')
+    await rollbackChanges(workspaceRoot)
+    process.exit(1)
+  }
+
+  process.on('SIGINT', cleanupAndExit)
+  process.on('SIGTERM', cleanupAndExit)
+
+  try {
+    // Prerequisite: Check if on main branch (skip versioning on main)
+    const currentBranch = getCurrentBranch({ cwd: workspaceRoot })
+    if (currentBranch === 'main') {
+      log('On main branch, skipping version-batch')
+      return { success: true }
+    }
+
+    verboseLog(`Current branch: ${currentBranch ?? 'unknown'}`)
+    verboseLog(`Base: ${base}, Head: ${head}`)
+
+    // Prerequisite: Check for unstable git state
+    if (isInUnstableGitState(workspaceRoot)) {
+      console.error('Git is in an unstable state (rebase/merge in progress). Aborting.')
+      return { success: false }
+    }
+
+    // Get project graph
+    const projectGraph = await createProjectGraphAsync()
+    verboseLog(`Loaded project graph with ${Object.keys(projectGraph.nodes).length} nodes`)
+
+    // Detect affected libraries
+    const affectedLibraries = await getAffectedLibraries(workspaceRoot, projectGraph, base, head)
+
+    if (affectedLibraries.length === 0) {
+      log('No affected libraries with version target found')
+      return { success: true }
+    }
+
+    log(`Found ${affectedLibraries.length} affected libraries: ${affectedLibraries.join(', ')}`)
+
+    if (dryRun) {
+      log('[dry-run] Would version the following libraries:')
+      for (const lib of affectedLibraries) {
+        log(`  - ${lib}`)
+      }
+      return { success: true }
+    }
+
+    // Run versioning for each affected library
+    const bumpedLibs: string[] = []
+    const allModifiedFiles: string[] = []
+
+    for (const lib of affectedLibraries) {
+      if (interrupted) {
+        break
+      }
+
+      const project = projectGraph.nodes[lib]
+      if (!project) {
+        console.warn(`Project ${lib} not found in graph, skipping`)
+        continue
+      }
+
+      verboseLog(`Processing ${lib}...`)
+
+      try {
+        const result = await runVersionForProject({
+          projectName: lib,
+          workspaceRoot,
+          projectRoot: project.data.root,
+          projectGraph,
+          skipCommit: true,
+          skipTag: true,
+          dryRun: false,
+          verbose,
+          quiet: !verbose,
+        })
+
+        if (result.success && result.bumped) {
+          bumpedLibs.push(lib)
+          allModifiedFiles.push(...result.modifiedFiles)
+          log(`  ✓ ${lib}: ${result.previousVersion} → ${result.newVersion}`)
+        } else if (result.success) {
+          verboseLog(`  - ${lib}: no version bump needed`)
+        } else {
+          console.error(`  ✗ ${lib}: ${result.error ?? 'unknown error'}`)
+          // Continue with other libraries, don't fail entire batch
+        }
+      } catch (error) {
+        console.error(`  ✗ ${lib}: ${error instanceof Error ? error.message : error}`)
+        // Continue with other libraries
+      }
+    }
+
+    if (interrupted) {
+      return { success: false }
+    }
+
+    // Create batch commit if any libraries were bumped
+    if (bumpedLibs.length > 0) {
+      log(`\nCreating batch commit for ${bumpedLibs.length} libraries...`)
+
+      const commitHash = await createBatchCommit(workspaceRoot, allModifiedFiles, bumpedLibs)
+
+      log(`Created commit: ${commitHash.slice(0, 8)}`)
+      log(`Bumped: ${bumpedLibs.join(', ')}`)
+    } else {
+      log('\nNo version bumps needed')
+    }
+
+    return { success: true }
+  } catch (error) {
+    console.error('version-batch failed:', error instanceof Error ? error.message : error)
+
+    // Rollback on failure
+    if (!dryRun) {
+      log('Rolling back changes...')
+      await rollbackChanges(workspaceRoot)
+    }
+
+    return { success: false }
+  } finally {
+    // Remove interrupt handlers
+    process.removeListener('SIGINT', cleanupAndExit)
+    process.removeListener('SIGTERM', cleanupAndExit)
+  }
+}

--- a/tools/package/src/executors/version-batch/lib/create-batch-commit.ts
+++ b/tools/package/src/executors/version-batch/lib/create-batch-commit.ts
@@ -1,0 +1,56 @@
+import { commit, stage } from '@hyperfrontend/versioning/git/operations'
+
+/**
+ * Creates a batch commit containing all the version changes.
+ *
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param files - List of files to stage
+ * @param libraries - List of library names that were bumped
+ * @returns The commit hash of the created commit
+ */
+export async function createBatchCommit(workspaceRoot: string, files: string[], libraries: string[]): Promise<string> {
+  if (files.length === 0) {
+    throw new Error('No files to commit')
+  }
+
+  if (libraries.length === 0) {
+    throw new Error('No libraries to include in commit message')
+  }
+
+  // Stage all modified files
+  const staged = stage(files, { cwd: workspaceRoot })
+  if (!staged) {
+    throw new Error('Failed to stage files for commit')
+  }
+
+  // Create commit message
+  const commitMessage = formatBatchCommitMessage(libraries)
+
+  // Create commit with --no-verify to skip hooks (we're creating the version commit)
+  const gitCommit = commit(commitMessage, { cwd: workspaceRoot, noVerify: true })
+
+  return gitCommit.hash
+}
+
+/**
+ * Formats the commit message for a batch version update.
+ *
+ * Format: `chore: update versions for lib-a, lib-b, lib-c`
+ *
+ * For many libraries, truncates the list to keep message readable.
+ *
+ * @param libraries - List of library names that were bumped
+ * @returns Formatted commit message
+ */
+function formatBatchCommitMessage(libraries: string[]): string {
+  const MAX_LIBS_IN_MESSAGE = 10
+
+  if (libraries.length <= MAX_LIBS_IN_MESSAGE) {
+    return `chore: update versions for ${libraries.join(', ')}`
+  }
+
+  const shown = libraries.slice(0, MAX_LIBS_IN_MESSAGE)
+  const remaining = libraries.length - MAX_LIBS_IN_MESSAGE
+
+  return `chore: update versions for ${shown.join(', ')} and ${remaining} more`
+}

--- a/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
+++ b/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
@@ -1,0 +1,107 @@
+import type { ProjectGraph } from '@nx/devkit'
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Gets the list of affected libraries based on git changes.
+ *
+ * Uses git diff to find changed files and maps them to projects
+ * using the Nx project graph. Only returns libraries that have
+ * a `version` target defined.
+ *
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param projectGraph - Nx project graph
+ * @param base - Base git ref (default: origin/main)
+ * @param head - Head git ref (default: HEAD)
+ * @returns List of affected library names that have a version target
+ */
+export async function getAffectedLibraries(
+  workspaceRoot: string,
+  projectGraph: ProjectGraph,
+  base = 'origin/main',
+  head = 'HEAD'
+): Promise<string[]> {
+  // Get changed files between base and head
+  const changedFiles = getChangedFiles(workspaceRoot, base, head)
+
+  if (changedFiles.length === 0) {
+    return []
+  }
+
+  // Map files to projects
+  const affectedProjects = new Set<string>()
+
+  for (const file of changedFiles) {
+    const project = findProjectForFile(file, projectGraph)
+    if (project) {
+      affectedProjects.add(project)
+    }
+  }
+
+  // Filter to libraries with version target
+  const librariesWithVersionTarget = Array.from(affectedProjects).filter((projectName) => {
+    const project = projectGraph.nodes[projectName]
+    if (!project) {
+      return false
+    }
+
+    // Check if project has a version target
+    const targets = project.data?.targets
+    return targets && 'version' in targets
+  })
+
+  return librariesWithVersionTarget.sort()
+}
+
+/**
+ * Gets the list of files changed between two git refs.
+ *
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param base - Base git ref
+ * @param head - Head git ref
+ * @returns List of changed file paths relative to workspace root
+ */
+function getChangedFiles(workspaceRoot: string, base: string, head: string): string[] {
+  try {
+    const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+      cwd: workspaceRoot,
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large diffs
+    })
+
+    return output
+      .trim()
+      .split('\n')
+      .filter((file) => file.length > 0)
+  } catch (error) {
+    // If git diff fails (e.g., refs don't exist), return empty
+    console.error('Failed to get changed files:', error instanceof Error ? error.message : error)
+    return []
+  }
+}
+
+/**
+ * Finds the project that owns a given file path.
+ *
+ * Uses the project graph to find which project contains the file
+ * based on project root paths.
+ *
+ * @param filePath - File path relative to workspace root
+ * @param projectGraph - Nx project graph
+ * @returns Project name or null if not found
+ */
+function findProjectForFile(filePath: string, projectGraph: ProjectGraph): string | null {
+  // Normalize path separators
+  const normalizedPath = filePath.replace(/\\/g, '/')
+
+  // Find the project whose root is a prefix of the file path
+  // Sort by root length descending to find the most specific match
+  const projects = Object.entries(projectGraph.nodes)
+    .map(([name, node]) => ({
+      name,
+      root: node.data.root,
+    }))
+    .filter((p) => normalizedPath.startsWith(p.root + '/') || normalizedPath === p.root)
+    .sort((a, b) => b.root.length - a.root.length)
+
+  return projects.length > 0 ? projects[0].name : null
+}

--- a/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
+++ b/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
@@ -1,5 +1,5 @@
 import type { ProjectGraph } from '@nx/devkit'
-import { execFileSync } from 'node:child_process'
+import { getChangedFilesBetween } from '@hyperfrontend/versioning'
 
 /**
  * Gets the list of affected libraries based on git changes.
@@ -20,8 +20,7 @@ export async function getAffectedLibraries(
   base = 'origin/main',
   head = 'HEAD'
 ): Promise<string[]> {
-  // Get changed files between base and head
-  const changedFiles = getChangedFiles(workspaceRoot, base, head)
+  const changedFiles = getChangedFilesBetween(base, head, { cwd: workspaceRoot })
 
   if (changedFiles.length === 0) {
     return []
@@ -50,33 +49,6 @@ export async function getAffectedLibraries(
   })
 
   return librariesWithVersionTarget.sort()
-}
-
-/**
- * Gets the list of files changed between two git refs.
- *
- * @param workspaceRoot - Absolute path to workspace root
- * @param base - Base git ref
- * @param head - Head git ref
- * @returns List of changed file paths relative to workspace root
- */
-function getChangedFiles(workspaceRoot: string, base: string, head: string): string[] {
-  try {
-    const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
-      cwd: workspaceRoot,
-      encoding: 'utf-8',
-      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large diffs
-    })
-
-    return output
-      .trim()
-      .split('\n')
-      .filter((file) => file.length > 0)
-  } catch (error) {
-    // If git diff fails (e.g., refs don't exist), return empty
-    console.error('Failed to get changed files:', error instanceof Error ? error.message : error)
-    return []
-  }
 }
 
 /**

--- a/tools/package/src/executors/version-batch/lib/rollback-changes.ts
+++ b/tools/package/src/executors/version-batch/lib/rollback-changes.ts
@@ -1,29 +1,20 @@
-import { execFileSync } from 'node:child_process'
-import { deleteTag, unstage } from '@hyperfrontend/versioning/git/operations'
+import { deleteTag, discardAllChanges } from '@hyperfrontend/versioning/git/operations'
+import { getLogger } from '../../version/lib/logger'
+
+const logger = getLogger()
 
 /**
  * Rolls back all uncommitted changes in the working directory.
  *
- * Uses `git checkout .` to discard all modifications to tracked files.
- * Also cleans up any untracked files that were created.
+ * Uses discardAllChanges() to discard all modifications to tracked files
+ * and unstage any staged changes.
  *
  * @param workspaceRoot - Absolute path to workspace root
  */
 export async function rollbackChanges(workspaceRoot: string): Promise<void> {
-  try {
-    // Discard all changes to tracked files
-    // Note: Library doesn't have discardChanges() yet - using raw git
-    // TODO: Replace with library call when discardChanges() is added (Phase 2)
-    execFileSync('git', ['checkout', '.'], {
-      cwd: workspaceRoot,
-      encoding: 'utf-8',
-    })
-
-    // Reset staged changes using library operation
-    unstage(['.'], { cwd: workspaceRoot })
-  } catch (error) {
-    // Log but don't throw - rollback is best-effort
-    console.error('Failed to rollback changes:', error instanceof Error ? error.message : error)
+  const success = discardAllChanges({ cwd: workspaceRoot })
+  if (!success) {
+    logger.warn('Failed to rollback changes')
   }
 }
 

--- a/tools/package/src/executors/version-batch/lib/rollback-changes.ts
+++ b/tools/package/src/executors/version-batch/lib/rollback-changes.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process'
+import { deleteTag, unstage } from '@hyperfrontend/versioning/git/operations'
+
+/**
+ * Rolls back all uncommitted changes in the working directory.
+ *
+ * Uses `git checkout .` to discard all modifications to tracked files.
+ * Also cleans up any untracked files that were created.
+ *
+ * @param workspaceRoot - Absolute path to workspace root
+ */
+export async function rollbackChanges(workspaceRoot: string): Promise<void> {
+  try {
+    // Discard all changes to tracked files
+    // Note: Library doesn't have discardChanges() yet - using raw git
+    // TODO: Replace with library call when discardChanges() is added (Phase 2)
+    execFileSync('git', ['checkout', '.'], {
+      cwd: workspaceRoot,
+      encoding: 'utf-8',
+    })
+
+    // Reset staged changes using library operation
+    unstage(['.'], { cwd: workspaceRoot })
+  } catch (error) {
+    // Log but don't throw - rollback is best-effort
+    console.error('Failed to rollback changes:', error instanceof Error ? error.message : error)
+  }
+}
+
+/**
+ * Cleans up any git tags created during a failed batch operation.
+ *
+ * @param workspaceRoot - Absolute path to workspace root
+ * @param tags - List of tag names to delete
+ */
+export async function cleanupTags(workspaceRoot: string, tags: string[]): Promise<void> {
+  for (const tag of tags) {
+    // deleteTag returns false if tag doesn't exist, which is fine
+    deleteTag(tag, { cwd: workspaceRoot })
+  }
+}

--- a/tools/package/src/executors/version-batch/schema.d.ts
+++ b/tools/package/src/executors/version-batch/schema.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Schema for the version-batch executor.
+ *
+ * This executor consolidates batch versioning orchestration logic
+ * into TypeScript. It detects affected libraries, versions each one,
+ * and creates a single batch commit.
+ */
+export interface VersionBatchExecutorSchema {
+  /**
+   * Base git ref for affected detection.
+   *
+   * @default "origin/main"
+   */
+  base?: string
+
+  /**
+   * Head git ref for affected detection.
+   *
+   * @default "HEAD"
+   */
+  head?: string
+
+  /**
+   * Preview changes without making them.
+   *
+   * @default false
+   */
+  dryRun?: boolean
+
+  /**
+   * Enable verbose logging.
+   *
+   * @default false
+   */
+  verbose?: boolean
+}

--- a/tools/package/src/executors/version-batch/schema.json
+++ b/tools/package/src/executors/version-batch/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "title": "Batch version executor",
+  "description": "Run versioning for all affected libraries and create a single batch commit",
+  "type": "object",
+  "properties": {
+    "base": {
+      "type": "string",
+      "description": "Base git ref for affected detection",
+      "default": "origin/main"
+    },
+    "head": {
+      "type": "string",
+      "description": "Head git ref for affected detection",
+      "default": "HEAD"
+    },
+    "dryRun": {
+      "type": "boolean",
+      "description": "Preview changes without making them",
+      "default": false
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/tools/package/src/executors/version-check/executor.ts
+++ b/tools/package/src/executors/version-check/executor.ts
@@ -48,7 +48,6 @@ export default async function versionCheckExecutor(
     return { success: false }
   }
 
-  // === SAFETY CHECKS ===
   if (options.skipIfVersionCommit !== false) {
     logger.debug('Checking if current commit is a version/release commit')
     if (isVersionCommit(workspaceRoot, projectName)) {
@@ -57,7 +56,6 @@ export default async function versionCheckExecutor(
     }
   }
 
-  // Skip if git is in unstable state (rebase/merge)
   if (isInUnstableGitState(workspaceRoot)) {
     logger.info('Skipping - git is in rebase/merge state')
     return { success: true }
@@ -66,7 +64,6 @@ export default async function versionCheckExecutor(
   const projectRoot = projectConfig.root
   logger.setContextValue('projectRoot', projectRoot)
 
-  // === VALIDATE VERSION STATE ===
   logger.info('Validating version state...')
 
   const result = await validateVersionState({
@@ -78,7 +75,6 @@ export default async function versionCheckExecutor(
     repository: options.repository,
   })
 
-  // === FORMAT AND OUTPUT RESULT ===
   const formatted = formatValidationResult(result)
 
   switch (result.status) {
@@ -95,16 +91,15 @@ export default async function versionCheckExecutor(
       return { success: false }
 
     case 'invalid':
-      // Use console.log for formatted output with proper line breaks
-      console.log(formatted)
-      console.log('')
-      console.log('To fix this issue:')
-      console.log('  1. Pull latest changes: git pull origin <branch>')
-      console.log(`  2. Run versioning: npx nx version ${projectName}`)
-      console.log('  3. Commit the changes: git add . && git commit --amend --no-edit')
-      console.log('  4. Push: git push --force-with-lease')
-      console.log('')
-      console.log('Or push without --no-verify to let lefthook handle versioning automatically.')
+      logger.warn(formatted)
+      logger.log('')
+      logger.log('To fix this issue:')
+      logger.log('  1. Pull latest changes: git pull origin <branch>')
+      logger.log(`  2. Run versioning: npx nx version ${projectName}`)
+      logger.log('  3. Commit the changes: git add . && git commit --amend --no-edit')
+      logger.log('  4. Push: git push --force-with-lease')
+      logger.log('')
+      logger.log('Or push without --no-verify to let lefthook handle versioning automatically.')
       return { success: false }
   }
 }

--- a/tools/package/src/executors/version/ARCHITECTURE.md
+++ b/tools/package/src/executors/version/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Version bumps happen **locally** via lefthook pre-push hooks, not in CI:
 flowchart TD
     A[Developer commits] --> B[git push]
     B --> C[lefthook pre-push]
-    C --> D[nx version-batch]
+    C --> D[nx version:all]
     D --> E[Version each affected library]
     E --> F["Commit: chore: update versions for lib-a, lib-b"]
     F --> G[Push proceeds with version commit]

--- a/tools/package/src/executors/version/ARCHITECTURE.md
+++ b/tools/package/src/executors/version/ARCHITECTURE.md
@@ -125,17 +125,18 @@ Version bumps happen **locally** via lefthook pre-push hooks, not in CI:
 flowchart TD
     A[Developer commits] --> B[git push]
     B --> C[lefthook pre-push]
-    C --> D[nx version --collectFiles]
-    D --> E[Stage modified files]
-    E --> F["Commit: chore: update versions for lib-xxx [skip ci]"]
+    C --> D[nx version-batch]
+    D --> E[Version each affected library]
+    E --> F["Commit: chore: update versions for lib-a, lib-b"]
     F --> G[Push proceeds with version commit]
 ```
 
-The `--collectFiles` flag:
+The `version-batch` executor:
 
-- Implies `skipCommit` and `skipTag`
-- Outputs modified file paths (MODIFIED:path format)
-- lefthook parses this output to stage files before creating the version commit
+- Detects affected libraries programmatically using Nx project graph
+- Runs versioning for each affected library
+- Creates a single batch commit for all changes
+- Handles rollback on failure
 
 ### PR Workflow (validation-only)
 

--- a/tools/package/src/executors/version/README.md
+++ b/tools/package/src/executors/version/README.md
@@ -24,14 +24,14 @@ npx nx version lib-cryptography --dryRun
 npx nx version lib-cryptography --releaseAs=minor
 ```
 
-For batch versioning of all affected libraries, use the `version-batch` executor:
+For batch versioning of all affected libraries, use the `version:all` target:
 
 ```bash
 # Preview batch versioning
-npx nx version-batch --dryRun
+npx nx version:all --dryRun
 
 # Run batch versioning (typically done by lefthook)
-npx nx version-batch
+npx nx version:all
 ```
 
 ## Options
@@ -98,7 +98,7 @@ This is controlled by the `updateDependents` option (default: true).
 
 Version bumps are applied **locally** via lefthook pre-push hooks. When you `git push`:
 
-1. lefthook runs `nx version-batch` which detects affected libraries
+1. lefthook runs `nx version:all` which detects affected libraries
 2. For each affected library, package.json and CHANGELOG.md are updated
 3. A single batch commit is created: `chore: update versions for lib-a, lib-b`
 4. Push proceeds with the version commit included

--- a/tools/package/src/executors/version/README.md
+++ b/tools/package/src/executors/version/README.md
@@ -22,9 +22,16 @@ npx nx version lib-cryptography --dryRun
 
 # Force a specific bump type
 npx nx version lib-cryptography --releaseAs=minor
+```
 
-# Output modified files (for CI)
-npx nx version lib-cryptography --collectFiles
+For batch versioning of all affected libraries, use the `version-batch` executor:
+
+```bash
+# Preview batch versioning
+npx nx version-batch --dryRun
+
+# Run batch versioning (typically done by lefthook)
+npx nx version-batch
 ```
 
 ## Options
@@ -40,7 +47,6 @@ npx nx version lib-cryptography --collectFiles
 | `updateDependents`    | boolean | true             | Update version references in dependent packages          |
 | `skipIfVersionCommit` | boolean | true             | Skip if current commit is a version commit               |
 | `skipIfUnstableGit`   | boolean | true             | Skip if git is in rebase/merge state                     |
-| `collectFiles`        | boolean | false            | Output modified files list (implies skipCommit)          |
 | `verbose`             | boolean | false            | Enable detailed logging                                  |
 | `quiet`               | boolean | false            | Suppress non-error output                                |
 | `showDiff`            | boolean | false            | Show unified diff of changes before committing           |
@@ -92,9 +98,9 @@ This is controlled by the `updateDependents` option (default: true).
 
 Version bumps are applied **locally** via lefthook pre-push hooks. When you `git push`:
 
-1. lefthook runs `nx version <lib> --collectFiles` for affected libraries
-2. Package.json and CHANGELOG.md are updated
-3. A version commit is created: `chore: update versions for lib-xxx [skip ci]`
+1. lefthook runs `nx version-batch` which detects affected libraries
+2. For each affected library, package.json and CHANGELOG.md are updated
+3. A single batch commit is created: `chore: update versions for lib-a, lib-b`
 4. Push proceeds with the version commit included
 
 See [lefthook.yml](../../../../lefthook.yml) for the hook configuration.

--- a/tools/package/src/executors/version/executor.ts
+++ b/tools/package/src/executors/version/executor.ts
@@ -1,16 +1,6 @@
 import type { ExecutorContext } from '@nx/devkit'
-import type { FlowConfig } from '@hyperfrontend/versioning'
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
-import { readPackageJsonIfExists } from '@hyperfrontend/project-scope/project/package'
-import { createVersionFlow } from '@hyperfrontend/versioning/flow'
-import { executeFlow } from '@hyperfrontend/versioning/flow/executor'
-import { stage, amendCommitNoEdit } from '@hyperfrontend/versioning/git/operations'
-import { isInUnstableGitState } from './lib/is-in-unstable-git-state'
-import { isVersionCommit } from './lib/is-version-commit'
 import { getLogger } from './lib/logger'
-import { updateDependentVersions } from './lib/update-dependent-versions'
-import { updateE2eDependencies } from './lib/update-e2e-dependencies'
+import { runVersionForProject } from './lib/run-version-for-project'
 import { VersionExecutorSchema } from './schema'
 
 /**
@@ -22,6 +12,9 @@ import { VersionExecutorSchema } from './schema'
  * - Full control over versioning behavior
  * - Tags as OUTPUT (created after publish), not INPUT
  *
+ * This executor delegates to `runVersionForProject()` for the core versioning logic,
+ * allowing the same logic to be reused by the `version-batch` executor.
+ *
  * @param options - Configuration options for the version executor
  * @param context - Nx executor context
  * @returns Success status
@@ -32,171 +25,50 @@ export default async function versionExecutor(options: VersionExecutorSchema, co
   logger.setLogLevel(options)
   logger.setContextValue('projectName', projectName ?? 'unknown')
   logger.setContextValue('workspaceRoot', workspaceRoot)
+
   if (!projectName) {
     logger.error('Project name is required')
     return { success: false }
   }
-  logger.debug(`Executor started with log level: {logLevel}`)
 
-  if (options.collectFiles) {
-    logger.debug('CollectFiles mode enabled - normalizing options for version flow')
-    options.skipCommit = true
-    options.skipTag = true
-    logger.info('collectFiles mode enabled, skipCommit and skipTag set to true')
+  if (!projectGraph) {
+    logger.error('Project graph is required')
+    return { success: false }
   }
 
-  const modifiedFiles: string[] = []
-
-  const projectConfig = projectGraph?.nodes[projectName]?.data
+  const projectConfig = projectGraph.nodes[projectName]?.data
   if (!projectConfig) {
     logger.error(`Project not found in project graph`)
     return { success: false }
   }
 
-  logger.debug('Performing safety checks')
+  logger.debug(`Executor started with log level: {logLevel}`)
 
-  if (options.skipIfVersionCommit !== false) {
-    logger.debug('Checking if current commit is a version/release commit')
-    if (isVersionCommit(workspaceRoot, projectName)) {
-      logger.info('Skipping - current commit is a version/release commit for this project')
-      return { success: true }
-    }
-  }
-  if (options.skipIfUnstableGit !== false) {
-    logger.debug('Checking if git is in an unstable state (rebase/merge)')
-    if (isInUnstableGitState(workspaceRoot)) {
-      logger.info('Skipping - git is in rebase/merge state')
-      return { success: true }
-    }
-  }
-
-  const projectRoot = projectConfig.root
-  logger.setContextValue('projectRoot', projectRoot)
-  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json')
-  logger.setContextValue('packageJsonPath', packageJsonPath)
-  const tagPrefix = options.tagPrefix || `${projectName}@`
-  logger.setContextValue('tagPrefix', tagPrefix)
-
-  logger.debug(`Project root: {projectRoot}`)
-  logger.debug(`Package.json path: {packageJsonPath}`)
-  logger.debug(`Tag prefix: {tagPrefix}`)
-
-  // === BUILD FLOW CONFIG ===
-  const flowConfig: Partial<FlowConfig> = {
+  // Delegate to core versioning logic
+  const result = await runVersionForProject({
+    projectName,
+    workspaceRoot,
+    projectRoot: projectConfig.root,
+    projectGraph,
+    skipCommit: options.skipCommit,
+    skipTag: options.skipTag ?? true,
     dryRun: options.dryRun,
-    skipGit: options.skipCommit,
-    skipTag: options.skipTag ?? true, // Default to true - tags created after publish
-    skipChangelog: false,
-    trackDeps: options.trackDeps,
-    tagFormat: `${tagPrefix}\${version}`,
+    verbose: options.verbose,
+    quiet: options.quiet,
     releaseAs: options.releaseAs,
-    repository: options.repository ?? 'inferred', // Default to auto-detect for compare URLs
-    scopeFiltering: options.scopeFiltering,
-    backupChangelog: options.backupChangelog,
-  }
-
-  logger.debug(
-    `Flow config: dryRun=${flowConfig.dryRun}, skipGit=${flowConfig.skipGit}, skipTag=${flowConfig.skipTag}${flowConfig.releaseAs ? `, releaseAs=${flowConfig.releaseAs}` : ''}`
-  )
-  logger.info('Starting version flow using @hyperfrontend/versioning')
-
-  // === EXECUTE FLOW ===
-  const flow = createVersionFlow('conventional', flowConfig)
-  const flowResult = await executeFlow(flow, projectName, workspaceRoot, {
-    dryRun: options.dryRun,
-    verbose: options.verbose ?? false,
+    tagPrefix: options.tagPrefix,
+    trackDeps: options.trackDeps,
+    updateDependents: options.updateDependents,
+    skipIfVersionCommit: options.skipIfVersionCommit,
+    skipIfUnstableGit: options.skipIfUnstableGit,
     showDiff: options.showDiff,
     diffFormat: options.diffFormat,
     rollbackOnFailure: options.rollbackOnFailure,
-    projectRoot,
+    repository: options.repository,
+    scopeFiltering: options.scopeFiltering,
+    backupChangelog: options.backupChangelog,
   })
 
-  // === PROCESS RESULT ===
-  const success = flowResult.status === 'success' || flowResult.status === 'skipped'
-
-  if (flowResult.status === 'success') {
-    logger.info(flowResult.summary)
-  } else if (flowResult.status === 'skipped') {
-    logger.info('No release needed or already published')
-    return { success: true }
-  } else {
-    logger.error(flowResult.summary)
-    return { success: false }
-  }
-
-  // === COLLECT MODIFIED FILES ===
-  logger.debug('Collecting modified files')
-  if (flowResult.state.modifiedFiles) {
-    for (const file of flowResult.state.modifiedFiles) {
-      const relPath = file.startsWith(workspaceRoot) ? file.slice(workspaceRoot.length + 1) : file
-      modifiedFiles.push(relPath)
-      logger.debug(`Modified file: ${relPath}`)
-    }
-  } else {
-    // Fallback
-    logger.debug('No modified files in flow result, using fallback')
-    modifiedFiles.push(join(projectRoot, 'package.json'))
-    const changelogPath = join(workspaceRoot, projectRoot, 'CHANGELOG.md')
-    if (existsSync(changelogPath)) {
-      modifiedFiles.push(join(projectRoot, 'CHANGELOG.md'))
-    }
-  }
-
-  // === POST-PROCESSING: Update dependent packages ===
-  const shouldUpdateDependents = options.updateDependents !== false
-  logger.debug(`Update dependents: ${shouldUpdateDependents}`)
-  if (shouldUpdateDependents) {
-    const pkg = readPackageJsonIfExists(packageJsonPath)
-    const packageName = pkg?.name ?? null
-    // Use nextVersion from flow result (works in dry run), fallback to package.json
-    const newVersion = flowResult.state.nextVersion ?? pkg?.version ?? '0.0.0'
-
-    logger.debug(`Package: ${packageName}, Version: ${newVersion}`)
-    if (packageName && newVersion !== '0.0.0') {
-      const updatedFiles = updateDependentVersions(packageName, newVersion, workspaceRoot, packageJsonPath, options.dryRun ?? false)
-      const e2eUpdatedFiles = updateE2eDependencies(packageName, newVersion, workspaceRoot, options.dryRun ?? false)
-      const allUpdatedFiles = [...updatedFiles, ...e2eUpdatedFiles]
-
-      if (updatedFiles.length > 0) {
-        logger.info(`Updated dependency version in ${updatedFiles.length} library package(s):`)
-        for (const file of updatedFiles) {
-          logger.debug(`  - ${file}`)
-        }
-      }
-
-      if (e2eUpdatedFiles.length > 0) {
-        logger.info(`Updated e2e app dependency in ${e2eUpdatedFiles.length} package(s):`)
-        for (const file of e2eUpdatedFiles) {
-          logger.debug(`  - ${file}`)
-        }
-      }
-
-      if (allUpdatedFiles.length > 0) {
-        modifiedFiles.push(...allUpdatedFiles)
-
-        // Stage and amend the version commit (if not dry run and not skipping commit)
-        if (!options.dryRun && !options.skipCommit) {
-          logger.debug('Staging and amending commit with dependency updates')
-          try {
-            stage(allUpdatedFiles, { cwd: workspaceRoot })
-            amendCommitNoEdit({ cwd: workspaceRoot })
-            logger.info('Amended commit to include dependency updates')
-          } catch (error) {
-            logger.warn(`Could not amend commit with dependency updates: ${error}`)
-          }
-        }
-      }
-    }
-  }
-
-  // === OUTPUT MODIFIED FILES (collectFiles mode) ===
-  if (options.collectFiles) {
-    logger.debug('Outputting modified files list')
-    for (const file of modifiedFiles) {
-      process.stdout.write(`MODIFIED:${file}\n`)
-    }
-  }
-
   logger.debug('Executor completed successfully')
-  return { success }
+  return { success: result.success }
 }

--- a/tools/package/src/executors/version/lib/is-in-unstable-git-state.ts
+++ b/tools/package/src/executors/version/lib/is-in-unstable-git-state.ts
@@ -1,37 +1,27 @@
-import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { getOperationState } from '@hyperfrontend/versioning'
 import { getLogger } from './logger'
 
 /**
  * Checks if git is in a rebase or merge state.
+ *
+ * Thin wrapper around `getOperationState()` from lib-versioning that adds
+ * executor-specific logging.
  *
  * @param cwd - Working directory
  * @returns True if in unstable state
  */
 export function isInUnstableGitState(cwd: string): boolean {
   const logger = getLogger().channel('isInUnstableGitState')
-  try {
-    logger.debug(`checking git state in "${cwd}"`)
-    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim()
+  logger.debug(`checking git state in "${cwd}"`)
 
-    const rebaseMerge = existsSync(join(cwd, gitDir, 'rebase-merge'))
-    const rebaseApply = existsSync(join(cwd, gitDir, 'rebase-apply'))
-    const mergeHead = existsSync(join(cwd, gitDir, 'MERGE_HEAD'))
+  const state = getOperationState({ cwd })
 
-    const isUnstable = rebaseMerge || rebaseApply || mergeHead
-    if (isUnstable) {
-      logger.info(`detected unstable git state (rebase-merge: ${rebaseMerge}, rebase-apply: ${rebaseApply}, MERGE_HEAD: ${mergeHead})`)
-    } else {
-      logger.debug(`git state is stable`)
-    }
-    return isUnstable
-  } catch (error) {
-    logger.debug(`error checking git state - ${error instanceof Error ? error.message : String(error)}`)
-    return false
+  if (state.inProgress) {
+    const { rebaseMerge, rebaseApply, mergeHead } = state.details
+    logger.info(`detected unstable git state (rebase-merge: ${rebaseMerge}, rebase-apply: ${rebaseApply}, MERGE_HEAD: ${mergeHead})`)
+  } else {
+    logger.debug(`git state is stable`)
   }
+
+  return state.inProgress
 }

--- a/tools/package/src/executors/version/lib/run-version-for-project.ts
+++ b/tools/package/src/executors/version/lib/run-version-for-project.ts
@@ -1,0 +1,318 @@
+import type { ProjectGraph } from '@nx/devkit'
+import type { FlowConfig, FlowResult } from '@hyperfrontend/versioning'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readPackageJsonIfExists } from '@hyperfrontend/project-scope/project/package'
+import { createVersionFlow } from '@hyperfrontend/versioning/flow'
+import { executeFlow } from '@hyperfrontend/versioning/flow/executor'
+import { stage, amendCommitNoEdit } from '@hyperfrontend/versioning/git/operations'
+import { isInUnstableGitState } from './is-in-unstable-git-state'
+import { isVersionCommit } from './is-version-commit'
+import { getLogger } from './logger'
+import { updateDependentVersions } from './update-dependent-versions'
+import { updateE2eDependencies } from './update-e2e-dependencies'
+
+/**
+ * Options for running version logic on a single project.
+ */
+export interface RunVersionOptions {
+  /** Name of the project to version */
+  projectName: string
+  /** Absolute path to workspace root */
+  workspaceRoot: string
+  /** Project root relative to workspace root */
+  projectRoot: string
+  /** Nx project graph for dependency resolution */
+  projectGraph: ProjectGraph
+  /** Skip creating a git commit */
+  skipCommit?: boolean
+  /** Skip creating a git tag */
+  skipTag?: boolean
+  /** Preview changes without applying */
+  dryRun?: boolean
+  /** Enable verbose logging */
+  verbose?: boolean
+  /** Suppress non-error output */
+  quiet?: boolean
+  /** Force a specific bump type */
+  releaseAs?: 'major' | 'minor' | 'patch'
+  /** Version tag prefix */
+  tagPrefix?: string
+  /** Include dependencies in bump calculation */
+  trackDeps?: boolean
+  /** Update version references in dependent packages */
+  updateDependents?: boolean
+  /** Skip if current commit is a version commit */
+  skipIfVersionCommit?: boolean
+  /** Skip if git is in unstable state */
+  skipIfUnstableGit?: boolean
+  /** Show diff preview */
+  showDiff?: boolean
+  /** Diff output format */
+  diffFormat?: 'unified' | 'summary'
+  /** Rollback on failure */
+  rollbackOnFailure?: boolean
+  /** Repository config for changelog URLs */
+  repository?: FlowConfig['repository']
+  /** Scope filtering configuration */
+  scopeFiltering?: FlowConfig['scopeFiltering']
+  /** Backup changelog before modification */
+  backupChangelog?: boolean
+}
+
+/**
+ * Result of running version logic on a single project.
+ */
+export interface RunVersionResult {
+  /** Whether the operation completed successfully */
+  success: boolean
+  /** Whether a version bump actually occurred */
+  bumped: boolean
+  /** Previous version (null if first release or skipped) */
+  previousVersion: string | null
+  /** New version (null if skipped) */
+  newVersion: string | null
+  /** All files modified during the operation */
+  modifiedFiles: string[]
+  /** Error message if operation failed */
+  error?: string
+  /** The underlying flow result for advanced use cases */
+  flowResult?: FlowResult
+}
+
+/**
+ * Runs versioning logic for a single project.
+ *
+ * This function contains the core versioning logic extracted from the Nx executor,
+ * allowing it to be called directly by the version-batch executor without going
+ * through the Nx executor interface.
+ *
+ * Key behaviors:
+ * - Uses npm registry as source of truth (not git tags)
+ * - Performs safety checks (version commit detection, unstable git state)
+ * - Executes the versioning flow via `@hyperfrontend/versioning`
+ * - Updates dependent package versions
+ * - Tracks all modified files
+ *
+ * @param options - Configuration options for versioning
+ * @returns Result containing success status, version info, and modified files
+ *
+ * @example
+ * ```typescript
+ * const result = await runVersionForProject({
+ *   projectName: 'my-lib',
+ *   workspaceRoot: '/path/to/workspace',
+ *   projectRoot: 'libs/my-lib',
+ *   projectGraph,
+ *   skipCommit: true,
+ *   skipTag: true,
+ * })
+ *
+ * if (result.bumped) {
+ *   console.log(`Bumped from ${result.previousVersion} to ${result.newVersion}`)
+ *   console.log(`Modified files: ${result.modifiedFiles.join(', ')}`)
+ * }
+ * ```
+ */
+export async function runVersionForProject(options: RunVersionOptions): Promise<RunVersionResult> {
+  const {
+    projectName,
+    workspaceRoot,
+    projectRoot,
+    skipCommit = false,
+    skipTag = true,
+    dryRun = false,
+    verbose = false,
+    quiet = false,
+    releaseAs,
+    tagPrefix = `${projectName}@`,
+    trackDeps = false,
+    updateDependents = true,
+    skipIfVersionCommit = true,
+    skipIfUnstableGit = true,
+    showDiff = false,
+    diffFormat,
+    rollbackOnFailure,
+    repository = 'inferred',
+    scopeFiltering,
+    backupChangelog = false,
+  } = options
+
+  const logger = getLogger()
+  logger.setLogLevel({ verbose, quiet })
+  logger.setContextValue('projectName', projectName)
+  logger.setContextValue('workspaceRoot', workspaceRoot)
+  logger.setContextValue('projectRoot', projectRoot)
+
+  const modifiedFiles: string[] = []
+
+  // === SAFETY CHECKS ===
+  if (skipIfVersionCommit) {
+    logger.debug('Checking if current commit is a version/release commit')
+    if (isVersionCommit(workspaceRoot, projectName)) {
+      logger.info('Skipping - current commit is a version/release commit for this project')
+      return {
+        success: true,
+        bumped: false,
+        previousVersion: null,
+        newVersion: null,
+        modifiedFiles: [],
+      }
+    }
+  }
+
+  if (skipIfUnstableGit) {
+    logger.debug('Checking if git is in an unstable state (rebase/merge)')
+    if (isInUnstableGitState(workspaceRoot)) {
+      logger.info('Skipping - git is in rebase/merge state')
+      return {
+        success: true,
+        bumped: false,
+        previousVersion: null,
+        newVersion: null,
+        modifiedFiles: [],
+      }
+    }
+  }
+
+  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json')
+  logger.setContextValue('packageJsonPath', packageJsonPath)
+  logger.setContextValue('tagPrefix', tagPrefix)
+
+  logger.debug(`Project root: {projectRoot}`)
+  logger.debug(`Package.json path: {packageJsonPath}`)
+  logger.debug(`Tag prefix: {tagPrefix}`)
+
+  // === BUILD FLOW CONFIG ===
+  const flowConfig: Partial<FlowConfig> = {
+    dryRun,
+    skipGit: skipCommit,
+    skipTag,
+    skipChangelog: false,
+    trackDeps,
+    tagFormat: `${tagPrefix}\${version}`,
+    releaseAs,
+    repository,
+    scopeFiltering,
+    backupChangelog,
+  }
+
+  logger.debug(
+    `Flow config: dryRun=${flowConfig.dryRun}, skipGit=${flowConfig.skipGit}, skipTag=${flowConfig.skipTag}${flowConfig.releaseAs ? `, releaseAs=${flowConfig.releaseAs}` : ''}`
+  )
+  logger.info('Starting version flow using @hyperfrontend/versioning')
+
+  // === EXECUTE FLOW ===
+  const flow = createVersionFlow('conventional', flowConfig)
+  const flowResult = await executeFlow(flow, projectName, workspaceRoot, {
+    dryRun,
+    verbose,
+    showDiff,
+    diffFormat,
+    rollbackOnFailure,
+    projectRoot,
+  })
+
+  // === PROCESS RESULT ===
+  const success = flowResult.status === 'success' || flowResult.status === 'skipped'
+  const bumped = flowResult.status === 'success'
+
+  if (flowResult.status === 'success') {
+    logger.info(flowResult.summary)
+  } else if (flowResult.status === 'skipped') {
+    logger.info('No release needed or already published')
+    return {
+      success: true,
+      bumped: false,
+      previousVersion: flowResult.state.currentVersion ?? null,
+      newVersion: null,
+      modifiedFiles: [],
+      flowResult,
+    }
+  } else {
+    logger.error(flowResult.summary)
+    return {
+      success: false,
+      bumped: false,
+      previousVersion: null,
+      newVersion: null,
+      modifiedFiles: [],
+      error: flowResult.summary,
+      flowResult,
+    }
+  }
+
+  // === COLLECT MODIFIED FILES ===
+  logger.debug('Collecting modified files')
+  if (flowResult.state.modifiedFiles) {
+    for (const file of flowResult.state.modifiedFiles) {
+      const relPath = file.startsWith(workspaceRoot) ? file.slice(workspaceRoot.length + 1) : file
+      modifiedFiles.push(relPath)
+      logger.debug(`Modified file: ${relPath}`)
+    }
+  } else {
+    // Fallback
+    logger.debug('No modified files in flow result, using fallback')
+    modifiedFiles.push(join(projectRoot, 'package.json'))
+    const changelogPath = join(workspaceRoot, projectRoot, 'CHANGELOG.md')
+    if (existsSync(changelogPath)) {
+      modifiedFiles.push(join(projectRoot, 'CHANGELOG.md'))
+    }
+  }
+
+  // === POST-PROCESSING: Update dependent packages ===
+  if (updateDependents) {
+    const pkg = readPackageJsonIfExists(packageJsonPath)
+    const packageName = pkg?.name ?? null
+    // Use nextVersion from flow result (works in dry run), fallback to package.json
+    const newVersion = flowResult.state.nextVersion ?? pkg?.version ?? '0.0.0'
+
+    logger.debug(`Package: ${packageName}, Version: ${newVersion}`)
+    if (packageName && newVersion !== '0.0.0') {
+      const updatedFiles = updateDependentVersions(packageName, newVersion, workspaceRoot, packageJsonPath, dryRun)
+      const e2eUpdatedFiles = updateE2eDependencies(packageName, newVersion, workspaceRoot, dryRun)
+      const allUpdatedFiles = [...updatedFiles, ...e2eUpdatedFiles]
+
+      if (updatedFiles.length > 0) {
+        logger.info(`Updated dependency version in ${updatedFiles.length} library package(s):`)
+        for (const file of updatedFiles) {
+          logger.debug(`  - ${file}`)
+        }
+      }
+
+      if (e2eUpdatedFiles.length > 0) {
+        logger.info(`Updated e2e app dependency in ${e2eUpdatedFiles.length} package(s):`)
+        for (const file of e2eUpdatedFiles) {
+          logger.debug(`  - ${file}`)
+        }
+      }
+
+      if (allUpdatedFiles.length > 0) {
+        modifiedFiles.push(...allUpdatedFiles)
+
+        // Stage and amend the version commit (if not dry run and not skipping commit)
+        if (!dryRun && !skipCommit) {
+          logger.debug('Staging and amending commit with dependency updates')
+          try {
+            stage(allUpdatedFiles, { cwd: workspaceRoot })
+            amendCommitNoEdit({ cwd: workspaceRoot })
+            logger.info('Amended commit to include dependency updates')
+          } catch (error) {
+            logger.warn(`Could not amend commit with dependency updates: ${error}`)
+          }
+        }
+      }
+    }
+  }
+
+  logger.debug('Version operation completed successfully')
+
+  return {
+    success,
+    bumped,
+    previousVersion: flowResult.state.currentVersion ?? null,
+    newVersion: flowResult.state.nextVersion ?? null,
+    modifiedFiles,
+    flowResult,
+  }
+}

--- a/tools/package/src/executors/version/schema.d.ts
+++ b/tools/package/src/executors/version/schema.d.ts
@@ -30,11 +30,6 @@ export interface VersionExecutorSchema {
   skipIfVersionCommit?: boolean
   /** Skip versioning if git is in rebase/merge state. */
   skipIfUnstableGit?: boolean
-  /**
-   * Output list of modified files without staging.
-   * Implies skipCommit=true and skipTag=true.
-   */
-  collectFiles?: boolean
   /** Enable verbose output for debugging. Shows additional details about each step. */
   verbose?: boolean
   /** Suppress all non-error output. */

--- a/tools/package/src/executors/version/schema.json
+++ b/tools/package/src/executors/version/schema.json
@@ -48,11 +48,6 @@
       "description": "Skip versioning if git is in rebase/merge state.",
       "default": true
     },
-    "collectFiles": {
-      "type": "boolean",
-      "description": "Output list of modified files without staging. Implies skipCommit=true and skipTag=true. When combined with --dryRun, reports files that would be modified.",
-      "default": false
-    },
     "verbose": {
       "type": "boolean",
       "description": "Enable verbose output for debugging. Shows additional details about each step.",


### PR DESCRIPTION
## Description

This PR introduces a new `version-batch` executor that consolidates batch versioning orchestration logic into TypeScript, replacing the previous shell-based approach in lefthook. The executor programmatically detects affected libraries using the Nx project graph, runs versioning for each one, and creates a single batch commit for all changes.

Additionally, this PR refactors the existing `version` executor to extract core versioning logic into a reusable `runVersionForProject()` function, enabling code sharing between the single-project and batch versioning workflows.

## Type of Change

♻️ Refactor | ✨ Feature

## Changes Made

- Added new `version-batch` executor (`tools/package/src/executors/version-batch/`) that:
  - Detects affected libraries programmatically using Nx project graph
  - Runs versioning for each affected library
  - Creates a single batch commit for all changes
  - Handles rollback on failure
- Extracted core versioning logic from `version` executor into `runVersionForProject()` for reusability
- Added new git operations in `lib-versioning`:
  - `getOperationState()` - Detects unstable git state (rebase/merge)
  - `getChangedFilesBetween()` - Gets files changed between refs
  - `discardAllChanges()` - Rolls back uncommitted changes
- Simplified `lefthook.yml` by replacing shell script orchestration with `nx version:all`
- Added `version:all` target to workspace `project.json`
- Updated documentation (`ARCHITECTURE.md`, `README.md`, `CONTRIBUTING.md`)
- Removed deprecated `collectFiles` option from `version` executor
- Fixed logger usage in `version-check` and `version-batch` executors
- Patched vulnerable `picomatch` transitive dev dependency
- Optimized pre-push checks to run only on affected projects with caching

## Testing

- Existing unit tests pass
- New unit tests added for:
  - `libs/versioning/src/git/operations/diff.spec.ts` - File change detection
  - `libs/versioning/src/git/operations/operation-state.spec.ts` - Git state detection
  - `libs/versioning/src/git/operations/stage.spec.ts` - Extended stage operations
  - `libs/versioning/src/git/factory.spec.ts` - Git client factory
- Manual testing: Push workflow verified with lefthook integration

## Screenshots/Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

N/A - No UI changes

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## Additional Notes

### Breaking Changes

- The `collectFiles` option has been removed from the `version` executor. This was an internal option used by the old shell-based orchestration and is no longer needed.

### Performance

- Pre-push checks now run only on affected projects instead of all projects
- Caching enabled for pre-push checks to avoid redundant work

### Migration

No manual migration required. The new `version:all` target is configured automatically in the workspace.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
