### PR TITLE
Improved eslint maintainance and address security vulnerabilty

### DIFF
--- a/.github/skills/eslint-rules/SKILL.md
+++ b/.github/skills/eslint-rules/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: eslint-rules
+version: 1.0.0
+description: Create custom ESLint rules for the hyperfrontend Nx monorepo.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Terminal
+---
+
+# ESLint Rules Skill
+
+Create rules in `tools/eslint-rules/`. REUSE shared utilities. Follow existing patterns.
+
+## Reference Locations
+
+| What                | Where                               |
+| ------------------- | ----------------------------------- |
+| Existing rules      | `tools/eslint-rules/src/rules/*.ts` |
+| Rule documentation  | `tools/eslint-rules/docs/*.md`      |
+| Shared utilities    | `tools/eslint-rules/src/utils/`     |
+| Test infrastructure | `tools/eslint-rules/src/testing/`   |
+| Registration        | `tools/eslint-rules/src/index.ts`   |
+| Config              | `eslint.base.config.cjs`            |
+
+**Before creating a rule:** Read `tools/eslint-rules/docs/` to check for existing rules. Do not duplicate.
+
+---
+
+## Rule Categories
+
+- **`lib-*`** — Publishable library enforcement (package.json, project.json, README). Guard with `isPublishableLibrary()`.
+- **`no-*`** — Prohibitions (enums, unsafe patterns, async fs).
+- **`prefer-*`** — Style preferences with autofixes.
+- **`require-*`** — Mandate presence (node: protocol).
+- **Workspace** — Cross-project validation (docs-site, root-readme).
+
+---
+
+## Critical Patterns
+
+### Publishable Library Detection
+
+A library is publishable if `project.json` has `projectType: 'library'` AND both `build` + `publish` targets.
+
+```typescript
+import { isPublishableLibrary } from '../utils/nx-project'
+if (!isPublishableLibrary(dirname(context.filename))) return {}
+```
+
+### JSON Rule Cast
+
+JSON rules require this cast for the listener return:
+
+```typescript
+return { ... } as unknown as Rule.RuleListener
+```
+
+### Doc URL
+
+```typescript
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/AndrewRedican/hyperfrontend/blob/main/tools/eslint-rules/docs/${name}.md`
+)
+```
+
+### Registration
+
+In `tools/eslint-rules/src/index.ts`:
+
+```typescript
+[RULE_NAME]: rule as unknown as Rule.RuleModule
+```
+
+### File I/O
+
+- **Use `utils/fs.ts` first** — Do not reimplement file operations
+- **Sync only** — Use `readFileSync`, `writeFileSync`, `existsSync` (never async)
+- **Specify mode** — `writeFileSync(path, data, { mode: 0o644 })`
+- **Safe reads** — Use `readJsonFileIfExists()`, `readFileIfExists()` from utils
+
+### String Matching
+
+- **Avoid regex** — Use `startsWith()`, `endsWith()`, `includes()`, `split()`
+- **Node builtins** — Use `NODE_BUILTIN_MODULES.has()` not regex patterns
+
+---
+
+## Shared Utilities — MUST REUSE
+
+### nx-project.ts
+
+- `isPublishableLibrary(projectRoot)` — Check if lib has build+publish targets
+- `isPublishableProjectJson(json)` — Check parsed project.json
+- `readProjectJson(dir)` / `readPackageJson(dir)` — Parse config files
+- `findPublishableLibraryDirectories(dir)` — Find all publishable libs
+- `getAllPublishableLibraries(root, subdir)` — Full metadata for all
+
+### workspace.ts
+
+- `findWorkspaceRoot(path)` — Monorepo root
+- `findProjectRoot(path)` — Nearest project root
+- `findNxWorkspaceRoot(path)` — Find nx.json location
+- `findWorkspaceRootByMarker(path, marker)` — Custom root detection
+
+### fs.ts
+
+- `exists(path)` / `isDirectory(path)` — Path checks
+- `readJsonFileIfExists(path)` / `readFileIfExists(path)` — Safe reads
+- `readDirectory(path)` — List contents
+
+### import-analysis.ts
+
+- `getImportCategory(source)` — Returns 0-4 (NodeBuiltin→CurrentDir)
+- `compareImportSources(a, b)` — Sort comparator
+- `ImportCategory` enum — NodeBuiltin=0, External=1, Hyperfrontend=2, Relative=3, CurrentDir=4
+
+### node-builtins.ts
+
+- `NODE_BUILTIN_MODULES` — Set of all Node.js builtins
+- `isNodeBuiltinWithoutPrefix(name)` — Missing node: prefix?
+- `addNodePrefix(name)` — Add node: prefix
+
+### logger.ts
+
+- `createRuleLogger(ruleName)` — Scoped debug logger
+
+---
+
+## Testing — Jest + RuleTester
+
+Tests run with **Jest**. 100% code coverage required.
+
+### Test Naming
+
+Use assertive language. No "should":
+
+- ✗ `should report error when...`
+- ✓ `reports error when...`
+- ✓ `flags missing field`
+- ✓ `allows valid import`
+
+### RuleTester Factories
+
+```typescript
+import { createTypeScriptRuleTester, createPackageJsonRuleTester, createProjectJsonRuleTester } from '../testing'
+```
+
+### TempWorkspace (workspace-aware rules)
+
+```typescript
+import { createTempWorkspaceManager, PUBLISHABLE_LIBRARY_PROJECT_JSON } from '../testing'
+const manager = createTempWorkspaceManager()
+afterAll(() => manager.cleanupAll())
+const ws = manager.create({ projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON, files: {...} })
+// Use: { code: '...', filename: ws.getPath('package.json') }
+```
+
+### Fixtures
+
+**project.json:** `PUBLISHABLE_LIBRARY_PROJECT_JSON`, `NON_PUBLISHABLE_LIBRARY_PROJECT_JSON`, `APPLICATION_PROJECT_JSON`, `E2E_PROJECT_JSON`
+
+**package.json:** `PUBLISHABLE_PACKAGE_JSON`, `MINIMAL_PACKAGE_JSON`, `PACKAGE_JSON_WITH_PACKAGE_EXPORT`
+
+**Factories:** `createPublishableProjectJson(overrides)`, `createPackageJson(overrides)`
+
+---
+
+## Checklist
+
+- [ ] Export `RULE_NAME` constant
+- [ ] Guard lib-\* rules with `isPublishableLibrary()`
+- [ ] Use shared utilities (do not reimplement)
+- [ ] Tests: assertive names, 100% coverage, TempWorkspace if workspace-aware
+- [ ] Add to `index.ts` with cast
+- [ ] Doc in `tools/eslint-rules/docs/{name}.md`
+- [ ] Enable in `eslint.base.config.cjs`

--- a/apps/package-e2e/versioning/package.json
+++ b/apps/package-e2e/versioning/package.json
@@ -6,7 +6,7 @@
     "pack-install": "cd ../../../dist/libs/versioning && npm pack && cd - && npm install ../../../dist/libs/versioning/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.0.tgz"
+    "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.1.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/libs/versioning/CHANGELOG.md
+++ b/libs/versioning/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1](https://github.com/AndrewRedican/hyperfrontend/compare/f1adb23d9138f218c27c152ac18b9ec3ec554c72...dbc22a50298c81c8558a214abc3d5256db3d40fd) - 2026-03-30
+
+### Bug Fixes
+
+- add end-of-options separator to prevent git argument injection
+
 ## [0.5.0](https://github.com/AndrewRedican/hyperfrontend/compare/74ee35afe04d203271bf25992247df1d817c7fc2...3d23dade0efa7172d5311a8676cfe0d52dbe749d) - 2026-03-26
 
 ### Features

--- a/libs/versioning/package.json
+++ b/libs/versioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperfrontend/versioning",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Versioning library with changelog parsing, conventional commits, and semver flow orchestration.",
   "dependencies": {
     "@hyperfrontend/immutable-api-utils": "0.1.2",

--- a/libs/versioning/src/git/factory.ts
+++ b/libs/versioning/src/git/factory.ts
@@ -589,7 +589,8 @@ function fetch(options: { cwd: string; timeout: number }, remote = 'origin', fet
   if (!isValidRemoteName(remote)) {
     return false
   }
-  const args: string[] = ['fetch', remote]
+  // '--' explicitly ends option processing so the remote cannot be interpreted as a flag (e.g. --upload-pack)
+  const args: string[] = ['fetch', '--', remote]
 
   if (fetchOptions?.prune) {
     args.push('--prune')
@@ -626,7 +627,8 @@ function pull(options: { cwd: string; timeout: number }, remote = 'origin', bran
   if (!isValidRemoteName(remote)) {
     return false
   }
-  const args: string[] = ['pull', remote]
+  // '--' explicitly ends option processing so the remote cannot be interpreted as a flag (e.g. --upload-pack)
+  const args: string[] = ['pull', '--', remote]
   if (branch) {
     args.push(branch)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14597,9 +14597,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "overrides": {
     "@rollup/plugin-terser": {
-      "serialize-javascript": "7.0.3"
+      "serialize-javascript": ">=7.0.5"
     },
     "eslint": {
       "ajv": "6.14.0"

--- a/plugins/features/eslint.config.cjs
+++ b/plugins/features/eslint.config.cjs
@@ -3,12 +3,6 @@ const baseConfig = require('../../eslint.base.config.cjs')
 module.exports = [
   ...baseConfig,
   {
-    files: ['**/*.ts'],
-    rules: {
-      'workspace/no-unsafe-builtin-methods': 'off',
-    },
-  },
-  {
     files: ['**/*.json'],
     rules: {
       '@nx/dependency-checks': [

--- a/plugins/features/package.json
+++ b/plugins/features/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "main": "./src/index.js",
   "dependencies": {
+    "@hyperfrontend/immutable-api-utils": "0.1.2",
     "@nx/devkit": "22.3.3"
   },
   "generators": "./generators.json",

--- a/plugins/features/src/executors/serve/executor.ts
+++ b/plugins/features/src/executors/serve/executor.ts
@@ -1,4 +1,5 @@
-import { ServeExecutorSchema } from './schema'
+import type { ServeExecutorSchema } from './schema'
+import { log } from '@hyperfrontend/immutable-api-utils/built-in-copy/console'
 
 /**
  * Nx executor that serves a hyperfrontend feature in a development playground.
@@ -149,10 +150,10 @@ export default async function* serveExecutor(options: ServeExecutorSchema) {
    *      - Links to documentation
    */
 
-  console.log('Starting feature playground...')
-  console.log('Feature project:', options.project)
-  console.log('Port:', options.port)
-  console.log('Mode:', options.mode)
+  log('Starting feature playground...')
+  log('Feature project:', options.project)
+  log('Port:', options.port)
+  log('Mode:', options.mode)
 
   // Implementation placeholder
   yield { success: true }

--- a/plugins/features/src/generators/add/generator.ts
+++ b/plugins/features/src/generators/add/generator.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit'
 import type { AddGeneratorSchema } from './schema'
+import { log } from '@hyperfrontend/immutable-api-utils/built-in-copy/console'
 
 /**
  * Nx generator that adds a hyperfrontend microfrontend feature to a host application.
@@ -161,14 +162,14 @@ export async function addGenerator(tree: Tree, options: AddGeneratorSchema) {
    *      - Next steps
    */
 
-  console.log('Adding hyperfrontend feature to host...')
-  console.log('Feature:', options.featureName)
-  console.log('Host project:', options.project)
-  console.log('Install method:', options.installMethod)
+  log('Adding hyperfrontend feature to host...')
+  log('Feature:', options.featureName)
+  log('Host project:', options.project)
+  log('Install method:', options.installMethod)
 
   // Implementation placeholder
   return () => {
-    console.log('Feature consumption setup complete!')
+    log('Feature consumption setup complete!')
   }
 }
 

--- a/plugins/features/src/generators/init/generator.ts
+++ b/plugins/features/src/generators/init/generator.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit'
 import type { InitGeneratorSchema } from './schema'
+import { log } from '@hyperfrontend/immutable-api-utils/built-in-copy/console'
 
 /**
  * Nx generator that initializes a project as a hyperfrontend microfrontend feature.
@@ -125,13 +126,13 @@ export async function initGenerator(tree: Tree, options: InitGeneratorSchema) {
    *      - Commands to build and test the feature
    */
 
-  console.log('Generating hyperfrontend feature...')
-  console.log('Project:', options.project)
-  console.log('Config path:', options.configPath)
+  log('Generating hyperfrontend feature...')
+  log('Project:', options.project)
+  log('Config path:', options.configPath)
 
   // Implementation placeholder
   return () => {
-    console.log('Feature generation complete!')
+    log('Feature generation complete!')
   }
 }
 

--- a/tools/app/eslint.config.cjs
+++ b/tools/app/eslint.config.cjs
@@ -3,12 +3,6 @@ const baseConfig = require('../../eslint.base.config.cjs')
 module.exports = [
   ...baseConfig,
   {
-    files: ['**/*.ts'],
-    rules: {
-      'workspace/no-unsafe-builtin-methods': 'off',
-    },
-  },
-  {
     files: ['**/*.json'],
     rules: {
       '@nx/dependency-checks': [

--- a/tools/app/src/executors/serve/executor.ts
+++ b/tools/app/src/executors/serve/executor.ts
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '@nx/devkit'
+import { createPromise } from '@hyperfrontend/immutable-api-utils/built-in-copy/promise'
 
 /**
  * Serve executor for hyperfrontend application projects.
@@ -47,7 +48,7 @@ export default async function serveExecutor(options: ServeExecutorOptions, conte
   logger.info(`  Running: ${command}`)
   logger.info(`  In: ${cwd}`)
 
-  return new Promise((resolve) => {
+  return createPromise<{ success: boolean }>((resolve) => {
     const child = spawn(command, {
       cwd,
       stdio: 'inherit',

--- a/tools/eslint-rules/eslint.config.cjs
+++ b/tools/eslint-rules/eslint.config.cjs
@@ -5,7 +5,6 @@ module.exports = [
   {
     files: ['**/*.ts'],
     rules: {
-      'workspace/no-unsafe-builtin-methods': 'off',
       // Node.js type strip mode (used when require()'ing .ts files) doesn't support angle-bracket assertions - Vercel deployment issue
       'workspace/prefer-angle-bracket-assertion': 'off',
     },

--- a/tools/eslint-rules/src/rules/assertive-test-names.spec.ts
+++ b/tools/eslint-rules/src/rules/assertive-test-names.spec.ts
@@ -1,8 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
-
+import { createTypeScriptRuleTester } from '../testing'
 import { assertiveTestNames } from './assertive-test-names'
 
-const ruleTester = new RuleTester()
+const ruleTester = createTypeScriptRuleTester()
 
 ruleTester.run('assertive-test-names', assertiveTestNames, {
   valid: [

--- a/tools/eslint-rules/src/rules/assertive-test-names.ts
+++ b/tools/eslint-rules/src/rules/assertive-test-names.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils'
+import type { TSESTree } from '@typescript-eslint/utils'
+import { ESLintUtils } from '@typescript-eslint/utils'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the assertive-test-names rule.
@@ -14,7 +16,7 @@ type MessageIds = 'noShouldInTestName'
 /**
  * Test function names that this rule checks (it and test variants only, not describe).
  */
-const TEST_FUNCTION_NAMES = new Set(['it', 'test', 'fit', 'xit'])
+const TEST_FUNCTION_NAMES = createSet(['it', 'test', 'fit', 'xit'])
 
 /**
  * Pattern to match the word "should" (case-insensitive, word boundary).

--- a/tools/eslint-rules/src/rules/deepest-import-path.spec.ts
+++ b/tools/eslint-rules/src/rules/deepest-import-path.spec.ts
@@ -1,10 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTempWorkspaceManager, createTypeScriptRuleTester } from '../testing'
 import rule, { clearCache } from './deepest-import-path'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Creates a temporary workspace structure for testing.
@@ -15,38 +13,31 @@ const tempDirs: string[] = []
  * @returns The path to the temporary workspace directory.
  */
 function createTempWorkspace(config: { tsconfigBasePaths?: Record<string, string[]>; sourceFiles?: Record<string, string> }): string {
-  const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-deepest-import-'))
-  tempDirs.push(workspaceDir)
-
-  // Create tsconfig.base.json
-  const tsconfig = {
-    compilerOptions: {
-      baseUrl: '.',
-      paths: config.tsconfigBasePaths ?? {},
-    },
+  const files: Record<string, string> = {
+    'tsconfig.base.json': JSON.stringify(
+      {
+        compilerOptions: {
+          baseUrl: '.',
+          paths: config.tsconfigBasePaths ?? {},
+        },
+      },
+      null,
+      2
+    ),
   }
-  writeFileSync(join(workspaceDir, 'tsconfig.base.json'), JSON.stringify(tsconfig, null, 2), { mode: 0o600 })
 
   // Create source files
   if (config.sourceFiles) {
     for (const [filePath, content] of Object.entries(config.sourceFiles)) {
-      const fullPath = join(workspaceDir, filePath)
-      const dirPath = join(fullPath, '..')
-      mkdirSync(dirPath, { recursive: true })
-      writeFileSync(fullPath, content, { mode: 0o600 })
+      files[filePath] = content
     }
   }
 
-  return workspaceDir
+  const workspace = manager.create({ files })
+  return workspace.root
 }
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
+const ruleTester = createTypeScriptRuleTester()
 
 describe('deepest-import-path', () => {
   beforeEach(() => {
@@ -54,9 +45,7 @@ describe('deepest-import-path', () => {
   })
 
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   describe('valid cases', () => {

--- a/tools/eslint-rules/src/rules/deepest-import-path.ts
+++ b/tools/eslint-rules/src/rules/deepest-import-path.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils'
-import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
+import { exists, findTypeScriptWorkspaceRoot, readFileContent, readJsonFileIfExists } from '../utils'
 
 /**
  * Rule identifier for the deepest-import-path rule.
@@ -46,44 +46,6 @@ let cachedWorkspaceRoot: string | null = null
 const exportCache = new Map<string, Map<string, ExportMapping>>()
 
 /**
- * Finds the workspace root by locating tsconfig.base.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The workspace root path, or null if not found.
- */
-function findWorkspaceRoot(startDir: string): string | null {
-  let dir = startDir
-  const root = '/'
-  while (dir !== root) {
-    if (existsSync(join(dir, 'tsconfig.base.json'))) {
-      return dir
-    }
-    const parent = dirname(dir)
-    /* istanbul ignore if -- defensive infinite loop prevention */
-    if (parent === dir) {
-      break
-    }
-    dir = parent
-  }
-  return null
-}
-
-/**
- * Reads and parses a JSON file.
- *
- * @param filePath - The path to the JSON file.
- * @returns The parsed JSON object, or null if parsing fails.
- */
-function readJsonFile<T>(filePath: string): T | null {
-  try {
-    const content = readFileSync(filePath, 'utf-8')
-    return <T>JSON.parse(content)
-  } catch {
-    return null
-  }
-}
-
-/**
  * Gets the tsconfig paths for packages matching the given prefix.
  *
  * @param workspaceRoot - The workspace root directory.
@@ -97,7 +59,7 @@ function getTsconfigPaths(workspaceRoot: string, packagePrefix: string): Map<str
   }
 
   const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json')
-  const tsconfig = readJsonFile<TsConfig>(tsconfigPath)
+  const tsconfig = readJsonFileIfExists<TsConfig>(tsconfigPath)
 
   /* istanbul ignore if -- defensive for malformed tsconfig */
   if (!tsconfig?.compilerOptions?.paths) {
@@ -143,12 +105,12 @@ function resolveImportPath(importPath: string, fromFile: string): string | null 
   const extensions = ['.ts', '.tsx', '/index.ts', '/index.tsx']
   for (const ext of extensions) {
     const fullPath = basePath + ext
-    if (existsSync(fullPath)) {
+    if (exists(fullPath)) {
       return fullPath
     }
   }
 
-  if (existsSync(basePath)) {
+  if (exists(basePath)) {
     return basePath
   }
 
@@ -166,13 +128,13 @@ function resolveImportPath(importPath: string, fromFile: string): string | null 
 function parseExports(filePath: string, visited: Set<string> = new Set()): Set<string> {
   const exports = new Set<string>()
 
-  if (!existsSync(filePath) || visited.has(filePath)) {
+  if (!exists(filePath) || visited.has(filePath)) {
     return exports
   }
   visited.add(filePath)
 
   try {
-    const content = readFileSync(filePath, 'utf-8')
+    const content = readFileContent(filePath)
 
     const namedExportRegex = /export\s*\{([^}]+)\}/g
     let match: RegExpExecArray | null
@@ -369,7 +331,7 @@ export default createRule<[RuleOptions?], MessageIds>({
   create(context, [options]) {
     const packagePrefix = options?.packagePrefix ?? '@hyperfrontend/'
     const filename = context.filename
-    const workspaceRoot = findWorkspaceRoot(dirname(filename))
+    const workspaceRoot = findTypeScriptWorkspaceRoot(dirname(filename))
 
     /* istanbul ignore if -- defensive if workspace root not found */
     if (!workspaceRoot) {

--- a/tools/eslint-rules/src/rules/deepest-import-path.ts
+++ b/tools/eslint-rules/src/rules/deepest-import-path.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/utils'
 import { dirname, join, resolve } from 'node:path'
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+import { entries } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { exists, findTypeScriptWorkspaceRoot, readFileContent, readJsonFileIfExists } from '../utils'
 
 /**
@@ -43,7 +46,7 @@ let cachedWorkspaceRoot: string | null = null
  * Cache for export analysis results.
  * Key: source file path, Value: Map of export name to deepest path.
  */
-const exportCache = new Map<string, Map<string, ExportMapping>>()
+const exportCache = createMap<string, Map<string, ExportMapping>>()
 
 /**
  * Gets the tsconfig paths for packages matching the given prefix.
@@ -63,15 +66,15 @@ function getTsconfigPaths(workspaceRoot: string, packagePrefix: string): Map<str
 
   /* istanbul ignore if -- defensive for malformed tsconfig */
   if (!tsconfig?.compilerOptions?.paths) {
-    cachedPaths = new Map()
+    cachedPaths = createMap()
     cachedWorkspaceRoot = workspaceRoot
     return cachedPaths
   }
 
-  const paths = new Map<string, string>()
+  const paths = createMap<string, string>()
   const baseUrl = tsconfig.compilerOptions.baseUrl ?? '.'
 
-  for (const [alias, targets] of Object.entries(tsconfig.compilerOptions.paths)) {
+  for (const [alias, targets] of entries(tsconfig.compilerOptions.paths)) {
     if (!alias.startsWith(packagePrefix)) {
       continue
     }
@@ -125,8 +128,8 @@ function resolveImportPath(importPath: string, fromFile: string): string | null 
  * @param visited - Set of already visited files to prevent circular dependencies.
  * @returns Set of exported names from this file.
  */
-function parseExports(filePath: string, visited: Set<string> = new Set()): Set<string> {
-  const exports = new Set<string>()
+function parseExports(filePath: string, visited: Set<string> = createSet()): Set<string> {
+  const exports = createSet<string>()
 
   if (!exists(filePath) || visited.has(filePath)) {
     return exports

--- a/tools/eslint-rules/src/rules/docs-site-libraries.spec.ts
+++ b/tools/eslint-rules/src/rules/docs-site-libraries.spec.ts
@@ -1,11 +1,10 @@
 import type { ArrayExpression, Literal, ObjectExpression, Property, SpreadElement } from 'estree'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RuleTester } from 'eslint'
-import rule, { RULE_NAME, extractPackageNamesFromArray, findWorkspaceRoot, getAllPublishableLibraries } from './docs-site-libraries'
+import { createTempWorkspaceManager } from '../testing'
+import rule, { RULE_NAME, extractPackageNamesFromArray, getAllPublishableLibraries } from './docs-site-libraries'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Valid publishable library project.json for testing.
@@ -39,48 +38,35 @@ function createTempWorkspace(config: {
   libs?: Array<{ name: string; projectJson: object; packageJson?: object }>
   plugins?: Array<{ name: string; projectJson: object; packageJson?: object }>
 }): string {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-docs-site-libs-test-'))
-  tempDirs.push(workspaceDir)
+  const files: Record<string, string> = {
+    'nx.json': JSON.stringify({ version: 2 }, null, 2),
+  }
 
-  // Create nx.json to mark as workspace root
-  writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-  // Create libs directory and libraries
+  // Create libraries
   if (config.libs && config.libs.length > 0) {
-    const libsDir = join(workspaceDir, 'libs')
-    mkdirSync(libsDir, { recursive: true, mode: 0o700 })
-
     for (const lib of config.libs) {
-      const libDir = join(libsDir, lib.name)
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(libDir, 'project.json'), JSON.stringify(lib.projectJson, null, 2), { mode: 0o600 })
+      files[`libs/${lib.name}/project.json`] = JSON.stringify(lib.projectJson, null, 2)
       if (lib.packageJson) {
-        writeFileSync(join(libDir, 'package.json'), JSON.stringify(lib.packageJson, null, 2), { mode: 0o600 })
+        files[`libs/${lib.name}/package.json`] = JSON.stringify(lib.packageJson, null, 2)
       }
     }
   }
 
-  // Create plugins directory and plugins
+  // Create plugins
   if (config.plugins && config.plugins.length > 0) {
-    const pluginsDir = join(workspaceDir, 'plugins')
-    mkdirSync(pluginsDir, { recursive: true, mode: 0o700 })
-
     for (const plugin of config.plugins) {
-      const pluginDir = join(pluginsDir, plugin.name)
-      mkdirSync(pluginDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(pluginDir, 'project.json'), JSON.stringify(plugin.projectJson, null, 2), { mode: 0o600 })
+      files[`plugins/${plugin.name}/project.json`] = JSON.stringify(plugin.projectJson, null, 2)
       if (plugin.packageJson) {
-        writeFileSync(join(pluginDir, 'package.json'), JSON.stringify(plugin.packageJson, null, 2), { mode: 0o600 })
+        files[`plugins/${plugin.name}/package.json`] = JSON.stringify(plugin.packageJson, null, 2)
       }
     }
   }
 
-  // Create the apps/docs-site/src/lib directory
-  const docsLibDir = join(workspaceDir, 'apps', 'docs-site', 'src', 'lib')
-  mkdirSync(docsLibDir, { recursive: true, mode: 0o700 })
-
-  return workspaceDir
+  const workspace = manager.create({
+    files,
+    directories: ['apps/docs-site/src/lib'],
+  })
+  return workspace.root
 }
 
 /**
@@ -112,9 +98,7 @@ ${libraryEntries}
 
 describe('docs-site-libraries', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   describe('rule metadata', () => {
@@ -133,24 +117,6 @@ describe('docs-site-libraries', () => {
     it('has all required message IDs', () => {
       const messageIds = Object.keys(rule.meta?.messages ?? {})
       expect(messageIds).toContain('missingLibrary')
-    })
-  })
-
-  describe('findWorkspaceRoot', () => {
-    it('finds workspace root when nx.json exists', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      const nestedDir = join(workspaceDir, 'apps', 'docs-site', 'src', 'lib')
-
-      const result = findWorkspaceRoot(nestedDir)
-      expect(result).toBe(workspaceDir)
-    })
-
-    it('returns null when no nx.json found', () => {
-      const tempDir = mkdtempSync(join(tmpdir(), 'no-nx-json-'))
-      tempDirs.push(tempDir)
-
-      const result = findWorkspaceRoot(tempDir)
-      expect(result).toBeNull()
     })
   })
 
@@ -220,14 +186,16 @@ describe('docs-site-libraries', () => {
     })
 
     it('handles nested library structures', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      // Create nested lib structure manually
-      const nestedLibDir = join(workspaceDir, 'libs', 'utils', 'json')
-      mkdirSync(nestedLibDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(nestedLibDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2), { mode: 0o600 })
-      writeFileSync(join(nestedLibDir, 'package.json'), JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/utils/json/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2),
+          'libs/utils/json/package.json': JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2),
+        },
+        directories: ['apps/docs-site/src/lib'],
+      })
 
-      const result = getAllPublishableLibraries(workspaceDir)
+      const result = getAllPublishableLibraries(workspace.root)
       expect(result).toHaveLength(1)
       expect(result[0].packageName).toBe('@hyperfrontend/json-utils')
       expect(result[0].relativePath).toBe('libs/utils/json')
@@ -660,14 +628,15 @@ describe('docs-site-libraries', () => {
           name: 'handles nested library paths',
           code: createContentTsCode([]),
           filename: (() => {
-            const dir = createTempWorkspace({ libs: [] })
-            const nestedLibDir = join(dir, 'libs', 'utils', 'json')
-            mkdirSync(nestedLibDir, { recursive: true, mode: 0o700 })
-            writeFileSync(join(nestedLibDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2), { mode: 0o600 })
-            writeFileSync(join(nestedLibDir, 'package.json'), JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2), {
-              mode: 0o600,
+            const workspace = manager.create({
+              files: {
+                'nx.json': JSON.stringify({ version: 2 }, null, 2),
+                'libs/utils/json/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2),
+                'libs/utils/json/package.json': JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2),
+              },
+              directories: ['apps/docs-site/src/lib'],
             })
-            return join(dir, 'apps', 'docs-site', 'src', 'lib', 'content.ts')
+            return join(workspace.root, 'apps', 'docs-site', 'src', 'lib', 'content.ts')
           })(),
           errors: [
             {

--- a/tools/eslint-rules/src/rules/docs-site-libraries.ts
+++ b/tools/eslint-rules/src/rules/docs-site-libraries.ts
@@ -1,6 +1,7 @@
 import type { Rule } from 'eslint'
 import type { ArrayExpression, Identifier, Node, VariableDeclaration, VariableDeclarator } from 'estree'
 import { basename, dirname, join } from 'node:path'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { exists, findNxWorkspaceRoot, isDirectory, isPublishableLibraryDir, readDirectory, readJsonFileIfExists } from '../utils'
 
 /**
@@ -94,7 +95,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
  * @returns Set of package names found.
  */
 export function extractPackageNamesFromArray(arrayExpression: ArrayExpression): Set<string> {
-  const packageNames = new Set<string>()
+  const packageNames = createSet<string>()
 
   for (const element of arrayExpression.elements) {
     // Each element should be an object expression

--- a/tools/eslint-rules/src/rules/docs-site-libraries.ts
+++ b/tools/eslint-rules/src/rules/docs-site-libraries.ts
@@ -1,9 +1,7 @@
 import type { Rule } from 'eslint'
 import type { ArrayExpression, Identifier, Node, VariableDeclaration, VariableDeclarator } from 'estree'
-import type { ProjectJson } from '../utils/nx-project'
-import { existsSync, readdirSync, statSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
-import { parseJsonFile } from '../utils/nx-project'
+import { exists, findNxWorkspaceRoot, isDirectory, isPublishableLibraryDir, readDirectory, readJsonFileIfExists } from '../utils'
 
 /**
  * Rule identifier for the docs-site-libraries rule.
@@ -28,37 +26,6 @@ export interface PublishableLibrary {
 }
 
 /**
- * Checks if a directory contains a publishable library project.
- *
- * @param projectDir - The absolute path to the project directory.
- * @returns True if the project is a publishable library, false otherwise.
- */
-function isPublishableLibraryDir(projectDir: string): boolean {
-  const projectJsonPath = join(projectDir, 'project.json')
-
-  if (!existsSync(projectJsonPath)) {
-    return false
-  }
-
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
-
-  if (!projectJson) {
-    return false
-  }
-
-  // Must be a library with build and publish targets
-  if (projectJson.projectType !== 'library') {
-    return false
-  }
-
-  if (!projectJson.targets?.build || !projectJson.targets?.publish) {
-    return false
-  }
-
-  return true
-}
-
-/**
  * Gets the package name from a library's package.json.
  *
  * @param projectDir - The absolute path to the project directory.
@@ -66,7 +33,7 @@ function isPublishableLibraryDir(projectDir: string): boolean {
  */
 function getPackageName(projectDir: string): string | null {
   const packageJsonPath = join(projectDir, 'package.json')
-  const packageJson = parseJsonFile<{ name?: string }>(packageJsonPath)
+  const packageJson = readJsonFileIfExists<{ name?: string }>(packageJsonPath)
   return packageJson?.name ?? null
 }
 
@@ -78,7 +45,7 @@ function getPackageName(projectDir: string): string | null {
  * @param results - Array to accumulate results.
  */
 function findPublishableLibraries(baseDir: string, workspaceRoot: string, results: PublishableLibrary[]): void {
-  if (!existsSync(baseDir)) {
+  if (!exists(baseDir)) {
     return
   }
 
@@ -100,7 +67,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
   // Recursively check subdirectories
   let entries: string[]
   try {
-    entries = readdirSync(baseDir)
+    entries = readDirectory(baseDir)
   } catch {
     return
   }
@@ -113,37 +80,10 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
 
     const entryPath = join(baseDir, entry)
 
-    let stats
-    try {
-      stats = statSync(entryPath)
-    } catch {
-      continue
-    }
-
-    if (stats.isDirectory()) {
+    if (isDirectory(entryPath)) {
       findPublishableLibraries(entryPath, workspaceRoot, results)
     }
   }
-}
-
-/**
- * Finds the workspace root by looking for nx.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The workspace root path, or null if not found.
- */
-export function findWorkspaceRoot(startDir: string): string | null {
-  let dir = startDir
-  const root = '/'
-
-  while (dir !== root) {
-    if (existsSync(join(dir, 'nx.json'))) {
-      return dir
-    }
-    dir = dirname(dir)
-  }
-
-  return null
 }
 
 /**
@@ -243,7 +183,7 @@ const rule: Rule.RuleModule = {
       return {}
     }
 
-    const workspaceRoot = findWorkspaceRoot(fileDir)
+    const workspaceRoot = findNxWorkspaceRoot(fileDir)
 
     if (!workspaceRoot) {
       return {}

--- a/tools/eslint-rules/src/rules/import-order.spec.ts
+++ b/tools/eslint-rules/src/rules/import-order.spec.ts
@@ -1,17 +1,11 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTypeScriptRuleTester } from '../testing'
 import rule from './import-order'
 
 type TestOptions = readonly []
 type MessageIds = 'incorrectOrder'
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Valid test cases - imports in correct order

--- a/tools/eslint-rules/src/rules/lib-ci-workflows.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-ci-workflows.spec.ts
@@ -1,17 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import rule, {
-  deriveCoverageFlag,
-  findWorkspaceRoot,
-  hasCoverageEntry,
-  hasMatrixEntry,
-  hasPathFilter,
-  hasStatusWorkflow,
-  RULE_NAME,
-} from './lib-ci-workflows'
+import { createTempWorkspaceManager } from '../testing'
+import rule, { deriveCoverageFlag, hasCoverageEntry, hasMatrixEntry, hasPathFilter, hasStatusWorkflow, RULE_NAME } from './lib-ci-workflows'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Valid publishable library project.json for testing.
@@ -52,48 +43,37 @@ function createTempWorkspace(config: {
     statusWorkflows?: string[]
   }
 }): string {
-  // mkdtempSync creates a unique directory atomically
-  const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-  tempDirs.push(workspaceDir)
-
-  // Create nx.json to mark as workspace root
-  writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
+  const files: Record<string, string> = {
+    'nx.json': JSON.stringify({ version: 2 }, null, 2),
+  }
 
   // Create libs directory and libraries
   if (config.libs && config.libs.length > 0) {
-    const libsDir = join(workspaceDir, 'libs')
-    mkdirSync(libsDir, { recursive: true, mode: 0o700 })
-
     for (const lib of config.libs) {
       const folderName = lib.folderName ?? lib.name
-      const libDir = join(libsDir, folderName)
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(libDir, 'project.json'), JSON.stringify(lib.projectJson, null, 2), { mode: 0o600 })
+      files[`libs/${folderName}/project.json`] = JSON.stringify(lib.projectJson, null, 2)
     }
   }
 
-  // Create .github/workflows directory
-  const workflowsDir = join(workspaceDir, '.github', 'workflows')
-  mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-
   // Create ci-libraries.yml if provided
   if (config.workflows?.ciLibraries !== undefined) {
-    writeFileSync(join(workflowsDir, 'ci-libraries.yml'), config.workflows.ciLibraries, { mode: 0o600 })
+    files['.github/workflows/ci-libraries.yml'] = config.workflows.ciLibraries
   }
 
   // Create ci-main.yml if provided
   if (config.workflows?.ciMain !== undefined) {
-    writeFileSync(join(workflowsDir, 'ci-main.yml'), config.workflows.ciMain, { mode: 0o600 })
+    files['.github/workflows/ci-main.yml'] = config.workflows.ciMain
   }
 
   // Create status workflow files
   if (config.workflows?.statusWorkflows) {
     for (const workflowName of config.workflows.statusWorkflows) {
-      writeFileSync(join(workflowsDir, workflowName), '# Status workflow', { mode: 0o600 })
+      files[`.github/workflows/${workflowName}`] = '# Status workflow'
     }
   }
 
-  return workspaceDir
+  const workspace = manager.create({ files })
+  return workspace.root
 }
 
 /**
@@ -157,9 +137,7 @@ ${libsArray}
 
 describe('lib-ci-workflows', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   describe('rule metadata', () => {
@@ -205,25 +183,6 @@ describe('lib-ci-workflows', () => {
 
     it('handles simple paths', () => {
       expect(deriveCoverageFlag('libs/cryptography')).toBe('cryptography')
-    })
-  })
-
-  describe('findWorkspaceRoot', () => {
-    it('finds workspace root when nx.json exists', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      const nestedDir = join(workspaceDir, 'libs', 'nested')
-      mkdirSync(nestedDir, { recursive: true, mode: 0o700 })
-
-      const result = findWorkspaceRoot(nestedDir)
-      expect(result).toBe(workspaceDir)
-    })
-
-    it('returns null when no nx.json found', () => {
-      const tempDir = mkdtempSync(join(tmpdir(), 'no-nx-json-'))
-      tempDirs.push(tempDir)
-
-      const result = findWorkspaceRoot(tempDir)
-      expect(result).toBeNull()
     })
   })
 
@@ -344,13 +303,15 @@ describe('lib-ci-workflows', () => {
     })
 
     it('ignores ci-libraries.yml not in .github/workflows', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      const otherDir = join(workspaceDir, 'other')
-      mkdirSync(otherDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(otherDir, 'ci-libraries.yml'), 'name: test', { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'other/ci-libraries.yml': 'name: test',
+        },
+      })
 
       const handler = rule.create({
-        filename: join(otherDir, 'ci-libraries.yml'),
+        filename: join(workspace.root, 'other', 'ci-libraries.yml'),
         sourceCode: { getText: () => 'name: test' },
       } as never)
 
@@ -616,28 +577,18 @@ describe('lib-ci-workflows', () => {
       const libs = [{ flag: 'json-utils', path: 'libs/utils/json', projectName: 'lib-json-utils' }]
 
       // Create workspace with nested utils structure
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create nested utils directory
-      const utilsJsonDir = join(workspaceDir, 'libs', 'utils', 'json')
-      mkdirSync(utilsJsonDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(utilsJsonDir, 'project.json'), JSON.stringify({ ...PUBLISHABLE_PROJECT_JSON, name: 'lib-json-utils' }, null, 2), {
-        mode: 0o600,
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/utils/json/project.json': JSON.stringify({ ...PUBLISHABLE_PROJECT_JSON, name: 'lib-json-utils' }, null, 2),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent(libs),
+          '.github/workflows/ci-main.yml': createCiMainContent(libs),
+          '.github/workflows/ci-lib-json-utils.yml': '# Status workflow',
+        },
       })
 
-      // Create workflows
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent(libs), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent(libs), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-lib-json-utils.yml'), '# Status workflow', { mode: 0o600 })
-
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -660,24 +611,17 @@ describe('lib-ci-workflows', () => {
     })
 
     it('ignores libraries with no project.json', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with a folder but NO project.json
-      const libDir = join(workspaceDir, 'libs', 'no-project-json')
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      // No project.json file created
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+        directories: ['libs/no-project-json'],
+      })
 
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -696,24 +640,17 @@ describe('lib-ci-workflows', () => {
     })
 
     it('ignores libraries with invalid project.json', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with invalid project.json
-      const libDir = join(workspaceDir, 'libs', 'invalid-json')
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(libDir, 'project.json'), 'not valid json {{{', { mode: 0o600 })
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/invalid-json/project.json': 'not valid json {{{',
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+      })
 
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -732,32 +669,21 @@ describe('lib-ci-workflows', () => {
     })
 
     it('ignores application projects', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with an application project (not library)
-      const libDir = join(workspaceDir, 'libs', 'app-project')
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(
-        join(libDir, 'project.json'),
-        JSON.stringify({
-          name: 'app-project',
-          projectType: 'application',
-          targets: { build: {}, publish: {} },
-        }),
-        { mode: 0o600 }
-      )
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/app-project/project.json': JSON.stringify({
+            name: 'app-project',
+            projectType: 'application',
+            targets: { build: {}, publish: {} },
+          }),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+      })
 
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -776,32 +702,21 @@ describe('lib-ci-workflows', () => {
     })
 
     it('ignores libraries without build target', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with library missing build target
-      const libDir = join(workspaceDir, 'libs', 'no-build')
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(
-        join(libDir, 'project.json'),
-        JSON.stringify({
-          name: 'lib-no-build',
-          projectType: 'library',
-          targets: { publish: {} }, // No build target
-        }),
-        { mode: 0o600 }
-      )
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/no-build/project.json': JSON.stringify({
+            name: 'lib-no-build',
+            projectType: 'library',
+            targets: { publish: {} }, // No build target
+          }),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+      })
 
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -820,26 +735,17 @@ describe('lib-ci-workflows', () => {
     })
 
     it('skips hidden directories', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with a hidden folder
-      const libsDir = join(workspaceDir, 'libs')
-      mkdirSync(libsDir, { recursive: true, mode: 0o700 })
-      const hiddenDir = join(libsDir, '.hidden-lib')
-      mkdirSync(hiddenDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(hiddenDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON), { mode: 0o600 })
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/.hidden-lib/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+      })
 
       const errors: Array<{ messageId: string }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -858,32 +764,20 @@ describe('lib-ci-workflows', () => {
     })
 
     it('uses fallback name when project.json has no name', () => {
-      const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-ci-workflows-test-'))
-      tempDirs.push(workspaceDir)
-
-      // Create nx.json
-      writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-      // Create libs directory with project.json missing name field
-      const libDir = join(workspaceDir, 'libs', 'unnamed')
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(
-        join(libDir, 'project.json'),
-        JSON.stringify({
-          projectType: 'library',
-          targets: { build: {}, publish: {} },
-        }),
-        { mode: 0o600 }
-      )
-
-      const workflowsDir = join(workspaceDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      // Not including the library so it will report missing CI config
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), createCiLibrariesContent([]), { mode: 0o600 })
-      writeFileSync(join(workflowsDir, 'ci-main.yml'), createCiMainContent([]), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/unnamed/project.json': JSON.stringify({
+            projectType: 'library',
+            targets: { build: {}, publish: {} },
+          }),
+          '.github/workflows/ci-libraries.yml': createCiLibrariesContent([]),
+          '.github/workflows/ci-main.yml': createCiMainContent([]),
+        },
+      })
 
       const errors: Array<{ messageId: string; data?: Record<string, string> }> = []
-      const ciLibrariesPath = join(workspaceDir, '.github', 'workflows', 'ci-libraries.yml')
+      const ciLibrariesPath = join(workspace.root, '.github', 'workflows', 'ci-libraries.yml')
 
       const handler = rule.create({
         filename: ciLibrariesPath,
@@ -902,16 +796,15 @@ describe('lib-ci-workflows', () => {
     })
 
     it('returns empty handler when workspace root not found', () => {
-      const tempDir = mkdtempSync(join(tmpdir(), 'no-workspace-'))
-      tempDirs.push(tempDir)
-
-      // Create workflows dir but NO nx.json
-      const workflowsDir = join(tempDir, '.github', 'workflows')
-      mkdirSync(workflowsDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(workflowsDir, 'ci-libraries.yml'), 'name: test', { mode: 0o600 })
+      // Create workspace with workflows dir but NO nx.json
+      const workspace = manager.create({
+        files: {
+          '.github/workflows/ci-libraries.yml': 'name: test',
+        },
+      })
 
       const handler = rule.create({
-        filename: join(workflowsDir, 'ci-libraries.yml'),
+        filename: join(workspace.root, '.github', 'workflows', 'ci-libraries.yml'),
         sourceCode: { getText: () => 'name: test' },
       } as never)
 

--- a/tools/eslint-rules/src/rules/lib-ci-workflows.ts
+++ b/tools/eslint-rules/src/rules/lib-ci-workflows.ts
@@ -1,5 +1,6 @@
 import type { Rule } from 'eslint'
 import { basename, dirname, join } from 'node:path'
+import { min } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
 import {
   exists,
   findNxWorkspaceRoot,
@@ -135,7 +136,7 @@ export function hasPathFilter(content: string, coverageFlag: string, relativePat
     // Look for the filter name followed by colon
     if (line === filterPattern || line.startsWith(`${filterPattern} `)) {
       // Check if the next line (or same line) contains the path pattern
-      for (let j = i; j < Math.min(i + 5, lines.length); j++) {
+      for (let j = i; j < min(i + 5, lines.length); j++) {
         if (lines[j].includes(pathPattern)) {
           return true
         }

--- a/tools/eslint-rules/src/rules/lib-ci-workflows.ts
+++ b/tools/eslint-rules/src/rules/lib-ci-workflows.ts
@@ -1,7 +1,14 @@
 import type { Rule } from 'eslint'
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
-import { parseJsonFile } from '../utils/nx-project'
+import {
+  exists,
+  findNxWorkspaceRoot,
+  isDirectory,
+  isPublishableLibraryDir,
+  readDirectory,
+  readFileIfExists,
+  readJsonFileIfExists,
+} from '../utils'
 
 /**
  * Rule identifier for the lib-ci-workflows rule.
@@ -38,36 +45,6 @@ interface ProjectJson {
 }
 
 /**
- * Checks if a directory contains a publishable library project.
- *
- * @param projectDir - The absolute path to the project directory.
- * @returns True if the project is a publishable library, false otherwise.
- */
-function isPublishableLibraryDir(projectDir: string): boolean {
-  const projectJsonPath = join(projectDir, 'project.json')
-
-  if (!existsSync(projectJsonPath)) {
-    return false
-  }
-
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
-
-  if (!projectJson) {
-    return false
-  }
-
-  if (projectJson.projectType !== 'library') {
-    return false
-  }
-
-  if (!projectJson.targets?.build || !projectJson.targets?.publish) {
-    return false
-  }
-
-  return true
-}
-
-/**
  * Derives the coverage flag from a library path.
  * Example: "libs/utils/json" -> "json-utils"
  * Example: "libs/network-protocol" -> "network-protocol"
@@ -100,7 +77,7 @@ export function deriveCoverageFlag(relativePath: string): string {
  * @param results - Array to accumulate results.
  */
 function findPublishableLibraries(baseDir: string, workspaceRoot: string, results: PublishableLibrary[]): void {
-  if (!existsSync(baseDir)) {
+  if (!exists(baseDir)) {
     return
   }
 
@@ -108,7 +85,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
   if (isPublishableLibraryDir(baseDir)) {
     const relativePath = baseDir.slice(workspaceRoot.length + 1)
     const projectJsonPath = join(baseDir, 'project.json')
-    const projectJson = parseJsonFile<ProjectJson & { name?: string }>(projectJsonPath)
+    const projectJson = readJsonFileIfExists<ProjectJson & { name?: string }>(projectJsonPath)
 
     results.push({
       name: projectJson?.name ?? `lib-${basename(baseDir)}`,
@@ -120,7 +97,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
   // Recursively check subdirectories
   let entries: string[]
   try {
-    entries = readdirSync(baseDir)
+    entries = readDirectory(baseDir)
   } catch {
     return
   }
@@ -133,37 +110,10 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
 
     const entryPath = join(baseDir, entry)
 
-    let stats
-    try {
-      stats = statSync(entryPath)
-    } catch {
-      continue
-    }
-
-    if (stats.isDirectory()) {
+    if (isDirectory(entryPath)) {
       findPublishableLibraries(entryPath, workspaceRoot, results)
     }
   }
-}
-
-/**
- * Finds the workspace root by looking for nx.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The workspace root path, or null if not found.
- */
-export function findWorkspaceRoot(startDir: string): string | null {
-  let dir = startDir
-  const root = '/'
-
-  while (dir !== root) {
-    if (existsSync(join(dir, 'nx.json'))) {
-      return dir
-    }
-    dir = dirname(dir)
-  }
-
-  return null
 }
 
 /**
@@ -244,7 +194,7 @@ export function hasMatrixEntry(content: string, projectName: string, coverageFla
  */
 export function hasStatusWorkflow(workspaceRoot: string, projectName: string): boolean {
   const workflowPath = join(workspaceRoot, '.github', 'workflows', `ci-${projectName}.yml`)
-  return existsSync(workflowPath)
+  return exists(workflowPath)
 }
 
 /**
@@ -269,14 +219,7 @@ export function hasCoverageEntry(content: string, coverageFlag: string, relative
  * @returns The file content or null.
  */
 function safeReadFile(filePath: string): string | null {
-  try {
-    if (!existsSync(filePath)) {
-      return null
-    }
-    return readFileSync(filePath, 'utf-8')
-  } catch {
-    return null
-  }
+  return readFileIfExists(filePath)
 }
 
 const rule: Rule.RuleModule = {
@@ -311,7 +254,7 @@ const rule: Rule.RuleModule = {
     }
 
     const fileDir = dirname(filePath)
-    const workspaceRoot = findWorkspaceRoot(fileDir)
+    const workspaceRoot = findNxWorkspaceRoot(fileDir)
 
     if (!workspaceRoot) {
       return {}

--- a/tools/eslint-rules/src/rules/lib-e2e-project-required.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-e2e-project-required.spec.ts
@@ -1,10 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-e2e-project-required'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Creates a temporary workspace structure for testing.
@@ -19,47 +17,34 @@ function createTempWorkspace(config: { projectJson: object; hasE2eProject?: bool
   libProjectRoot: string
   e2eProjectRoot: string
 } {
-  const workspaceRoot = mkdtempSync(join(tmpdir(), 'eslint-test-workspace-'))
-  tempDirs.push(workspaceRoot)
+  const files: Record<string, string> = {
+    'nx.json': JSON.stringify({ version: 2 }, null, 2),
+    'libs/test-lib/project.json': JSON.stringify(config.projectJson, null, 2),
+  }
 
-  // Create nx.json to mark workspace root
-  writeFileSync(join(workspaceRoot, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-  // Create libs/test-lib directory
-  const libProjectRoot = join(workspaceRoot, 'libs', 'test-lib')
-  mkdirSync(libProjectRoot, { recursive: true })
-
-  // Write project.json for the library
-  writeFileSync(join(libProjectRoot, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-
-  // Create e2e project if specified
-  const e2eProjectRoot = join(workspaceRoot, 'apps', 'package-e2e', 'test-lib')
   if (config.hasE2eProject) {
-    mkdirSync(e2eProjectRoot, { recursive: true })
-    writeFileSync(
-      join(e2eProjectRoot, 'project.json'),
-      JSON.stringify(
-        {
-          name: 'e2e-lib-test-lib',
-          projectType: 'application',
-          tags: ['type:e2e'],
-          implicitDependencies: ['lib-test-lib'],
-        },
-        null,
-        2
-      ),
-      { mode: 0o600 }
+    files['apps/package-e2e/test-lib/project.json'] = JSON.stringify(
+      {
+        name: 'e2e-lib-test-lib',
+        projectType: 'application',
+        tags: ['type:e2e'],
+        implicitDependencies: ['lib-test-lib'],
+      },
+      null,
+      2
     )
   }
 
-  return { workspaceRoot, libProjectRoot, e2eProjectRoot }
+  const workspace = manager.create({ files })
+
+  return {
+    workspaceRoot: workspace.root,
+    libProjectRoot: join(workspace.root, 'libs', 'test-lib'),
+    e2eProjectRoot: join(workspace.root, 'apps', 'package-e2e', 'test-lib'),
+  }
 }
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const ruleTester = createJsonRuleTester()
 
 /**
  * Valid publishable library project.json.
@@ -93,9 +78,7 @@ const applicationProjectJson = {
 
 describe('lib-e2e-project-required', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-e2e-project-required', rule, {
@@ -126,32 +109,26 @@ describe('lib-e2e-project-required', () => {
         name: 'skips application projects',
         code: JSON.stringify(applicationProjectJson, null, 2),
         filename: (() => {
-          const workspaceRoot = mkdtempSync(join(tmpdir(), 'eslint-test-app-'))
-          tempDirs.push(workspaceRoot)
-
-          writeFileSync(join(workspaceRoot, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-          const appRoot = join(workspaceRoot, 'apps', 'test-app')
-          mkdirSync(appRoot, { recursive: true })
-          writeFileSync(join(appRoot, 'project.json'), JSON.stringify(applicationProjectJson, null, 2), { mode: 0o600 })
-
-          return join(appRoot, 'project.json')
+          const workspace = manager.create({
+            files: {
+              'nx.json': JSON.stringify({ version: 2 }, null, 2),
+              'apps/test-app/project.json': JSON.stringify(applicationProjectJson, null, 2),
+            },
+          })
+          return join(workspace.root, 'apps', 'test-app', 'project.json')
         })(),
       },
       {
         name: 'skips projects outside libs folder',
         code: JSON.stringify(publishableProjectJson, null, 2),
         filename: (() => {
-          const workspaceRoot = mkdtempSync(join(tmpdir(), 'eslint-test-outside-'))
-          tempDirs.push(workspaceRoot)
-
-          writeFileSync(join(workspaceRoot, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-          const projectRoot = join(workspaceRoot, 'packages', 'test-lib')
-          mkdirSync(projectRoot, { recursive: true })
-          writeFileSync(join(projectRoot, 'project.json'), JSON.stringify(publishableProjectJson, null, 2), { mode: 0o600 })
-
-          return join(projectRoot, 'project.json')
+          const workspace = manager.create({
+            files: {
+              'nx.json': JSON.stringify({ version: 2 }, null, 2),
+              'packages/test-lib/project.json': JSON.stringify(publishableProjectJson, null, 2),
+            },
+          })
+          return join(workspace.root, 'packages', 'test-lib', 'project.json')
         })(),
       },
     ],

--- a/tools/eslint-rules/src/rules/lib-e2e-project-required.ts
+++ b/tools/eslint-rules/src/rules/lib-e2e-project-required.ts
@@ -1,30 +1,12 @@
 import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
-import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { isPublishableLibrary } from '../utils/nx-project'
+import { exists, findNxWorkspaceRoot, isPublishableLibrary } from '../utils'
 
 /**
  * Rule identifier for the lib-e2e-project-required rule.
  */
 export const RULE_NAME = 'lib-e2e-project-required'
-
-/**
- * Finds the workspace root by locating nx.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The workspace root path, or null if not found.
- */
-function findWorkspaceRoot(startDir: string): string | null {
-  let dir = startDir
-  while (dir !== '/') {
-    if (existsSync(join(dir, 'nx.json'))) {
-      return dir
-    }
-    dir = dirname(dir)
-  }
-  return null
-}
 
 /**
  * Checks if the project directory is within the libs folder.
@@ -59,7 +41,7 @@ function getE2eFolderName(libraryName: string): string {
 function hasE2eProject(libraryName: string, workspaceRoot: string): boolean {
   const e2eFolderName = getE2eFolderName(libraryName)
   const e2eProjectJson = join(workspaceRoot, 'apps', 'package-e2e', e2eFolderName, 'project.json')
-  return existsSync(e2eProjectJson)
+  return exists(e2eProjectJson)
 }
 
 const rule: Rule.RuleModule = {
@@ -79,7 +61,7 @@ const rule: Rule.RuleModule = {
   create(context) {
     const filePath = context.filename
     const projectRoot = dirname(filePath)
-    const workspaceRoot = findWorkspaceRoot(projectRoot)
+    const workspaceRoot = findNxWorkspaceRoot(projectRoot)
 
     /* istanbul ignore next - workspace root should always exist */
     if (!workspaceRoot) {

--- a/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.spec.ts
@@ -1,46 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-pkg-bundle-entry'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 describe('lib-pkg-bundle-entry', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-bundle-entry', rule, {
@@ -49,7 +15,7 @@ describe('lib-pkg-bundle-entry', () => {
         name: 'skips non-publishable libraries',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -58,14 +24,14 @@ describe('lib-pkg-bundle-entry', () => {
             },
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
         name: 'skips application projects',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'application',
               targets: {
@@ -75,21 +41,21 @@ describe('lib-pkg-bundle-entry', () => {
             },
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
         name: 'skips when no bundle entries defined',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: { build: {}, publish: {} },
             },
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -105,7 +71,7 @@ describe('lib-pkg-bundle-entry', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -120,7 +86,7 @@ describe('lib-pkg-bundle-entry', () => {
               },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -136,7 +102,7 @@ describe('lib-pkg-bundle-entry', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -151,7 +117,7 @@ describe('lib-pkg-bundle-entry', () => {
               },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -167,7 +133,7 @@ describe('lib-pkg-bundle-entry', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -187,7 +153,7 @@ describe('lib-pkg-bundle-entry', () => {
               },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
     ],
@@ -204,7 +170,7 @@ describe('lib-pkg-bundle-entry', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -216,7 +182,7 @@ describe('lib-pkg-bundle-entry', () => {
               exports: { '.': './src/index.js' },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingBundleEntry', data: { entry: './browser' } }],
       },
@@ -232,7 +198,7 @@ describe('lib-pkg-bundle-entry', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -244,7 +210,7 @@ describe('lib-pkg-bundle-entry', () => {
               exports: { '.': './src/index.js' },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingBundleEntry', data: { entry: './node' } }],
       },
@@ -252,7 +218,7 @@ describe('lib-pkg-bundle-entry', () => {
         name: 'reports when no exports field exists',
         code: JSON.stringify({ name: '@hyperfrontend/test-lib' }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -262,7 +228,7 @@ describe('lib-pkg-bundle-entry', () => {
             },
             packageJson: { name: '@hyperfrontend/test-lib' },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingBundleEntry', data: { entry: './browser' } }],
       },

--- a/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
@@ -1,7 +1,8 @@
 import type { Rule } from 'eslint'
 import type { JSONNode, JSONProperty } from 'jsonc-eslint-parser/lib/parser/ast'
 import { dirname, join } from 'node:path'
-import { isPublishableLibrary, parseJsonFile } from '../utils/nx-project'
+import { readJsonFileIfExists } from '../utils/fs'
+import { isPublishableLibrary } from '../utils/nx-project'
 
 /**
  * Rule identifier for the lib-pkg-bundle-entry rule.
@@ -29,7 +30,7 @@ interface ProjectJson {
  */
 function getBundleEntries(projectRoot: string): string[] {
   const projectJsonPath = join(projectRoot, 'project.json')
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
+  const projectJson = readJsonFileIfExists<ProjectJson>(projectJsonPath)
 
   if (!projectJson?.targets?.build?.options) {
     return []

--- a/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
@@ -1,6 +1,7 @@
 import type { Rule } from 'eslint'
 import type { JSONNode, JSONProperty } from 'jsonc-eslint-parser/lib/parser/ast'
 import { dirname, join } from 'node:path'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { readJsonFileIfExists } from '../utils/fs'
 import { isPublishableLibrary } from '../utils/nx-project'
 
@@ -47,7 +48,7 @@ function getBundleEntries(projectRoot: string): string[] {
     entries.push(options.umd.entry)
   }
 
-  return [...new Set(entries)]
+  return [...createSet(entries)]
 }
 
 const rule: Rule.RuleModule = {
@@ -80,7 +81,7 @@ const rule: Rule.RuleModule = {
       return {}
     }
 
-    const exportKeys = new Set<string>()
+    const exportKeys = createSet<string>()
     let exportsNode: JSONProperty | null = null
 
     return {

--- a/tools/eslint-rules/src/rules/lib-pkg-exports-exist.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-exports-exist.spec.ts
@@ -1,58 +1,18 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import {
+  createJsonRuleTester,
+  createTempWorkspaceManager,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  APPLICATION_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+} from '../testing'
 import rule from './lib-pkg-exports-exist'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @param config.files - Optional array of file paths to create (relative to project root).
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object; files?: string[] }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-
-  // Create any additional files specified
-  if (config.files) {
-    for (const file of config.files) {
-      const filePath = join(testDir, file)
-      const dirPath = join(filePath, '..')
-      mkdirSync(dirPath, { recursive: true })
-      writeFileSync(filePath, '// generated for test', { mode: 0o600 })
-    }
-  }
-
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 describe('lib-pkg-exports-exist', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-exports-exist', rule, {
@@ -61,33 +21,22 @@ describe('lib-pkg-exports-exist', () => {
         name: 'skips non-publishable libraries',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: {
-                build: {},
-              },
-            },
+          const workspace = manager.create({
+            projectJson: NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
         name: 'skips application projects',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'application',
-              targets: {
-                build: {},
-                publish: {},
-              },
-            },
+          const workspace = manager.create({
+            projectJson: { ...APPLICATION_PROJECT_JSON, targets: { ...APPLICATION_PROJECT_JSON.targets, publish: {} } },
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -103,20 +52,20 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
                 './utils': './src/utils/index.js',
               },
             },
-            files: ['src/index.js', 'src/utils/index.js'],
+            files: {
+              'src/index.js': '// generated for test',
+              'src/utils/index.js': '// generated for test',
+            },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -132,20 +81,19 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
                 './package.json': './package.json',
               },
             },
-            files: ['src/index.js'],
+            files: {
+              'src/index.js': '// generated for test',
+            },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -163,11 +111,8 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': {
@@ -176,9 +121,12 @@ describe('lib-pkg-exports-exist', () => {
                 },
               },
             },
-            files: ['src/index.mjs', 'src/index.cjs'],
+            files: {
+              'src/index.mjs': '// generated for test',
+              'src/index.cjs': '// generated for test',
+            },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -194,20 +142,20 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
                 './utils': './src/utils/index.js',
               },
             },
-            files: ['src/index.ts', 'src/utils/index.ts'],
+            files: {
+              'src/index.ts': '// generated for test',
+              'src/utils/index.ts': '// generated for test',
+            },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -225,11 +173,8 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': {
@@ -238,9 +183,11 @@ describe('lib-pkg-exports-exist', () => {
                 },
               },
             },
-            files: ['src/index.ts'],
+            files: {
+              'src/index.ts': '// generated for test',
+            },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
     ],
@@ -257,11 +204,8 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
@@ -269,7 +213,7 @@ describe('lib-pkg-exports-exist', () => {
             },
             // Note: not creating the file
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [
           {
@@ -291,20 +235,19 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
                 './utils': './src/utils/index.js',
               },
             },
-            files: ['src/index.js'], // Only create main export, not utils
+            files: {
+              'src/index.js': '// generated for test',
+            }, // Only create main export, not utils
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [
           {
@@ -328,11 +271,8 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': {
@@ -341,9 +281,11 @@ describe('lib-pkg-exports-exist', () => {
                 },
               },
             },
-            files: ['src/index.mjs'], // Only create import, not require
+            files: {
+              'src/index.mjs': '// generated for test',
+            }, // Only create import, not require
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [
           {
@@ -366,11 +308,8 @@ describe('lib-pkg-exports-exist', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: {
-              projectType: 'library',
-              targets: { build: {}, publish: {} },
-            },
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 '.': './src/index.js',
@@ -380,7 +319,7 @@ describe('lib-pkg-exports-exist', () => {
             },
             // No files created
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [
           {

--- a/tools/eslint-rules/src/rules/lib-pkg-exports-exist.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-exports-exist.ts
@@ -1,8 +1,7 @@
 import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
-import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { isPublishableLibrary } from '../utils/nx-project'
+import { exists, isPublishableLibrary } from '../utils'
 
 /**
  * Rule identifier for the lib-pkg-exports-exist rule.
@@ -24,7 +23,7 @@ function exportPathExists(exportPath: string, projectRoot: string): boolean {
   const resolvedPath = join(projectRoot, normalizedPath)
 
   // Check if the exact path exists
-  if (existsSync(resolvedPath)) {
+  if (exists(resolvedPath)) {
     return true
   }
 
@@ -36,7 +35,7 @@ function exportPathExists(exportPath: string, projectRoot: string): boolean {
     const mtsPath = resolvedPath.replace(/\.mjs$/, '.mts')
     const ctsPath = resolvedPath.replace(/\.cjs$/, '.cts')
 
-    return existsSync(tsPath) || existsSync(mtsPath) || existsSync(ctsPath)
+    return exists(tsPath) || exists(mtsPath) || exists(ctsPath)
   }
 
   return false

--- a/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.spec.ts
@@ -1,49 +1,14 @@
 import type { RuleTester as ESLintRuleTester } from 'eslint'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import {
+  createJsonRuleTester,
+  createTempWorkspaceManager,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+} from '../testing'
 import rule from './lib-pkg-exports-js-only'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
-
-/**
- * Publishable library project.json.
- */
-const publishableProjectJson = {
-  projectType: 'library',
-  targets: { build: {}, publish: {} },
-}
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 function createValidJsExportsCase(): ESLintRuleTester.ValidTestCase {
   const pkg = {
@@ -55,13 +20,13 @@ function createValidJsExportsCase(): ESLintRuleTester.ValidTestCase {
       './package.json': './package.json',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
@@ -75,22 +40,19 @@ function createValidConditionalExportsCase(): ESLintRuleTester.ValidTestCase {
       },
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createNonPublishableCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: {
-      projectType: 'library',
-      targets: { build: {} }, // No publish target
-    },
+  const workspace = manager.create({
+    projectJson: NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: {
       name: 'internal-lib',
       exports: { '.': './src/index.ts' }, // Would be invalid but skipped
@@ -98,7 +60,7 @@ function createNonPublishableCase(): ESLintRuleTester.ValidTestCase {
   })
   return {
     code: JSON.stringify({ name: 'internal-lib', exports: { '.': './src/index.ts' } }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
@@ -109,13 +71,13 @@ function createTsExtensionCase(): ESLintRuleTester.InvalidTestCase {
       '.': './src/index.ts',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'invalidExtension' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -133,13 +95,13 @@ function createTsxExtensionCase(): ESLintRuleTester.InvalidTestCase {
       './component': './src/component.tsx',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'invalidExtension' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -157,13 +119,13 @@ function createMtsExtensionCase(): ESLintRuleTester.InvalidTestCase {
       '.': './src/index.mts',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'invalidExtension' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -181,13 +143,13 @@ function createCtsExtensionCase(): ESLintRuleTester.InvalidTestCase {
       '.': './src/index.cts',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'invalidExtension' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -208,13 +170,13 @@ function createConditionalTsCase(): ESLintRuleTester.InvalidTestCase {
       },
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'invalidExtension' }, { messageId: 'invalidExtension' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -230,9 +192,7 @@ function createConditionalTsCase(): ESLintRuleTester.InvalidTestCase {
 
 describe('lib-pkg-exports-js-only', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-exports-js-only', rule, {

--- a/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.ts
@@ -1,6 +1,7 @@
 import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
 import { dirname, extname } from 'node:path'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { isPublishableLibrary } from '../utils/nx-project'
 
 /**
@@ -12,7 +13,7 @@ export const RULE_NAME = 'lib-pkg-exports-js-only'
  * Valid extensions for export paths in package.json.
  * Only compiled JavaScript and JSON files should be referenced.
  */
-const VALID_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.json'])
+const VALID_EXTENSIONS = createSet<string>(['.js', '.mjs', '.cjs', '.json'])
 
 /**
  * Checks if a path represents a package.json self-reference export.

--- a/tools/eslint-rules/src/rules/lib-pkg-fields.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-fields.spec.ts
@@ -1,41 +1,15 @@
 import type { RuleTester as ESLintRuleTester } from 'eslint'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import {
+  createJsonRuleTester,
+  createTempWorkspaceManager,
+  APPLICATION_PROJECT_JSON,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+} from '../testing'
 import rule from './lib-pkg-fields'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 /**
  * Complete valid package.json content with all required fields.
@@ -53,73 +27,59 @@ const validPackageJson = {
   },
 }
 
-/**
- * Publishable library project.json.
- */
-const publishableProjectJson = {
-  projectType: 'library',
-  targets: { build: {}, publish: {} },
-}
-
 function createNonPublishableCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: {
-      projectType: 'library',
-      targets: { build: {} },
-    },
+  const workspace = manager.create({
+    projectJson: NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: { name: 'internal-lib' }, // Missing required fields but should be skipped
   })
   return {
     code: JSON.stringify({ name: 'internal-lib' }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createApplicationCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: {
-      projectType: 'application',
-      targets: { build: {}, publish: {} },
-    },
+  const workspace = manager.create({
+    projectJson: { ...APPLICATION_PROJECT_JSON, targets: { ...APPLICATION_PROJECT_JSON.targets, publish: {} } },
     packageJson: { name: 'test-app' },
   })
   return {
     code: JSON.stringify({ name: 'test-app' }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createNoProjectJsonCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
+  const workspace = manager.create({
     packageJson: { name: 'standalone-pkg' },
   })
   return {
     code: JSON.stringify({ name: 'standalone-pkg' }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createValidPublishableCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: validPackageJson,
   })
   return {
     code: JSON.stringify(validPackageJson, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createMissingNameCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['name']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingName' }],
   }
 }
@@ -127,13 +87,13 @@ function createMissingNameCase(): ESLintRuleTester.InvalidTestCase {
 function createMissingDescriptionCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['description']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingDescription' }],
   }
 }
@@ -141,13 +101,13 @@ function createMissingDescriptionCase(): ESLintRuleTester.InvalidTestCase {
 function createMissingLicenseCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['license']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingLicense' }],
   }
 }
@@ -155,13 +115,13 @@ function createMissingLicenseCase(): ESLintRuleTester.InvalidTestCase {
 function createMissingSideEffectsCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['sideEffects']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingSideEffects' }],
   }
 }
@@ -169,13 +129,13 @@ function createMissingSideEffectsCase(): ESLintRuleTester.InvalidTestCase {
 function createMissingEnginesCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['engines']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingEngines' }],
   }
 }
@@ -183,26 +143,26 @@ function createMissingEnginesCase(): ESLintRuleTester.InvalidTestCase {
 function createMissingKeywordsCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { ...validPackageJson }
   delete (<Record<string, unknown>>pkg)['keywords']
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'missingKeywords' }],
   }
 }
 
 function createMissingAllFieldsCase(): ESLintRuleTester.InvalidTestCase {
   const pkg = { version: '1.0.0' }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [
       { messageId: 'missingName' },
       { messageId: 'missingDescription' },
@@ -216,9 +176,7 @@ function createMissingAllFieldsCase(): ESLintRuleTester.InvalidTestCase {
 
 describe('lib-pkg-fields', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-fields', rule, {

--- a/tools/eslint-rules/src/rules/lib-pkg-fields.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-fields.ts
@@ -1,6 +1,7 @@
 import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
 import { dirname } from 'node:path'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { isPublishableLibrary } from '../utils/nx-project'
 
 /**
@@ -55,7 +56,7 @@ const rule: Rule.RuleModule = {
       return {}
     }
 
-    const foundFields = new Set<string>()
+    const foundFields = createSet<string>()
 
     return {
       /* istanbul ignore next - jsonc-eslint-parser always provides JSONProperty for object keys */

--- a/tools/eslint-rules/src/rules/lib-pkg-no-main.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-no-main.spec.ts
@@ -1,49 +1,15 @@
 import type { RuleTester as ESLintRuleTester } from 'eslint'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import {
+  createJsonRuleTester,
+  createTempWorkspaceManager,
+  APPLICATION_PROJECT_JSON,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+} from '../testing'
 import rule from './lib-pkg-no-main'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
-
-/**
- * Publishable library project.json.
- */
-const publishableProjectJson = {
-  projectType: 'library',
-  targets: { build: {}, publish: {} },
-}
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 /**
  * Valid package.json with exports (no main).
@@ -57,41 +23,35 @@ const validPackageJson = {
 }
 
 function createValidWithExportsCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: validPackageJson,
   })
   return {
     code: JSON.stringify(validPackageJson, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createNonPublishableCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: {
-      projectType: 'library',
-      targets: { build: {} }, // No publish target
-    },
+  const workspace = manager.create({
+    projectJson: NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: { name: 'internal-lib', main: './src/index.js' },
   })
   return {
     code: JSON.stringify({ name: 'internal-lib', main: './src/index.js' }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
 function createApplicationCase(): ESLintRuleTester.ValidTestCase {
-  const projectDir = createTempProject({
-    projectJson: {
-      projectType: 'application',
-      targets: { build: {}, publish: {} },
-    },
+  const workspace = manager.create({
+    projectJson: { ...APPLICATION_PROJECT_JSON, targets: { ...APPLICATION_PROJECT_JSON.targets, publish: {} } },
     packageJson: { name: 'test-app', main: './src/main.js' },
   })
   return {
     code: JSON.stringify({ name: 'test-app', main: './src/main.js' }, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
   }
 }
 
@@ -100,13 +60,13 @@ function createMainOnlyCase(): ESLintRuleTester.InvalidTestCase {
     name: '@hyperfrontend/test-lib',
     main: './src/index.js',
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'noMainField' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -126,13 +86,13 @@ function createMainWithExportsCase(): ESLintRuleTester.InvalidTestCase {
       './utils': './src/utils/index.js',
     },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'mainWithExports' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -153,13 +113,13 @@ function createMainLastPropertyWithExportsCase(): ESLintRuleTester.InvalidTestCa
     },
     main: './src/index.js',
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'mainWithExports' }],
     output: `{
   "name": "@hyperfrontend/test-lib",
@@ -176,13 +136,13 @@ function createMainWithNonStringValueCase(): ESLintRuleTester.InvalidTestCase {
     name: '@hyperfrontend/test-lib',
     main: { default: './src/index.js' },
   }
-  const projectDir = createTempProject({
-    projectJson: publishableProjectJson,
+  const workspace = manager.create({
+    projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
     packageJson: pkg,
   })
   return {
     code: JSON.stringify(pkg, null, 2),
-    filename: join(projectDir, 'package.json'),
+    filename: workspace.getPath('package.json'),
     errors: [{ messageId: 'noMainField' }],
     // No output - fix returns null when main is not a string
     output: null,
@@ -191,9 +151,7 @@ function createMainWithNonStringValueCase(): ESLintRuleTester.InvalidTestCase {
 
 describe('lib-pkg-no-main', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-no-main', rule, {

--- a/tools/eslint-rules/src/rules/lib-pkg-package-json-export.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-package-json-export.spec.ts
@@ -1,48 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import {
+  createJsonRuleTester,
+  createTempWorkspaceManager,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+} from '../testing'
 import rule from './lib-pkg-package-json-export'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - Optional project.json content.
- * @param config.packageJson - Optional package.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson?: object; packageJson?: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  }
-
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
-  }
-
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
-
-/**
- * Publishable library project.json.
- */
-const publishableProjectJson = {
-  projectType: 'library',
-  targets: { build: {}, publish: {} },
-}
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 /**
  * Valid package.json with ./package.json export.
@@ -57,9 +22,7 @@ const validPackageJson = {
 
 describe('lib-pkg-package-json-export', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-pkg-package-json-export', rule, {
@@ -68,33 +31,33 @@ describe('lib-pkg-package-json-export', () => {
         name: 'skips non-publishable libraries',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: { projectType: 'library', targets: { build: {} } },
+          const workspace = manager.create({
+            projectJson: NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
         name: 'skips application projects',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: { projectType: 'application', targets: { build: {}, publish: {} } },
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
         name: 'passes with ./package.json export',
         code: JSON.stringify(validPackageJson, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: validPackageJson,
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
       {
@@ -109,15 +72,15 @@ describe('lib-pkg-package-json-export', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: {
               exports: {
                 './package.json': './package.json',
               },
             },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
       },
     ],
@@ -126,11 +89,11 @@ describe('lib-pkg-package-json-export', () => {
         name: 'reports missing exports field',
         code: JSON.stringify({ name: '@hyperfrontend/test-lib' }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { name: '@hyperfrontend/test-lib' },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingPackageJsonExport' }],
       },
@@ -138,11 +101,11 @@ describe('lib-pkg-package-json-export', () => {
         name: 'reports exports without ./package.json',
         code: JSON.stringify({ exports: { '.': './src/index.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { exports: { '.': './src/index.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingPackageJsonExport' }],
       },
@@ -150,11 +113,11 @@ describe('lib-pkg-package-json-export', () => {
         name: 'reports empty exports object',
         code: JSON.stringify({ exports: {} }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { exports: {} },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingPackageJsonExport' }],
       },
@@ -162,11 +125,11 @@ describe('lib-pkg-package-json-export', () => {
         name: 'reports multiple exports without ./package.json',
         code: JSON.stringify({ exports: { '.': './src/index.js', './browser': './src/browser.js' } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
-            projectJson: publishableProjectJson,
+          const workspace = manager.create({
+            projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
             packageJson: { exports: { '.': './src/index.js', './browser': './src/browser.js' } },
           })
-          return join(dir, 'package.json')
+          return workspace.getPath('package.json')
         })(),
         errors: [{ messageId: 'missingPackageJsonExport' }],
       },

--- a/tools/eslint-rules/src/rules/lib-project-bundle-config.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-project-bundle-config.spec.ts
@@ -1,38 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-project-bundle-config'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - The project.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 describe('lib-project-bundle-config', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-project-bundle-config', rule, {
@@ -50,13 +24,13 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: { build: { options: { iife: {} } } },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -73,7 +47,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'application',
               targets: {
@@ -82,7 +56,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -96,13 +70,13 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -123,7 +97,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -136,7 +110,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -157,7 +131,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -170,7 +144,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -192,7 +166,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -206,7 +180,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
     ],
@@ -229,7 +203,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -242,7 +216,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingEntry', data: { format: 'iife' } }],
       },
@@ -264,7 +238,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -277,7 +251,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingGlobalName', data: { format: 'iife' } }],
       },
@@ -299,7 +273,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -312,7 +286,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingEntry', data: { format: 'umd' } }],
       },
@@ -334,7 +308,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -347,7 +321,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingGlobalName', data: { format: 'umd' } }],
       },
@@ -369,7 +343,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -382,7 +356,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [
           { messageId: 'missingEntry', data: { format: 'iife' } },
@@ -408,7 +382,7 @@ describe('lib-project-bundle-config', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: {
@@ -422,7 +396,7 @@ describe('lib-project-bundle-config', () => {
               },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [
           { messageId: 'missingGlobalName', data: { format: 'iife' } },

--- a/tools/eslint-rules/src/rules/lib-project-metadata.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-project-metadata.spec.ts
@@ -1,32 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-project-metadata'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - The project.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 /**
  * Valid publishable library project.json.
@@ -41,9 +17,7 @@ const validProjectJson = {
 
 describe('lib-project-metadata', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-project-metadata', rule, {
@@ -52,28 +26,28 @@ describe('lib-project-metadata', () => {
         name: 'skips non-publishable libraries',
         code: JSON.stringify({ name: 'test', projectType: 'library', targets: { build: {} } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: { name: 'test', projectType: 'library', targets: { build: {} } },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
         name: 'skips application projects',
         code: JSON.stringify({ name: 'app-test', projectType: 'application', targets: { build: {}, publish: {} } }, null, 2),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: { name: 'app-test', projectType: 'application', targets: { build: {}, publish: {} } },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
         name: 'passes with all required fields',
         code: JSON.stringify(validProjectJson, null, 2),
         filename: (() => {
-          const dir = createTempProject({ projectJson: validProjectJson })
-          return join(dir, 'project.json')
+          const workspace = manager.create({ projectJson: validProjectJson })
+          return workspace.getPath('project.json')
         })(),
       },
     ],
@@ -91,7 +65,7 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -99,7 +73,7 @@ describe('lib-project-metadata', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingTags' }],
       },
@@ -117,7 +91,7 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -126,7 +100,7 @@ describe('lib-project-metadata', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'emptyTags' }],
       },
@@ -143,7 +117,7 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               description: 'Test library',
               projectType: 'library',
@@ -151,7 +125,7 @@ describe('lib-project-metadata', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingName' }],
       },
@@ -169,7 +143,7 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'test-library',
               description: 'Test library',
@@ -178,7 +152,7 @@ describe('lib-project-metadata', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'invalidNamePrefix' }],
       },
@@ -195,7 +169,7 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               projectType: 'library',
@@ -203,7 +177,7 @@ describe('lib-project-metadata', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingDescription' }],
       },
@@ -218,13 +192,13 @@ describe('lib-project-metadata', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               projectType: 'library',
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingTags' }, { messageId: 'missingName' }, { messageId: 'missingDescription' }],
       },

--- a/tools/eslint-rules/src/rules/lib-project-version-targets.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-project-version-targets.spec.ts
@@ -1,38 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-project-version-targets'
 
-const tempDirs: string[] = []
-
-/**
- * Creates a temporary project structure for testing.
- *
- * @param config - Configuration for the temporary project.
- * @param config.projectJson - The project.json content.
- * @returns The path to the temporary project directory.
- */
-function createTempProject(config: { projectJson: object }): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-
-  writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  mkdirSync(join(testDir, 'src'), { recursive: true })
-  return testDir
-}
-
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const manager = createTempWorkspaceManager()
+const ruleTester = createJsonRuleTester()
 
 describe('lib-project-version-targets', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-project-version-targets', rule, {
@@ -49,10 +23,10 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: { name: 'test', projectType: 'library', targets: { build: {} } },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -67,10 +41,10 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: { name: 'app-test', projectType: 'application', targets: { build: {}, publish: {} } },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
       {
@@ -87,7 +61,7 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -96,7 +70,7 @@ describe('lib-project-version-targets', () => {
               targets: { build: {}, publish: {}, version: {}, 'version-check': {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
       },
     ],
@@ -115,7 +89,7 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -124,7 +98,7 @@ describe('lib-project-version-targets', () => {
               targets: { build: {}, publish: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingVersion' }, { messageId: 'missingVersionCheck' }],
       },
@@ -142,7 +116,7 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -151,7 +125,7 @@ describe('lib-project-version-targets', () => {
               targets: { build: {}, publish: {}, version: {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingVersionCheck' }],
       },
@@ -169,7 +143,7 @@ describe('lib-project-version-targets', () => {
           2
         ),
         filename: (() => {
-          const dir = createTempProject({
+          const workspace = manager.create({
             projectJson: {
               name: 'lib-test',
               description: 'Test library',
@@ -178,7 +152,7 @@ describe('lib-project-version-targets', () => {
               targets: { build: {}, publish: {}, 'version-check': {} },
             },
           })
-          return join(dir, 'project.json')
+          return workspace.getPath('project.json')
         })(),
         errors: [{ messageId: 'missingVersion' }],
       },

--- a/tools/eslint-rules/src/rules/lib-readme-structure.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-readme-structure.spec.ts
@@ -1,6 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { createTempWorkspaceManager } from '../testing'
 import rule, {
   extractBadgesBlock,
   extractDocumentationLink,
@@ -13,7 +12,7 @@ import rule, {
   RULE_NAME,
 } from './lib-readme-structure'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Valid publishable library project.json for testing.
@@ -34,14 +33,11 @@ const validProjectJson = {
  * @returns The path to the temporary project directory.
  */
 function createTempProject(config: { projectJson: object }): string {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-readme-test-'))
-  tempDirs.push(testDir)
-
-  writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
-  mkdirSync(join(testDir, 'src'), { recursive: true, mode: 0o700 })
-
-  return testDir
+  const workspace = manager.create({
+    projectJson: config.projectJson,
+    directories: ['src'],
+  })
+  return workspace.root
 }
 
 /**
@@ -136,9 +132,7 @@ import { something } from '@hyperfrontend/${packageName}'
 
 describe('lib-readme-structure', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   describe('rule metadata', () => {

--- a/tools/eslint-rules/src/rules/lib-readme-structure.ts
+++ b/tools/eslint-rules/src/rules/lib-readme-structure.ts
@@ -1,11 +1,12 @@
 import type { Rule } from 'eslint'
 import { dirname } from 'node:path'
+import { createURL } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
 import { isPublishableLibrary } from '../utils/nx-project'
 
 /**
  * The expected base URL for documentation links.
  */
-const DOCS_BASE_URL = new URL('https://www.hyperfrontend.dev/docs/')
+const DOCS_BASE_URL = createURL('https://www.hyperfrontend.dev/docs/')
 
 /**
  * Checks if a line contains a URL that starts with the expected documentation base URL.
@@ -38,7 +39,7 @@ function containsValidDocumentationUrl(line: string): boolean {
   // Check if any extracted URL matches the expected base URL
   return urls.some((url) => {
     try {
-      const parsed = new URL(url)
+      const parsed = createURL(url)
       // Verify the origin and pathname start correctly
       return parsed.origin === DOCS_BASE_URL.origin && parsed.pathname.startsWith(DOCS_BASE_URL.pathname)
     } catch {

--- a/tools/eslint-rules/src/rules/lib-tsconfig-paths.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-tsconfig-paths.spec.ts
@@ -1,10 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createTempWorkspaceManager } from '../testing'
 import rule from './lib-tsconfig-paths'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Creates a temporary workspace structure for testing.
@@ -25,27 +23,24 @@ function createTempWorkspace(config: {
     hasPublish?: boolean
   }>
 }): string {
-  const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-test-workspace-'))
-  tempDirs.push(workspaceDir)
+  // Build the files map
+  const files: Record<string, string> = {}
 
-  // Create libs directory
-  mkdirSync(join(workspaceDir, 'libs'), { recursive: true })
-
-  // Create tsconfig.base.json
-  const tsconfig = {
-    compilerOptions: {
-      baseUrl: '.',
-      paths: config.tsconfigBasePaths ?? {},
+  // Add tsconfig.base.json
+  files['tsconfig.base.json'] = JSON.stringify(
+    {
+      compilerOptions: {
+        baseUrl: '.',
+        paths: config.tsconfigBasePaths ?? {},
+      },
     },
-  }
-  writeFileSync(join(workspaceDir, 'tsconfig.base.json'), JSON.stringify(tsconfig, null, 2), { mode: 0o600 })
+    null,
+    2
+  )
 
   // Create library projects
   if (config.libraries) {
     for (const lib of config.libraries) {
-      const libDir = join(workspaceDir, lib.path)
-      mkdirSync(libDir, { recursive: true })
-
       // Create project.json
       const projectJson = {
         projectType: lib.projectType ?? 'library',
@@ -54,41 +49,36 @@ function createTempWorkspace(config: {
           ...(lib.hasPublish !== false ? { publish: {} } : {}),
         },
       }
-      writeFileSync(join(libDir, 'project.json'), JSON.stringify(projectJson, null, 2), { mode: 0o600 })
+      files[join(lib.path, 'project.json')] = JSON.stringify(projectJson, null, 2)
 
       // Create package.json
       const packageJson = {
         name: lib.name,
         exports: lib.exports,
       }
-      writeFileSync(join(libDir, 'package.json'), JSON.stringify(packageJson, null, 2), { mode: 0o600 })
+      files[join(lib.path, 'package.json')] = JSON.stringify(packageJson, null, 2)
 
       // Create source files
-      mkdirSync(join(libDir, 'src'), { recursive: true })
       const sourceFiles = lib.sourceFiles ?? ['src/index.ts']
       for (const file of sourceFiles) {
-        const filePath = join(libDir, file)
-        const dirPath = join(filePath, '..')
-        mkdirSync(dirPath, { recursive: true })
-        writeFileSync(filePath, '// generated for test', { mode: 0o600 })
+        files[join(lib.path, file)] = '// generated for test'
       }
     }
   }
 
-  return workspaceDir
+  const workspace = manager.create({
+    files,
+    directories: ['libs'],
+  })
+
+  return workspace.root
 }
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser: require('jsonc-eslint-parser'),
-  },
-})
+const ruleTester = createJsonRuleTester()
 
 describe('lib-tsconfig-paths', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('lib-tsconfig-paths', rule, {

--- a/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
+++ b/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
@@ -1,8 +1,8 @@
 import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
-import type { PackageJson, ProjectJson } from '../utils/nx-project'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import type { PackageJson } from '../utils/nx-project'
 import { dirname, join, relative } from 'node:path'
+import { exists, findLibraryDirectories, readJsonFileIfExists } from '../utils'
 
 /**
  * Rule identifier for the lib-tsconfig-paths rule.
@@ -32,80 +32,6 @@ interface EntryPointMapping {
 }
 
 /**
- * Parses a JSON file safely.
- *
- * @param filePath - The path to the JSON file.
- * @returns The parsed JSON object, or null if parsing fails.
- */
-function parseJsonFile<T>(filePath: string): T | null {
-  try {
-    const content = readFileSync(filePath, 'utf-8')
-    return <T>JSON.parse(content)
-    /* istanbul ignore next -- defensive error handling for malformed JSON */
-  } catch {
-    return null
-  }
-}
-
-/**
- * Checks if a project is a library by examining its project.json.
- *
- * @param projectDir - The project directory path.
- * @returns True if the project is a library.
- */
-function isLibrary(projectDir: string): boolean {
-  const projectJsonPath = join(projectDir, 'project.json')
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
-
-  /* istanbul ignore if -- defensive for malformed project.json */
-  if (!projectJson) {
-    return false
-  }
-
-  return projectJson.projectType === 'library'
-}
-
-/**
- * Recursively finds all library directories in the workspace.
- *
- * @param dir - The directory to search in.
- * @param workspaceRoot - The workspace root directory.
- * @returns Array of library directory paths.
- */
-function findLibraryDirectories(dir: string, workspaceRoot: string): string[] {
-  const results: string[] = []
-
-  if (!existsSync(dir)) {
-    return results
-  }
-
-  const entries = readdirSync(dir, { withFileTypes: true })
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
-      continue
-    }
-
-    // Skip node_modules, hidden directories, and common non-project directories
-    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') {
-      continue
-    }
-
-    const fullPath = join(dir, entry.name)
-
-    // Check if this directory is a library
-    if (isLibrary(fullPath)) {
-      results.push(fullPath)
-    }
-
-    // Recurse into subdirectories
-    results.push(...findLibraryDirectories(fullPath, workspaceRoot))
-  }
-
-  return results
-}
-
-/**
  * Converts a package.json export path (./sub/path.js) to a TypeScript source path.
  *
  * @param exportPath - The export path from package.json.
@@ -124,7 +50,7 @@ function resolveExportToSourcePath(exportPath: string, projectDir: string, works
   const absolutePath = join(projectDir, normalizedPath)
 
   // Check if the TypeScript file exists
-  if (existsSync(absolutePath)) {
+  if (exists(absolutePath)) {
     return relative(workspaceRoot, absolutePath)
   }
 
@@ -133,11 +59,11 @@ function resolveExportToSourcePath(exportPath: string, projectDir: string, works
   const ctsPath = absolutePath.replace(/\.ts$/, '.cts')
 
   /* istanbul ignore if -- mts fallback tested via dedicated test */
-  if (existsSync(mtsPath)) {
+  if (exists(mtsPath)) {
     return relative(workspaceRoot, mtsPath)
   }
   /* istanbul ignore if -- cts fallback tested via dedicated test */
-  if (existsSync(ctsPath)) {
+  if (exists(ctsPath)) {
     return relative(workspaceRoot, ctsPath)
   }
 
@@ -153,7 +79,7 @@ function resolveExportToSourcePath(exportPath: string, projectDir: string, works
  */
 function getLibraryEntryPoints(projectDir: string, workspaceRoot: string): EntryPointMapping[] {
   const packageJsonPath = join(projectDir, 'package.json')
-  const packageJson = parseJsonFile<PackageJson>(packageJsonPath)
+  const packageJson = readJsonFileIfExists<PackageJson>(packageJsonPath)
 
   if (!packageJson?.name || !packageJson.exports) {
     return []
@@ -366,7 +292,7 @@ const rule: Rule.RuleModule = {
     const libraryDirs: string[] = []
     for (const dir of libraryDirectories) {
       const absoluteDir = join(workspaceRoot, dir)
-      const foundDirs = findLibraryDirectories(absoluteDir, workspaceRoot)
+      const foundDirs = findLibraryDirectories(absoluteDir)
 
       // Filter out excluded directories
       for (const foundDir of foundDirs) {
@@ -464,7 +390,7 @@ const rule: Rule.RuleModule = {
           let fileExists = false
           if (sourcePath) {
             const absolutePath = join(workspaceRoot, sourcePath)
-            fileExists = existsSync(absolutePath)
+            fileExists = exists(absolutePath)
           }
 
           // Check if this path belongs to a known package (one with exports in package.json)

--- a/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
+++ b/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
@@ -2,6 +2,10 @@ import type { Rule } from 'eslint'
 import type { JSONNode } from 'jsonc-eslint-parser/lib/parser/ast'
 import type { PackageJson } from '../utils/nx-project'
 import { dirname, join, relative } from 'node:path'
+import { from } from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+import { entries, values } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { exists, findLibraryDirectories, readJsonFileIfExists } from '../utils'
 
 /**
@@ -88,7 +92,7 @@ function getLibraryEntryPoints(projectDir: string, workspaceRoot: string): Entry
   const mappings: EntryPointMapping[] = []
   const packageName = packageJson.name
 
-  for (const [exportKey, exportValue] of Object.entries(packageJson.exports)) {
+  for (const [exportKey, exportValue] of entries(packageJson.exports)) {
     // Skip package.json self-references
     /* istanbul ignore if -- tested in separate case */
     if (exportKey === './package.json' || exportValue === './package.json') {
@@ -102,7 +106,7 @@ function getLibraryEntryPoints(projectDir: string, workspaceRoot: string): Entry
       /* istanbul ignore else -- conditional exports tested separately */
     } else if (typeof exportValue === 'object' && exportValue !== null) {
       // Use 'import' or 'default' or first available path
-      exportPath = exportValue['import'] ?? exportValue['default'] ?? Object.values(exportValue)[0]
+      exportPath = exportValue['import'] ?? exportValue['default'] ?? values(exportValue)[0]
     }
 
     /* istanbul ignore if -- defensive for invalid export types */
@@ -147,7 +151,7 @@ function getLibraryEntryPoints(projectDir: string, workspaceRoot: string): Entry
  * @returns Map of path alias to source paths array.
  */
 function extractExistingPaths(pathsNode: JSONNode): Map<string, string[]> {
-  const paths = new Map<string, string[]>()
+  const paths = createMap<string, string[]>()
 
   /* istanbul ignore if -- defensive type guard for jsonc-eslint-parser */
   if (pathsNode.type !== 'JSONObjectExpression') {
@@ -354,10 +358,10 @@ const rule: Rule.RuleModule = {
         }
 
         const existingPaths = extractExistingPaths(pathsValue)
-        const existingPathsList = Array.from(existingPaths.keys())
+        const existingPathsList = from(existingPaths.keys())
 
         // Build a map of package names to their paths
-        const packageNameSet = new Set(expectedMappings.map((m) => m.packageName))
+        const packageNameSet = createSet(expectedMappings.map((m) => m.packageName))
 
         // Check for orphan paths (paths that point to non-existent files or don't match any package)
         const orphanPaths: Array<{ pathAlias: string; sourcePath: string; propertyNode: JSONNode; reason: 'nonexistent' | 'unknown' }> = []
@@ -395,7 +399,7 @@ const rule: Rule.RuleModule = {
 
           // Check if this path belongs to a known package (one with exports in package.json)
           /* istanbul ignore next -- callback may not execute if packageNameSet is empty */
-          const matchesKnownPackage = Array.from(packageNameSet).some((pkg) => keyName === pkg || keyName.startsWith(`${pkg}/`))
+          const matchesKnownPackage = from(packageNameSet).some((pkg) => keyName === pkg || keyName.startsWith(`${pkg}/`))
 
           if (!matchesKnownPackage) {
             // If the path doesn't match a known package but the file exists,
@@ -577,7 +581,7 @@ const rule: Rule.RuleModule = {
         /* istanbul ignore next -- callback may not execute if orphanPaths is empty */
         const nonOrphanPaths = existingPathsList.filter((p) => !orphanPaths.some((o) => o.pathAlias === p))
 
-        const packageIndices = new Map<string, number[]>()
+        const packageIndices = createMap<string, number[]>()
 
         for (let i = 0; i < nonOrphanPaths.length; i++) {
           const pathAlias = nonOrphanPaths[i]

--- a/tools/eslint-rules/src/rules/no-async-fs-api.ts
+++ b/tools/eslint-rules/src/rules/no-async-fs-api.ts
@@ -1,4 +1,7 @@
 import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+import { keys } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the no-async-fs-api rule.
@@ -75,7 +78,7 @@ const ASYNC_TO_SYNC_METHODS: Record<string, string> = {
  * These are the same as ASYNC_TO_SYNC_METHODS keys but explicitly listed
  * for clarity when checking callback patterns.
  */
-const ASYNC_METHODS = new Set(Object.keys(ASYNC_TO_SYNC_METHODS))
+const ASYNC_METHODS = createSet(keys(ASYNC_TO_SYNC_METHODS))
 
 /**
  * fs/promises specific exports that are async-only.
@@ -112,7 +115,7 @@ export default createRule<[], MessageIds>({
   defaultOptions: [],
   create(context) {
     // Track namespace imports for fs module
-    const fsNamespaceBindings = new Map<string, 'fs' | 'fs/promises'>()
+    const fsNamespaceBindings = createMap<string, 'fs' | 'fs/promises'>()
 
     return {
       // Check for fs/promises imports (always async)

--- a/tools/eslint-rules/src/rules/no-deprecated-tag.spec.ts
+++ b/tools/eslint-rules/src/rules/no-deprecated-tag.spec.ts
@@ -1,17 +1,11 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTypeScriptRuleTester } from '../testing'
 import rule from './no-deprecated-tag'
 
 type TestOptions = readonly []
 type MessageIds = 'noDeprecatedTag'
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Valid test cases - code without the deprecated tag

--- a/tools/eslint-rules/src/rules/no-deprecated-tag.ts
+++ b/tools/eslint-rules/src/rules/no-deprecated-tag.ts
@@ -1,4 +1,5 @@
 import { ESLintUtils } from '@typescript-eslint/utils'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the no-deprecated-tag rule.
@@ -19,7 +20,7 @@ const DEPRECATED_TAG = '@deprecated'
 /**
  * Characters that can follow a valid tag (whitespace or end of string).
  */
-const TAG_TERMINATORS = new Set([' ', '\t', '\n', '\r', '*', undefined])
+const TAG_TERMINATORS = createSet([' ', '\t', '\n', '\r', '*', undefined])
 
 /**
  * Finds the index of the deprecated tag in a comment, case-insensitive.

--- a/tools/eslint-rules/src/rules/no-mixed-type-import.spec.ts
+++ b/tools/eslint-rules/src/rules/no-mixed-type-import.spec.ts
@@ -1,17 +1,11 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTypeScriptRuleTester } from '../testing'
 import rule from './no-mixed-type-import'
 
 type TestOptions = readonly []
 type MessageIds = 'noMixedTypeImport'
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Valid test cases - pure type imports, pure value imports, or import type syntax

--- a/tools/eslint-rules/src/rules/no-namespace-import.spec.ts
+++ b/tools/eslint-rules/src/rules/no-namespace-import.spec.ts
@@ -1,17 +1,11 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTypeScriptRuleTester } from '../testing'
 import rule from './no-namespace-import'
 
 type TestOptions = readonly []
 type MessageIds = 'noNamespaceImport'
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Valid test cases - named imports, default imports, type imports, and allowed exceptions

--- a/tools/eslint-rules/src/rules/no-unsafe-builtin-methods.spec.ts
+++ b/tools/eslint-rules/src/rules/no-unsafe-builtin-methods.spec.ts
@@ -1,12 +1,12 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { createTempWorkspaceManager, createTypeScriptRuleTester } from '../testing'
 import rule from './no-unsafe-builtin-methods'
 
 type TestOptions = readonly []
 type MessageIds = 'unsafeBuiltinMethod' | 'unsafePrototypeCall' | 'unsafeConstructor' | 'unsafeGlobalFunction'
+
+const manager = createTempWorkspaceManager()
 
 /**
  * Creates a temporary project structure for testing.
@@ -14,19 +14,11 @@ type MessageIds = 'unsafeBuiltinMethod' | 'unsafePrototypeCall' | 'unsafeConstru
  * @returns The path to the temporary project directory.
  */
 function createTempProject(): string {
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-builtin-test-'))
-  return testDir
+  const workspace = manager.create({})
+  return workspace.root
 }
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
-
-const tempDirs: string[] = []
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Valid test cases
@@ -34,8 +26,6 @@ const tempDirs: string[] = []
 
 function createBuiltInCopyCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'built-in-copy'), { recursive: true })
   return {
     code: 'const obj = Object.freeze({ a: 1 });',
     filename: join(projectDir, 'src', 'built-in-copy', 'object.ts'),
@@ -44,8 +34,6 @@ function createBuiltInCopyCase(): ValidTestCase<TestOptions> {
 
 function createTestFileCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const obj = Object.freeze({ a: 1 });',
     filename: join(projectDir, 'src', 'index.spec.ts'),
@@ -54,8 +42,6 @@ function createTestFileCase(): ValidTestCase<TestOptions> {
 
 function createTestFileDotTestCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const obj = Object.freeze({ a: 1 });',
     filename: join(projectDir, 'src', 'index.test.ts'),
@@ -64,8 +50,6 @@ function createTestFileDotTestCase(): ValidTestCase<TestOptions> {
 
 function createSafeImportCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: `import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object';
 const obj = freeze({ a: 1 });`,
@@ -75,8 +59,6 @@ const obj = freeze({ a: 1 });`,
 
 function createSafeGlobalFunctionImportCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: `import { setTimeout } from '@hyperfrontend/immutable-api-utils/built-in-copy/timers';
 setTimeout(() => {}, 100);`,
@@ -86,8 +68,6 @@ setTimeout(() => {}, 100);`,
 
 function createNonIdentifierObjectCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = myObj.freeze({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -96,8 +76,6 @@ function createNonIdentifierObjectCase(): ValidTestCase<TestOptions> {
 
 function createComputedPropertyCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = Object["freeze"]({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -106,8 +84,6 @@ function createComputedPropertyCase(): ValidTestCase<TestOptions> {
 
 function createNonCallExpressionCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const fn = someFunction;',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -116,8 +92,6 @@ function createNonCallExpressionCase(): ValidTestCase<TestOptions> {
 
 function createCallWithoutCallPropertyCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = obj.someMethod.apply(context, args);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -126,8 +100,6 @@ function createCallWithoutCallPropertyCase(): ValidTestCase<TestOptions> {
 
 function createNonPrototypeCallCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = myObj.property.method.call(context);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -136,8 +108,6 @@ function createNonPrototypeCallCase(): ValidTestCase<TestOptions> {
 
 function createUntrackedPrototypeCallCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = Object.prototype.valueOf.call(obj);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -146,8 +116,6 @@ function createUntrackedPrototypeCallCase(): ValidTestCase<TestOptions> {
 
 function createNewNonPromiseCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const obj = new MyClass();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -156,8 +124,6 @@ function createNewNonPromiseCase(): ValidTestCase<TestOptions> {
 
 function createUnsafeMethodNotInListCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = Object.is(a, b);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -170,8 +136,6 @@ function createUnsafeMethodNotInListCase(): ValidTestCase<TestOptions> {
 
 function createObjectFreezeCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const obj = Object.freeze({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -181,8 +145,6 @@ function createObjectFreezeCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createObjectEntriesCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const entries = Object.entries({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -192,8 +154,6 @@ function createObjectEntriesCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createObjectKeysCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const keys = Object.keys({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -203,8 +163,6 @@ function createObjectKeysCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createObjectSetPrototypeOfCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'Object.setPrototypeOf(obj, proto);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -214,8 +172,6 @@ function createObjectSetPrototypeOfCase(): InvalidTestCase<MessageIds, TestOptio
 
 function createArrayIsArrayCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const isArr = Array.isArray(value);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -225,8 +181,6 @@ function createArrayIsArrayCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createArrayFromCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const arr = Array.from(iterable);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -236,8 +190,6 @@ function createArrayFromCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createJSONParseCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const obj = JSON.parse(str);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -247,8 +199,6 @@ function createJSONParseCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewPromiseCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const p = new Promise((resolve) => resolve(1));',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -258,8 +208,6 @@ function createNewPromiseCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createPrototypeHasOwnPropertyCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const has = Object.prototype.hasOwnProperty.call(obj, "key");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -269,8 +217,6 @@ function createPrototypeHasOwnPropertyCase(): InvalidTestCase<MessageIds, TestOp
 
 function createPrototypeToStringCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const type = Object.prototype.toString.call(value);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -280,8 +226,6 @@ function createPrototypeToStringCase(): InvalidTestCase<MessageIds, TestOptions>
 
 function createObjectValuesCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const values = Object.values({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -291,8 +235,6 @@ function createObjectValuesCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createJSONStringifyCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const str = JSON.stringify({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -302,8 +244,6 @@ function createJSONStringifyCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createArrayOfCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const arr = Array.of(1, 2, 3);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -313,8 +253,6 @@ function createArrayOfCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createMultipleViolationsCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: `const obj = Object.freeze({ a: 1 });
 const keys = Object.keys(obj);
@@ -326,8 +264,6 @@ const arr = Array.from(keys);`,
 
 function createConsoleLogCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'console.log("unsafe");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -337,8 +273,6 @@ function createConsoleLogCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createSetTimeoutCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'setTimeout(() => {}, 100);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -348,8 +282,6 @@ function createSetTimeoutCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createStructuredCloneCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const copy = structuredClone({ a: 1 });',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -359,8 +291,6 @@ function createStructuredCloneCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewMessageChannelCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const channel = new MessageChannel();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -370,8 +300,6 @@ function createNewMessageChannelCase(): InvalidTestCase<MessageIds, TestOptions>
 
 function createNewBroadcastChannelCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const broadcast = new BroadcastChannel("test");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -381,8 +309,6 @@ function createNewBroadcastChannelCase(): InvalidTestCase<MessageIds, TestOption
 
 function createNewMapCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const map = new Map();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -392,8 +318,6 @@ function createNewMapCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewSetCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const set = new Set();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -403,8 +327,6 @@ function createNewSetCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewWeakMapCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const weakMap = new WeakMap();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -414,8 +336,6 @@ function createNewWeakMapCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewWeakSetCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const weakSet = new WeakSet();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -425,8 +345,6 @@ function createNewWeakSetCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewRegExpCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const regex = new RegExp("test");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -436,8 +354,6 @@ function createNewRegExpCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewDateCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const date = new Date();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -447,8 +363,6 @@ function createNewDateCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewErrorCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const err = new Error("message");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -458,8 +372,6 @@ function createNewErrorCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewTypeErrorCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const err = new TypeError("message");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -469,8 +381,6 @@ function createNewTypeErrorCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createNewFunctionCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const fn = new Function("return 1");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -480,8 +390,6 @@ function createNewFunctionCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createPromiseAllCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = Promise.all([]);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -491,8 +399,6 @@ function createPromiseAllCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createPromiseResolveCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const result = Promise.resolve(1);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -502,8 +408,6 @@ function createPromiseResolveCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createDateNowCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const now = Date.now();',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -513,8 +417,6 @@ function createDateNowCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createReflectGetCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const val = Reflect.get(obj, "key");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -524,8 +426,6 @@ function createReflectGetCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createSymbolForCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const sym = Symbol.for("key");',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -535,8 +435,6 @@ function createSymbolForCase(): InvalidTestCase<MessageIds, TestOptions> {
 
 function createMapGroupByCase(): InvalidTestCase<MessageIds, TestOptions> {
   const projectDir = createTempProject()
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'const grouped = Map.groupBy([], (x) => x);',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -751,14 +649,7 @@ describe('no-unsafe-builtin-methods', () => {
     })
   })
 
-  // Cleanup temporary directories
   afterAll(() => {
-    for (const dir of tempDirs) {
-      try {
-        rmSync(dir, { recursive: true, force: true })
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+    manager.cleanupAll()
   })
 })

--- a/tools/eslint-rules/src/rules/no-unsafe-builtin-methods.ts
+++ b/tools/eslint-rules/src/rules/no-unsafe-builtin-methods.ts
@@ -1,5 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils'
 import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { fromEntries } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the no-unsafe-builtin-methods rule.
@@ -41,7 +43,7 @@ type SafeImport = { import: string; from: string }
  * Maps unsafe method access to safe imports
  */
 const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
-  Object: Object.fromEntries(
+  Object: fromEntries(
     [
       'freeze',
       'create',
@@ -65,29 +67,29 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       'getOwnPropertyDescriptors',
     ].map((m) => [m, { import: m, from: OBJECT }])
   ),
-  Array: Object.fromEntries(['isArray', 'from', 'of'].map((m) => [m, { import: m, from: ARRAY }])),
-  JSON: Object.fromEntries(['parse', 'stringify'].map((m) => [m, { import: m, from: JSON_COPY }])),
-  Promise: Object.fromEntries(
+  Array: fromEntries(['isArray', 'from', 'of'].map((m) => [m, { import: m, from: ARRAY }])),
+  JSON: fromEntries(['parse', 'stringify'].map((m) => [m, { import: m, from: JSON_COPY }])),
+  Promise: fromEntries(
     ['resolve', 'reject', 'all', 'race', 'allSettled', 'any', 'withResolvers'].map((m) => [
       m,
       { import: m === 'withResolvers' ? 'promiseWithResolvers' : `promise${m.charAt(0).toUpperCase()}${m.slice(1)}`, from: PROMISE },
     ])
   ),
-  Date: Object.fromEntries(
+  Date: fromEntries(
     [
       ['now', 'dateNow'],
       ['parse', 'dateParse'],
       ['UTC', 'dateUTC'],
     ].map(([m, i]) => [m, { import: i, from: DATE }])
   ),
-  Map: Object.fromEntries([['groupBy', { import: 'mapGroupBy', from: MAP }]]),
-  Symbol: Object.fromEntries(
+  Map: fromEntries([['groupBy', { import: 'mapGroupBy', from: MAP }]]),
+  Symbol: fromEntries(
     [
       ['for', 'symbolFor'],
       ['keyFor', 'symbolKeyFor'],
     ].map(([m, i]) => [m, { import: i, from: SYMBOL }])
   ),
-  Reflect: Object.fromEntries(
+  Reflect: fromEntries(
     [
       'apply',
       'construct',
@@ -104,7 +106,7 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       'preventExtensions',
     ].map((m) => [m, { import: m, from: REFLECT }])
   ),
-  console: Object.fromEntries(
+  console: fromEntries(
     [
       'log',
       'warn',
@@ -126,7 +128,7 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       'timeLog',
     ].map((m) => [m, { import: m, from: CONSOLE }])
   ),
-  Math: Object.fromEntries(
+  Math: fromEntries(
     [
       'abs',
       'sign',
@@ -165,7 +167,7 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       'imul',
     ].map((m) => [m, { import: m, from: MATH }])
   ),
-  Number: Object.fromEntries(
+  Number: fromEntries(
     [
       ['isNaN', 'isNaN'],
       ['isFinite', 'isFinite'],
@@ -175,14 +177,14 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       ['parseInt', 'parseInt'],
     ].map(([m, i]) => [m, { import: i, from: NUMBER_COPY }])
   ),
-  String: Object.fromEntries(
+  String: fromEntries(
     [
       ['fromCharCode', 'fromCharCode'],
       ['fromCodePoint', 'fromCodePoint'],
       ['raw', 'raw'],
     ].map(([m, i]) => [m, { import: i, from: STRING_COPY }])
   ),
-  URL: Object.fromEntries(
+  URL: fromEntries(
     [
       ['canParse', 'canParse'],
       ['createObjectURL', 'createObjectURL'],
@@ -190,8 +192,8 @@ const UNSAFE_METHODS: Record<string, Record<string, SafeImport>> = {
       ['parse', 'parseURL'],
     ].map(([m, i]) => [m, { import: i, from: URL_COPY }])
   ),
-  ArrayBuffer: Object.fromEntries([['isView', { import: 'isView', from: TYPED_ARRAYS }]]),
-  Uint8Array: Object.fromEntries(
+  ArrayBuffer: fromEntries([['isView', { import: 'isView', from: TYPED_ARRAYS }]]),
+  Uint8Array: fromEntries(
     [
       ['from', 'uint8ArrayFrom'],
       ['of', 'uint8ArrayOf'],
@@ -313,7 +315,7 @@ export default createRule<[], MessageIds>({
     }
 
     // Track identifiers imported from safe modules
-    const safeImports = new Set<string>()
+    const safeImports = createSet<string>()
 
     return {
       // Track imports from @hyperfrontend/immutable-api-utils

--- a/tools/eslint-rules/src/rules/no-unsafe-regex.ts
+++ b/tools/eslint-rules/src/rules/no-unsafe-regex.ts
@@ -1,6 +1,8 @@
 import type { TSESTree } from '@typescript-eslint/utils'
 import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils'
 import safeRegex from 'safe-regex2'
+import { parseInt } from '@hyperfrontend/immutable-api-utils/built-in-copy/number'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the no-unsafe-regex rule.
@@ -242,7 +244,7 @@ export default createRule<[NoUnsafeRegexOptions], MessageIds>({
     } = options
 
     // Build set of factory function names for fast lookup
-    const factoryFunctions = new Set(['RegExp', ...regexpFactoryFunctions])
+    const factoryFunctions = createSet(['RegExp', ...regexpFactoryFunctions])
 
     /**
      * Checks if a pattern should be ignored based on ignorePatterns config.

--- a/tools/eslint-rules/src/rules/no-unwanted-barrel-files.spec.ts
+++ b/tools/eslint-rules/src/rules/no-unwanted-barrel-files.spec.ts
@@ -1,12 +1,12 @@
 import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { join } from 'node:path'
+import { createTempWorkspaceManager, createTypeScriptRuleTester } from '../testing'
 import rule from './no-unwanted-barrel-files'
 
 type TestOptions = readonly []
 type MessageIds = 'unwantedBarrelFile'
+
+const manager = createTempWorkspaceManager()
 
 /**
  * Creates a temporary project structure for testing.
@@ -15,40 +15,42 @@ type MessageIds = 'unwantedBarrelFile'
  * @param config.projectJson - Optional project.json content.
  * @param config.packageJson - Optional package.json content.
  * @param config.indexFiles - Optional list of index files to create.
+ * @param config.invalidPackageJson - Optional flag to create invalid package.json.
+ * @param config.invalidProjectJson - Optional flag to create invalid project.json.
  * @returns The path to the temporary project directory.
  */
-function createTempProject(config: { projectJson?: object; packageJson?: object; indexFiles?: string[] }): string {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
+function createTempProject(config: {
+  projectJson?: object
+  packageJson?: object
+  indexFiles?: string[]
+  invalidPackageJson?: boolean
+  invalidProjectJson?: boolean
+}): string {
+  const files: Record<string, string> = {}
 
-  if (config.projectJson) {
-    writeFileSync(join(testDir, 'project.json'), JSON.stringify(config.projectJson, null, 2), { mode: 0o600 })
+  if (config.invalidProjectJson) {
+    files['project.json'] = 'invalid json {{{'
+  } else if (config.projectJson) {
+    files['project.json'] = JSON.stringify(config.projectJson, null, 2)
   }
 
-  if (config.packageJson) {
-    writeFileSync(join(testDir, 'package.json'), JSON.stringify(config.packageJson, null, 2), { mode: 0o600 })
+  if (config.invalidPackageJson) {
+    files['package.json'] = 'invalid json {{{'
+  } else if (config.packageJson) {
+    files['package.json'] = JSON.stringify(config.packageJson, null, 2)
   }
 
   if (config.indexFiles) {
     for (const indexFile of config.indexFiles) {
-      const fullPath = join(testDir, indexFile)
-      mkdirSync(dirname(fullPath), { recursive: true })
-      writeFileSync(fullPath, 'export {};\n', { mode: 0o600 })
+      files[indexFile] = 'export {};\n'
     }
   }
 
-  return testDir
+  const workspace = manager.create({ files })
+  return workspace.root
 }
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: false,
-    },
-  },
-})
-
-const tempDirs: string[] = []
+const ruleTester = createTypeScriptRuleTester()
 
 /**
  * Creates a valid test case for non-index.ts files.
@@ -75,8 +77,6 @@ function createMainEntryPointCase(): ValidTestCase<TestOptions> {
     },
     packageJson: { name: 'test-lib' },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export * from "./lib";',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -101,8 +101,6 @@ function createDeclaredExportCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'browser'), { recursive: true })
   return {
     code: 'export * from "./implementation";',
     filename: join(projectDir, 'src', 'browser', 'index.ts'),
@@ -122,8 +120,6 @@ function createNonLibraryCase(): ValidTestCase<TestOptions> {
     },
     packageJson: { name: 'test-app' },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'internal'), { recursive: true })
   return {
     code: 'export {}',
     filename: join(projectDir, 'src', 'internal', 'index.ts'),
@@ -143,8 +139,6 @@ function createNonPublishableCase(): ValidTestCase<TestOptions> {
     },
     packageJson: { name: 'internal-lib' },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'internal'), { recursive: true })
   return {
     code: 'export {}',
     filename: join(projectDir, 'src', 'internal', 'index.ts'),
@@ -160,8 +154,6 @@ function createNoProjectJsonCase(): ValidTestCase<TestOptions> {
   const projectDir = createTempProject({
     packageJson: { name: 'test-lib' },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export {}',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -181,8 +173,6 @@ function createUndeclaredBarrelNoExportsCase(): InvalidTestCase<MessageIds, Test
     },
     packageJson: { name: 'test-lib' },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'lib', 'creators'), { recursive: true })
   return {
     code: 'export * from "./creator";',
     filename: join(projectDir, 'src', 'lib', 'creators', 'index.ts'),
@@ -209,8 +199,6 @@ function createUndeclaredBarrelWithExportsCase(): InvalidTestCase<MessageIds, Te
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'lib', 'utils'), { recursive: true })
   return {
     code: 'export * from "./internal-helper";',
     filename: join(projectDir, 'src', 'lib', 'utils', 'index.ts'),
@@ -239,8 +227,6 @@ function createObjectStyleExportsCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'browser'), { recursive: true })
   return {
     code: 'export * from "./implementation";',
     filename: join(projectDir, 'src', 'browser', 'index.ts'),
@@ -258,10 +244,8 @@ function createInvalidPackageJsonCase(): ValidTestCase<TestOptions> {
       projectType: 'library',
       targets: { build: {}, publish: {} },
     },
+    invalidPackageJson: true,
   })
-  tempDirs.push(projectDir)
-  writeFileSync(join(projectDir, 'package.json'), 'invalid json {{{', { mode: 0o600 })
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export {}',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -274,14 +258,12 @@ function createInvalidPackageJsonCase(): ValidTestCase<TestOptions> {
  * @returns A valid test case configuration.
  */
 function createInvalidProjectJsonCase(): ValidTestCase<TestOptions> {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-  writeFileSync(join(testDir, 'project.json'), 'invalid json {{{', { mode: 0o600 })
-  mkdirSync(join(testDir, 'src'), { recursive: true })
+  const projectDir = createTempProject({
+    invalidProjectJson: true,
+  })
   return {
     code: 'export {}',
-    filename: join(testDir, 'src', 'index.ts'),
+    filename: join(projectDir, 'src', 'index.ts'),
   }
 }
 
@@ -305,8 +287,6 @@ function createUnresolvableExportCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export * from "./lib";',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -319,31 +299,21 @@ function createUnresolvableExportCase(): ValidTestCase<TestOptions> {
  * @returns A valid test case configuration.
  */
 function createNullExportValueCase(): ValidTestCase<TestOptions> {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const testDir = mkdtempSync(join(tmpdir(), 'eslint-test-'))
-  tempDirs.push(testDir)
-  writeFileSync(
-    join(testDir, 'project.json'),
-    JSON.stringify({
+  const projectDir = createTempProject({
+    projectJson: {
       projectType: 'library',
       targets: { build: {}, publish: {} },
-    }),
-    { mode: 0o600 }
-  )
-  writeFileSync(
-    join(testDir, 'package.json'),
-    JSON.stringify({
+    },
+    packageJson: {
       name: 'test-lib',
       exports: {
         './special': null,
       },
-    }),
-    { mode: 0o600 }
-  )
-  mkdirSync(join(testDir, 'src'), { recursive: true })
+    },
+  })
   return {
     code: 'export * from "./lib";',
-    filename: join(testDir, 'src', 'index.ts'),
+    filename: join(projectDir, 'src', 'index.ts'),
   }
 }
 
@@ -363,8 +333,6 @@ function createEmptyExportsCase(): ValidTestCase<TestOptions> {
       exports: {},
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export * from "./lib";',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -391,8 +359,6 @@ function createRequireStyleExportsCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'node'), { recursive: true })
   return {
     code: 'export * from "./implementation";',
     filename: join(projectDir, 'src', 'node', 'index.ts'),
@@ -419,8 +385,6 @@ function createDefaultStyleExportsCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'default'), { recursive: true })
   return {
     code: 'export * from "./implementation";',
     filename: join(projectDir, 'src', 'default', 'index.ts'),
@@ -445,8 +409,6 @@ function createNonJsExportPathCase(): ValidTestCase<TestOptions> {
       },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src', 'special'), { recursive: true })
   return {
     code: 'export * from "./implementation";',
     filename: join(projectDir, 'src', 'special', 'index.ts'),
@@ -465,8 +427,6 @@ function createNoPackageJsonCase(): ValidTestCase<TestOptions> {
       targets: { build: {}, publish: {} },
     },
   })
-  tempDirs.push(projectDir)
-  mkdirSync(join(projectDir, 'src'), { recursive: true })
   return {
     code: 'export {}',
     filename: join(projectDir, 'src', 'index.ts'),
@@ -475,9 +435,7 @@ function createNoPackageJsonCase(): ValidTestCase<TestOptions> {
 
 describe('no-unwanted-barrel-files', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   ruleTester.run('no-unwanted-barrel-files', rule, {

--- a/tools/eslint-rules/src/rules/no-unwanted-barrel-files.ts
+++ b/tools/eslint-rules/src/rules/no-unwanted-barrel-files.ts
@@ -2,6 +2,7 @@ import type { TSESTree } from '@typescript-eslint/utils'
 import type { PackageJson } from '../utils/nx-project'
 import { dirname, join, relative, resolve } from 'node:path'
 import { ESLintUtils } from '@typescript-eslint/utils'
+import { entries, keys, values } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { readJsonFileIfExists } from '../utils/fs'
 import { isPublishableLibrary } from '../utils/nx-project'
 import { findProjectRoot } from '../utils/workspace'
@@ -42,7 +43,7 @@ function getAllowedIndexPaths(projectRoot: string, packageJson: PackageJson): st
   allowed.push(join(projectRoot, 'src', 'index.ts'))
 
   if (packageJson.exports) {
-    for (const exportValue of Object.values(packageJson.exports)) {
+    for (const exportValue of values(packageJson.exports)) {
       const resolvedPath = resolveExportValue(exportValue)
       if (resolvedPath) {
         const sourcePath = resolvedPath.replace(/^\.\//, '').replace(/\.(js|cjs|mjs)$/, '.ts')
@@ -61,8 +62,8 @@ function getAllowedIndexPaths(projectRoot: string, packageJson: PackageJson): st
  * @returns The formatted error details string.
  */
 function buildErrorDetails(packageJson: PackageJson): string {
-  if (packageJson.exports && Object.keys(packageJson.exports).length > 0) {
-    const exportsList = Object.entries(packageJson.exports)
+  if (packageJson.exports && keys(packageJson.exports).length > 0) {
+    const exportsList = entries(packageJson.exports)
       .map(([key, value]) => {
         const resolvedPath = resolveExportValue(value)
         const displayPath = resolvedPath ? resolvedPath.replace(/\.js$/, '.ts') : String(value)

--- a/tools/eslint-rules/src/rules/no-unwanted-barrel-files.ts
+++ b/tools/eslint-rules/src/rules/no-unwanted-barrel-files.ts
@@ -2,7 +2,9 @@ import type { TSESTree } from '@typescript-eslint/utils'
 import type { PackageJson } from '../utils/nx-project'
 import { dirname, join, relative, resolve } from 'node:path'
 import { ESLintUtils } from '@typescript-eslint/utils'
-import { findProjectRoot, isPublishableLibrary, parseJsonFile } from '../utils/nx-project'
+import { readJsonFileIfExists } from '../utils/fs'
+import { isPublishableLibrary } from '../utils/nx-project'
+import { findProjectRoot } from '../utils/workspace'
 
 /**
  * Rule identifier for the no-unwanted-barrel-files rule.
@@ -110,7 +112,7 @@ const rule = ESLintUtils.RuleCreator(
     }
 
     const packageJsonPath = join(projectRoot, 'package.json')
-    const packageJson = parseJsonFile<PackageJson>(packageJsonPath)
+    const packageJson = readJsonFileIfExists<PackageJson>(packageJsonPath)
 
     if (!packageJson) {
       return {}

--- a/tools/eslint-rules/src/rules/prefer-exec-file-sync.ts
+++ b/tools/eslint-rules/src/rules/prefer-exec-file-sync.ts
@@ -1,4 +1,5 @@
 import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Rule identifier for the prefer-exec-file-sync rule.
@@ -44,10 +45,10 @@ export default createRule<[], MessageIds>({
   defaultOptions: [],
   create(context) {
     // Track namespace imports for child_process module
-    const childProcessNamespaceBindings = new Set<string>()
+    const childProcessNamespaceBindings = createSet<string>()
 
     // Track local names of execSync imports (in case of aliased imports)
-    const execSyncLocalBindings = new Set<string>()
+    const execSyncLocalBindings = createSet<string>()
 
     return {
       // Check import declarations

--- a/tools/eslint-rules/src/rules/root-readme-packages.spec.ts
+++ b/tools/eslint-rules/src/rules/root-readme-packages.spec.ts
@@ -1,9 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import rule, { extractMentionedPaths, findWorkspaceRoot, parseReadmeSections, RULE_NAME } from './root-readme-packages'
+import { createTempWorkspaceManager } from '../testing'
+import rule, { extractMentionedPaths, parseReadmeSections, RULE_NAME } from './root-readme-packages'
 
-const tempDirs: string[] = []
+const manager = createTempWorkspaceManager()
 
 /**
  * Valid publishable library project.json for testing.
@@ -37,44 +36,32 @@ function createTempWorkspace(config: {
   libs?: Array<{ name: string; projectJson: object; packageJson?: object }>
   plugins?: Array<{ name: string; projectJson: object; packageJson?: object }>
 }): string {
-  // mkdtempSync creates a unique directory atomically, avoiding TOCTOU race conditions
-  const workspaceDir = mkdtempSync(join(tmpdir(), 'eslint-root-readme-test-'))
-  tempDirs.push(workspaceDir)
+  const files: Record<string, string> = {
+    'nx.json': JSON.stringify({ version: 2 }, null, 2),
+  }
 
-  // Create nx.json to mark as workspace root
-  writeFileSync(join(workspaceDir, 'nx.json'), JSON.stringify({ version: 2 }, null, 2), { mode: 0o600 })
-
-  // Create libs directory and libraries
+  // Create libraries
   if (config.libs && config.libs.length > 0) {
-    const libsDir = join(workspaceDir, 'libs')
-    mkdirSync(libsDir, { recursive: true, mode: 0o700 })
-
     for (const lib of config.libs) {
-      const libDir = join(libsDir, lib.name)
-      mkdirSync(libDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(libDir, 'project.json'), JSON.stringify(lib.projectJson, null, 2), { mode: 0o600 })
+      files[`libs/${lib.name}/project.json`] = JSON.stringify(lib.projectJson, null, 2)
       if (lib.packageJson) {
-        writeFileSync(join(libDir, 'package.json'), JSON.stringify(lib.packageJson, null, 2), { mode: 0o600 })
+        files[`libs/${lib.name}/package.json`] = JSON.stringify(lib.packageJson, null, 2)
       }
     }
   }
 
-  // Create plugins directory and plugins
+  // Create plugins
   if (config.plugins && config.plugins.length > 0) {
-    const pluginsDir = join(workspaceDir, 'plugins')
-    mkdirSync(pluginsDir, { recursive: true, mode: 0o700 })
-
     for (const plugin of config.plugins) {
-      const pluginDir = join(pluginsDir, plugin.name)
-      mkdirSync(pluginDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(pluginDir, 'project.json'), JSON.stringify(plugin.projectJson, null, 2), { mode: 0o600 })
+      files[`plugins/${plugin.name}/project.json`] = JSON.stringify(plugin.projectJson, null, 2)
       if (plugin.packageJson) {
-        writeFileSync(join(pluginDir, 'package.json'), JSON.stringify(plugin.packageJson, null, 2), { mode: 0o600 })
+        files[`plugins/${plugin.name}/package.json`] = JSON.stringify(plugin.packageJson, null, 2)
       }
     }
   }
 
-  return workspaceDir
+  const workspace = manager.create({ files })
+  return workspace.root
 }
 
 /**
@@ -112,9 +99,7 @@ ${internalRows}
 
 describe('root-readme-packages', () => {
   afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+    manager.cleanupAll()
   })
 
   describe('rule metadata', () => {
@@ -203,25 +188,6 @@ describe('root-readme-packages', () => {
     })
   })
 
-  describe('findWorkspaceRoot', () => {
-    it('finds workspace root when nx.json exists', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      const nestedDir = join(workspaceDir, 'libs', 'nested')
-      mkdirSync(nestedDir, { recursive: true, mode: 0o700 })
-
-      const result = findWorkspaceRoot(nestedDir)
-      expect(result).toBe(workspaceDir)
-    })
-
-    it('returns null when no nx.json found', () => {
-      const tempDir = mkdtempSync(join(tmpdir(), 'no-nx-json-'))
-      tempDirs.push(tempDir)
-
-      const result = findWorkspaceRoot(tempDir)
-      expect(result).toBeNull()
-    })
-  })
-
   describe('parseReadmeSections', () => {
     it('parses level 2 sections correctly', () => {
       const content = `# Title
@@ -293,12 +259,15 @@ Content.
     })
 
     it('ignores README.md not at workspace root', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      const nestedDir = join(workspaceDir, 'libs', 'some-lib')
-      mkdirSync(nestedDir, { recursive: true, mode: 0o700 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+        },
+        directories: ['libs/some-lib'],
+      })
 
       const handler = rule.create({
-        filename: join(nestedDir, 'README.md'),
+        filename: join(workspace.root, 'libs', 'some-lib', 'README.md'),
         sourceCode: { getText: () => '# Some content' },
       } as never)
 
@@ -442,16 +411,17 @@ Content.
     })
 
     it('handles nested publishable libraries', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-      // Create nested lib structure manually
-      const nestedLibDir = join(workspaceDir, 'libs', 'utils', 'json')
-      mkdirSync(nestedLibDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(nestedLibDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2), { mode: 0o600 })
-      writeFileSync(join(nestedLibDir, 'package.json'), JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/utils/json/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2),
+          'libs/utils/json/package.json': JSON.stringify({ name: '@hyperfrontend/json-utils' }, null, 2),
+        },
+      })
 
       const reportMock = jest.fn()
       const context = {
-        filename: join(workspaceDir, 'README.md'),
+        filename: join(workspace.root, 'README.md'),
         sourceCode: {
           getText: () => createValidReadme([], []),
         },
@@ -536,21 +506,17 @@ Content.
     })
 
     it('skips hidden directories and node_modules', () => {
-      const workspaceDir = createTempWorkspace({ libs: [] })
-
-      // Create hidden directory with project.json
-      const hiddenDir = join(workspaceDir, 'libs', '.hidden')
-      mkdirSync(hiddenDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(hiddenDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2), { mode: 0o600 })
-
-      // Create node_modules with project.json
-      const nodeModulesDir = join(workspaceDir, 'libs', 'node_modules', 'some-pkg')
-      mkdirSync(nodeModulesDir, { recursive: true, mode: 0o700 })
-      writeFileSync(join(nodeModulesDir, 'project.json'), JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2), { mode: 0o600 })
+      const workspace = manager.create({
+        files: {
+          'nx.json': JSON.stringify({ version: 2 }, null, 2),
+          'libs/.hidden/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2),
+          'libs/node_modules/some-pkg/project.json': JSON.stringify(PUBLISHABLE_PROJECT_JSON, null, 2),
+        },
+      })
 
       const reportMock = jest.fn()
       const context = {
-        filename: join(workspaceDir, 'README.md'),
+        filename: join(workspace.root, 'README.md'),
         sourceCode: {
           getText: () => createValidReadme([], []),
         },

--- a/tools/eslint-rules/src/rules/root-readme-packages.ts
+++ b/tools/eslint-rules/src/rules/root-readme-packages.ts
@@ -1,6 +1,8 @@
 import type { Rule } from 'eslint'
 import type { ProjectJson } from '../utils/nx-project'
 import { basename, dirname, join } from 'node:path'
+import { createMap } from '@hyperfrontend/immutable-api-utils/built-in-copy/map'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { exists, findNxWorkspaceRoot, isDirectory, isPublishableLibraryDir, readDirectory, readJsonFileIfExists } from '../utils'
 
 /**
@@ -123,7 +125,7 @@ export function extractMentionedPaths(sectionContent: string): string[] {
  * @returns Map of section titles to their content and line numbers.
  */
 export function parseReadmeSections(content: string): Map<string, { content: string; startLine: number; endLine: number }> {
-  const sections = new Map<string, { content: string; startLine: number; endLine: number }>()
+  const sections = createMap<string, { content: string; startLine: number; endLine: number }>()
   const lines = content.split('\n')
   let currentSection: { title: string; startLine: number; lines: string[] } | null = null
 
@@ -228,7 +230,7 @@ const rule: Rule.RuleModule = {
         // Extract all mentioned paths from both sections
         const mainPaths = extractMentionedPaths(mainPackagesSection.content)
         const internalPaths = extractMentionedPaths(internalPackagesSection.content)
-        const allMentionedPaths = new Set([...mainPaths, ...internalPaths])
+        const allMentionedPaths = createSet([...mainPaths, ...internalPaths])
 
         // Find all publishable libraries in the workspace
         const publishableLibraries: PublishableLibrary[] = []

--- a/tools/eslint-rules/src/rules/root-readme-packages.ts
+++ b/tools/eslint-rules/src/rules/root-readme-packages.ts
@@ -1,8 +1,7 @@
 import type { Rule } from 'eslint'
 import type { ProjectJson } from '../utils/nx-project'
-import { existsSync, readdirSync, statSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
-import { parseJsonFile } from '../utils/nx-project'
+import { exists, findNxWorkspaceRoot, isDirectory, isPublishableLibraryDir, readDirectory, readJsonFileIfExists } from '../utils'
 
 /**
  * Rule identifier for the root-readme-packages rule.
@@ -27,37 +26,6 @@ export interface PublishableLibrary {
 }
 
 /**
- * Checks if a directory contains a publishable library project.
- *
- * @param projectDir - The absolute path to the project directory.
- * @returns True if the project is a publishable library, false otherwise.
- */
-function isPublishableLibraryDir(projectDir: string): boolean {
-  const projectJsonPath = join(projectDir, 'project.json')
-
-  if (!existsSync(projectJsonPath)) {
-    return false
-  }
-
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
-
-  if (!projectJson) {
-    return false
-  }
-
-  // Must be a library with build and publish targets
-  if (projectJson.projectType !== 'library') {
-    return false
-  }
-
-  if (!projectJson.targets?.build || !projectJson.targets?.publish) {
-    return false
-  }
-
-  return true
-}
-
-/**
  * Recursively finds all publishable libraries in a directory.
  *
  * @param baseDir - The absolute path to search.
@@ -65,7 +33,7 @@ function isPublishableLibraryDir(projectDir: string): boolean {
  * @param results - Array to accumulate results.
  */
 function findPublishableLibraries(baseDir: string, workspaceRoot: string, results: PublishableLibrary[]): void {
-  if (!existsSync(baseDir)) {
+  if (!exists(baseDir)) {
     return
   }
 
@@ -75,8 +43,8 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
     const projectJsonPath = join(baseDir, 'project.json')
     const packageJsonPath = join(baseDir, 'package.json')
 
-    const projectJson = parseJsonFile<ProjectJson & { name?: string }>(projectJsonPath)
-    const packageJson = parseJsonFile<{ name?: string }>(packageJsonPath)
+    const projectJson = readJsonFileIfExists<ProjectJson & { name?: string }>(projectJsonPath)
+    const packageJson = readJsonFileIfExists<{ name?: string }>(packageJsonPath)
 
     results.push({
       name: projectJson?.name ?? basename(baseDir),
@@ -88,7 +56,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
   // Recursively check subdirectories
   let entries: string[]
   try {
-    entries = readdirSync(baseDir)
+    entries = readDirectory(baseDir)
   } catch {
     return
   }
@@ -101,14 +69,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
 
     const entryPath = join(baseDir, entry)
 
-    let stats
-    try {
-      stats = statSync(entryPath)
-    } catch {
-      continue
-    }
-
-    if (stats.isDirectory()) {
+    if (isDirectory(entryPath)) {
       findPublishableLibraries(entryPath, workspaceRoot, results)
     }
   }
@@ -153,26 +114,6 @@ export function extractMentionedPaths(sectionContent: string): string[] {
   }
 
   return paths
-}
-
-/**
- * Finds the workspace root by looking for nx.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The workspace root path, or null if not found.
- */
-export function findWorkspaceRoot(startDir: string): string | null {
-  let dir = startDir
-  const root = '/'
-
-  while (dir !== root) {
-    if (existsSync(join(dir, 'nx.json'))) {
-      return dir
-    }
-    dir = dirname(dir)
-  }
-
-  return null
 }
 
 /**
@@ -246,7 +187,7 @@ const rule: Rule.RuleModule = {
     }
 
     const fileDir = dirname(filePath)
-    const workspaceRoot = findWorkspaceRoot(fileDir)
+    const workspaceRoot = findNxWorkspaceRoot(fileDir)
 
     // Only process root README.md (in workspace root)
     if (!workspaceRoot || fileDir !== workspaceRoot) {

--- a/tools/eslint-rules/src/testing/fixtures.spec.ts
+++ b/tools/eslint-rules/src/testing/fixtures.spec.ts
@@ -1,0 +1,65 @@
+import {
+  APPLICATION_PROJECT_JSON,
+  createNamedPackageJson,
+  createPackageJson,
+  createPublishableProjectJson,
+  MINIMAL_PACKAGE_JSON,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  PUBLISHABLE_PACKAGE_JSON,
+} from './fixtures'
+
+describe('Project.json fixtures', () => {
+  it('PUBLISHABLE_LIBRARY_PROJECT_JSON is a valid publishable library', () => {
+    expect(PUBLISHABLE_LIBRARY_PROJECT_JSON.projectType).toBe('library')
+    expect(PUBLISHABLE_LIBRARY_PROJECT_JSON.targets).toHaveProperty('build')
+    expect(PUBLISHABLE_LIBRARY_PROJECT_JSON.targets).toHaveProperty('publish')
+  })
+
+  it('NON_PUBLISHABLE_LIBRARY_PROJECT_JSON does not have publish target', () => {
+    expect(NON_PUBLISHABLE_LIBRARY_PROJECT_JSON.projectType).toBe('library')
+    expect(NON_PUBLISHABLE_LIBRARY_PROJECT_JSON.targets).toHaveProperty('build')
+    expect(NON_PUBLISHABLE_LIBRARY_PROJECT_JSON.targets).not.toHaveProperty('publish')
+  })
+
+  it('APPLICATION_PROJECT_JSON is an application', () => {
+    expect(APPLICATION_PROJECT_JSON.projectType).toBe('application')
+  })
+})
+
+describe('Package.json fixtures', () => {
+  it('PUBLISHABLE_PACKAGE_JSON has exports field', () => {
+    expect(PUBLISHABLE_PACKAGE_JSON.exports).toBeDefined()
+    expect(PUBLISHABLE_PACKAGE_JSON.name).toMatch(/^@hyperfrontend\//)
+  })
+
+  it('MINIMAL_PACKAGE_JSON has only name and version', () => {
+    expect(Object.keys(MINIMAL_PACKAGE_JSON)).toContain('name')
+    expect(Object.keys(MINIMAL_PACKAGE_JSON)).toContain('version')
+  })
+})
+
+describe('Factory functions', () => {
+  it('createPublishableProjectJson allows overrides', () => {
+    const result = createPublishableProjectJson({ tags: ['custom'] })
+
+    expect(result.projectType).toBe('library')
+    expect(result.tags).toEqual(['custom'])
+    expect(result.targets).toHaveProperty('build')
+    expect(result.targets).toHaveProperty('publish')
+  })
+
+  it('createPackageJson allows overrides', () => {
+    const result = createPackageJson({ name: '@custom/lib' })
+
+    expect(result.name).toBe('@custom/lib')
+    expect(result.exports).toBeDefined()
+  })
+
+  it('createNamedPackageJson sets name correctly', () => {
+    const result = createNamedPackageJson('@test/my-lib')
+
+    expect(result.name).toBe('@test/my-lib')
+    expect(result.version).toBeDefined()
+  })
+})

--- a/tools/eslint-rules/src/testing/fixtures.ts
+++ b/tools/eslint-rules/src/testing/fixtures.ts
@@ -1,0 +1,300 @@
+/**
+ * Nx project.json configuration types.
+ */
+export interface ProjectJsonFixture {
+  projectType?: 'library' | 'application'
+  targets?: Record<string, object>
+  tags?: string[]
+  [key: string]: unknown
+}
+
+/**
+ * npm package.json configuration.
+ */
+export interface PackageJsonFixture {
+  name?: string
+  version?: string
+  exports?: Record<string, unknown> | string
+  main?: string
+  module?: string
+  types?: string
+  files?: string[]
+  publishConfig?: object
+  [key: string]: unknown
+}
+
+// =============================================================================
+// Project.json Fixtures
+// =============================================================================
+
+/**
+ * Valid publishable library project.json.
+ * Has both `build` and `publish` targets.
+ */
+export const PUBLISHABLE_LIBRARY_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'library',
+  targets: {
+    build: { executor: '@nx/js:tsc' },
+    publish: { executor: '@nx/js:release-publish' },
+  },
+}
+
+/**
+ * Non-publishable library project.json.
+ * Has `build` but no `publish` target.
+ */
+export const NON_PUBLISHABLE_LIBRARY_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'library',
+  targets: {
+    build: { executor: '@nx/js:tsc' },
+  },
+}
+
+/**
+ * Application project.json.
+ * projectType is 'application', not 'library'.
+ */
+export const APPLICATION_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'application',
+  targets: {
+    build: { executor: '@nx/webpack:build' },
+    serve: { executor: '@nx/webpack:dev-server' },
+  },
+}
+
+/**
+ * Library without build target.
+ */
+export const LIBRARY_NO_BUILD_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'library',
+  targets: {},
+}
+
+/**
+ * Minimal valid project.json (just projectType).
+ */
+export const MINIMAL_LIBRARY_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'library',
+}
+
+/**
+ * E2E project project.json.
+ */
+export const E2E_PROJECT_JSON: ProjectJsonFixture = {
+  projectType: 'application',
+  targets: {
+    e2e: { executor: '@nx/playwright:playwright' },
+  },
+  tags: ['type:e2e'],
+}
+
+// =============================================================================
+// Package.json Fixtures
+// =============================================================================
+
+/**
+ * Valid publishable package.json with exports field.
+ */
+export const PUBLISHABLE_PACKAGE_JSON: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  exports: {
+    '.': {
+      import: './dist/index.js',
+      require: './dist/index.cjs',
+      types: './dist/index.d.ts',
+    },
+    './package.json': './package.json',
+  },
+  files: ['dist'],
+}
+
+/**
+ * Package.json with ./package.json export.
+ */
+export const PACKAGE_JSON_WITH_PACKAGE_EXPORT: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  exports: {
+    './package.json': './package.json',
+  },
+}
+
+/**
+ * Package.json missing ./package.json export.
+ */
+export const PACKAGE_JSON_WITHOUT_PACKAGE_EXPORT: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  exports: {
+    '.': './dist/index.js',
+  },
+}
+
+/**
+ * Minimal package.json (name and version only).
+ */
+export const MINIMAL_PACKAGE_JSON: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+}
+
+/**
+ * Package.json with CommonJS main field.
+ */
+export const CJS_PACKAGE_JSON: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  main: './dist/index.cjs',
+}
+
+/**
+ * Package.json with ESM module field.
+ */
+export const ESM_PACKAGE_JSON: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  module: './dist/index.js',
+  type: 'module',
+}
+
+/**
+ * Package.json with TypeScript extensions in exports (invalid).
+ */
+export const TS_EXPORTS_PACKAGE_JSON: PackageJsonFixture = {
+  name: '@hyperfrontend/test-lib',
+  version: '0.0.1',
+  exports: {
+    '.': './src/index.ts',
+  },
+}
+
+// =============================================================================
+// tsconfig.json Fixtures
+// =============================================================================
+
+/**
+ * Tsconfig with paths for library imports.
+ */
+export const TSCONFIG_WITH_PATHS = {
+  compilerOptions: {
+    baseUrl: '.',
+    paths: {
+      '@hyperfrontend/*': ['libs/*/src/index.ts'],
+    },
+  },
+}
+
+/**
+ * Minimal tsconfig.json.
+ */
+export const MINIMAL_TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2020',
+    module: 'ESNext',
+  },
+}
+
+// =============================================================================
+// README Fixtures
+// =============================================================================
+
+/**
+ * Valid library README with required sections.
+ */
+export const VALID_LIB_README = `# @hyperfrontend/test-lib
+
+A test library.
+
+## Installation
+
+\`\`\`bash
+npm install @hyperfrontend/test-lib
+\`\`\`
+
+## Usage
+
+\`\`\`typescript
+import { foo } from '@hyperfrontend/test-lib'
+\`\`\`
+
+## API Reference
+
+See [TypeDoc](https://hyperfrontend.dev/docs/test-lib).
+`
+
+/**
+ * README missing required sections.
+ */
+export const INVALID_LIB_README = `# @hyperfrontend/test-lib
+
+This README is missing required sections.
+`
+
+/**
+ * Empty README.
+ */
+export const EMPTY_README = ''
+
+// =============================================================================
+// Source File Fixtures
+// =============================================================================
+
+/**
+ * Valid TypeScript index file with exports.
+ */
+export const VALID_INDEX_TS = `export const foo = 'bar'
+export function helper(): void {}
+export type FooType = { foo: string }
+`
+
+/**
+ * Valid barrel export file.
+ */
+export const VALID_BARREL_EXPORT = `export * from './foo'
+export * from './bar'
+export * from './baz'
+`
+
+// =============================================================================
+// Fixture Factories
+// =============================================================================
+
+/**
+ * Creates a custom publishable library project.json.
+ *
+ * @param overrides - Properties to override
+ * @returns ProjectJsonFixture
+ */
+export function createPublishableProjectJson(overrides?: Partial<ProjectJsonFixture>): ProjectJsonFixture {
+  return {
+    ...PUBLISHABLE_LIBRARY_PROJECT_JSON,
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a custom package.json.
+ *
+ * @param overrides - Properties to override
+ * @returns PackageJsonFixture
+ */
+export function createPackageJson(overrides?: Partial<PackageJsonFixture>): PackageJsonFixture {
+  return {
+    ...PUBLISHABLE_PACKAGE_JSON,
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a package.json with a specific name.
+ *
+ * @param name - Package name to set in the fixture
+ * @returns PackageJsonFixture
+ */
+export function createNamedPackageJson(name: string): PackageJsonFixture {
+  return {
+    ...PUBLISHABLE_PACKAGE_JSON,
+    name,
+  }
+}

--- a/tools/eslint-rules/src/testing/index.ts
+++ b/tools/eslint-rules/src/testing/index.ts
@@ -1,0 +1,56 @@
+// Temp workspace utilities
+export {
+  createTempWorkspace,
+  createTempWorkspaceManager,
+  type TempWorkspace,
+  type TempWorkspaceConfig,
+  type TempWorkspaceManager,
+} from './temp-workspace'
+
+// Common fixtures
+export {
+  // Project.json fixtures
+  PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  NON_PUBLISHABLE_LIBRARY_PROJECT_JSON,
+  APPLICATION_PROJECT_JSON,
+  LIBRARY_NO_BUILD_PROJECT_JSON,
+  MINIMAL_LIBRARY_PROJECT_JSON,
+  E2E_PROJECT_JSON,
+  // Package.json fixtures
+  PUBLISHABLE_PACKAGE_JSON,
+  PACKAGE_JSON_WITH_PACKAGE_EXPORT,
+  PACKAGE_JSON_WITHOUT_PACKAGE_EXPORT,
+  MINIMAL_PACKAGE_JSON,
+  CJS_PACKAGE_JSON,
+  ESM_PACKAGE_JSON,
+  TS_EXPORTS_PACKAGE_JSON,
+  // tsconfig fixtures
+  TSCONFIG_WITH_PATHS,
+  MINIMAL_TSCONFIG,
+  // README fixtures
+  VALID_LIB_README,
+  INVALID_LIB_README,
+  EMPTY_README,
+  // Source file fixtures
+  VALID_INDEX_TS,
+  VALID_BARREL_EXPORT,
+  // Factory functions
+  createPublishableProjectJson,
+  createPackageJson,
+  createNamedPackageJson,
+  // Types
+  type ProjectJsonFixture,
+  type PackageJsonFixture,
+} from './fixtures'
+
+// RuleTester factories
+export {
+  createJsonRuleTester,
+  createTypeScriptRuleTester,
+  createPackageJsonRuleTester,
+  createProjectJsonRuleTester,
+  type JsonRuleTesterConfig,
+  type TypeScriptRuleTesterConfig,
+  type ESLintRuleTester,
+  TypeScriptRuleTester,
+} from './rule-tester'

--- a/tools/eslint-rules/src/testing/rule-tester.spec.ts
+++ b/tools/eslint-rules/src/testing/rule-tester.spec.ts
@@ -1,0 +1,46 @@
+import { RuleTester as TypeScriptRuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester } from 'eslint'
+import { createJsonRuleTester, createPackageJsonRuleTester, createProjectJsonRuleTester, createTypeScriptRuleTester } from './rule-tester'
+
+describe('createJsonRuleTester', () => {
+  it('creates a RuleTester instance', () => {
+    const tester = createJsonRuleTester()
+
+    expect(tester).toBeInstanceOf(RuleTester)
+  })
+
+  it('does not throw when created with default config', () => {
+    expect(() => createJsonRuleTester()).not.toThrow()
+  })
+})
+
+describe('createTypeScriptRuleTester', () => {
+  // TypeScriptRuleTester registers afterAll hooks in constructor,
+  // so we must instantiate outside test blocks
+  const tester = createTypeScriptRuleTester()
+  const testerWithOptions = createTypeScriptRuleTester({ projectService: false })
+
+  it('creates a TypeScriptRuleTester instance', () => {
+    expect(tester).toBeInstanceOf(TypeScriptRuleTester)
+  })
+
+  it('accepts projectService option', () => {
+    expect(testerWithOptions).toBeInstanceOf(TypeScriptRuleTester)
+  })
+})
+
+describe('createPackageJsonRuleTester', () => {
+  it('creates a RuleTester instance (alias for JSON tester)', () => {
+    const tester = createPackageJsonRuleTester()
+
+    expect(tester).toBeInstanceOf(RuleTester)
+  })
+})
+
+describe('createProjectJsonRuleTester', () => {
+  it('creates a RuleTester instance (alias for JSON tester)', () => {
+    const tester = createProjectJsonRuleTester()
+
+    expect(tester).toBeInstanceOf(RuleTester)
+  })
+})

--- a/tools/eslint-rules/src/testing/rule-tester.ts
+++ b/tools/eslint-rules/src/testing/rule-tester.ts
@@ -1,0 +1,125 @@
+import { RuleTester as TypeScriptRuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester } from 'eslint'
+
+/**
+ * Configuration for JSON rule tester.
+ */
+export interface JsonRuleTesterConfig {
+  /**
+   * Additional language options to merge.
+   */
+  languageOptions?: Record<string, unknown>
+}
+
+/**
+ * Configuration for TypeScript rule tester.
+ */
+export interface TypeScriptRuleTesterConfig {
+  /**
+   * Whether to use project service.
+   *
+   * @default false
+   */
+  projectService?: boolean
+
+  /**
+   * Path to tsconfig.json.
+   */
+  tsconfigRootDir?: string
+
+  /**
+   * Additional language options to merge.
+   */
+  languageOptions?: Record<string, unknown>
+}
+
+/**
+ * Creates a RuleTester configured for JSON/JSONC files.
+ * Uses jsonc-eslint-parser.
+ *
+ * @param config - Optional configuration overrides
+ * @returns A configured RuleTester instance
+ *
+ * @example
+ * ```typescript
+ * const ruleTester = createJsonRuleTester()
+ *
+ * ruleTester.run('my-json-rule', rule, {
+ *   valid: [...],
+ *   invalid: [...]
+ * })
+ * ```
+ */
+export function createJsonRuleTester(config?: JsonRuleTesterConfig): RuleTester {
+  // Note: Using require() here because jsonc-eslint-parser is a CommonJS module
+  // and we need to pass the actual parser object, not a string name
+  const jsoncParser = require('jsonc-eslint-parser')
+
+  return new RuleTester({
+    languageOptions: {
+      parser: jsoncParser,
+      ...config?.languageOptions,
+    },
+  })
+}
+
+/**
+ * Creates a RuleTester configured for TypeScript files.
+ * Uses `@typescript-eslint/parser`.
+ *
+ * @param config - Optional configuration overrides
+ * @returns A configured TypeScriptRuleTester instance
+ *
+ * @example
+ * ```typescript
+ * const ruleTester = createTypeScriptRuleTester()
+ *
+ * ruleTester.run('my-ts-rule', rule, {
+ *   valid: [...],
+ *   invalid: [...]
+ * })
+ * ```
+ */
+export function createTypeScriptRuleTester(config?: TypeScriptRuleTesterConfig): TypeScriptRuleTester {
+  return new TypeScriptRuleTester({
+    languageOptions: {
+      parserOptions: {
+        projectService: config?.projectService ?? false,
+        ...(config?.tsconfigRootDir && { tsconfigRootDir: config.tsconfigRootDir }),
+      },
+      ...config?.languageOptions,
+    },
+  })
+}
+
+/**
+ * Creates a RuleTester configured for package.json files specifically.
+ * Uses jsonc-eslint-parser with JSON-specific settings.
+ *
+ * Alias for createJsonRuleTester() for semantic clarity.
+ *
+ * @param config - Optional configuration overrides
+ * @returns A configured RuleTester instance
+ */
+export function createPackageJsonRuleTester(config?: JsonRuleTesterConfig): RuleTester {
+  return createJsonRuleTester(config)
+}
+
+/**
+ * Creates a RuleTester configured for project.json files specifically.
+ * Uses jsonc-eslint-parser with JSON-specific settings.
+ *
+ * Alias for createJsonRuleTester() for semantic clarity.
+ *
+ * @param config - Optional configuration overrides
+ * @returns A configured RuleTester instance
+ */
+export function createProjectJsonRuleTester(config?: JsonRuleTesterConfig): RuleTester {
+  return createJsonRuleTester(config)
+}
+
+/**
+ * Re-export RuleTester types for convenience.
+ */
+export type { RuleTester as ESLintRuleTester } from 'eslint'
+export { RuleTester as TypeScriptRuleTester } from '@typescript-eslint/rule-tester'

--- a/tools/eslint-rules/src/testing/temp-workspace.spec.ts
+++ b/tools/eslint-rules/src/testing/temp-workspace.spec.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { createTempWorkspace, createTempWorkspaceManager } from './temp-workspace'
+
+describe('createTempWorkspace', () => {
+  const workspaces: ReturnType<typeof createTempWorkspace>[] = []
+
+  afterAll(() => {
+    for (const ws of workspaces) {
+      ws.cleanup()
+    }
+  })
+
+  it('creates a temporary directory', () => {
+    const workspace = createTempWorkspace()
+    workspaces.push(workspace)
+
+    expect(existsSync(workspace.root)).toBe(true)
+    expect(statSync(workspace.root).isDirectory()).toBe(true)
+  })
+
+  it('creates src directory by default', () => {
+    const workspace = createTempWorkspace()
+    workspaces.push(workspace)
+
+    expect(existsSync(join(workspace.root, 'src'))).toBe(true)
+  })
+
+  it('writes project.json when provided', () => {
+    const projectJson = { projectType: 'library', targets: {} }
+    const workspace = createTempWorkspace({ projectJson })
+    workspaces.push(workspace)
+
+    const content = JSON.parse(readFileSync(join(workspace.root, 'project.json'), 'utf-8'))
+    expect(content).toEqual(projectJson)
+  })
+
+  it('writes package.json when provided', () => {
+    const packageJson = { name: '@test/lib', version: '1.0.0' }
+    const workspace = createTempWorkspace({ packageJson })
+    workspaces.push(workspace)
+
+    const content = JSON.parse(readFileSync(join(workspace.root, 'package.json'), 'utf-8'))
+    expect(content).toEqual(packageJson)
+  })
+
+  it('writes README.md when provided', () => {
+    const readme = '# Test Library\n\nDescription here.'
+    const workspace = createTempWorkspace({ readme })
+    workspaces.push(workspace)
+
+    const content = readFileSync(join(workspace.root, 'README.md'), 'utf-8')
+    expect(content).toBe(readme)
+  })
+
+  it('writes additional files with nested directories', () => {
+    const workspace = createTempWorkspace({
+      files: {
+        'src/index.ts': 'export const foo = 1',
+        'src/utils/helper.ts': 'export function helper() {}',
+      },
+    })
+    workspaces.push(workspace)
+
+    expect(readFileSync(join(workspace.root, 'src/index.ts'), 'utf-8')).toBe('export const foo = 1')
+    expect(readFileSync(join(workspace.root, 'src/utils/helper.ts'), 'utf-8')).toBe('export function helper() {}')
+  })
+
+  it('creates additional directories', () => {
+    const workspace = createTempWorkspace({
+      directories: ['dist', 'docs/api'],
+    })
+    workspaces.push(workspace)
+
+    expect(existsSync(join(workspace.root, 'dist'))).toBe(true)
+    expect(existsSync(join(workspace.root, 'docs/api'))).toBe(true)
+  })
+
+  it('returns correct paths via getPath()', () => {
+    const workspace = createTempWorkspace()
+    workspaces.push(workspace)
+
+    expect(workspace.getPath('package.json')).toBe(join(workspace.root, 'package.json'))
+    expect(workspace.getPath('src/index.ts')).toBe(join(workspace.root, 'src/index.ts'))
+  })
+
+  it('allows writing files after creation', () => {
+    const workspace = createTempWorkspace()
+    workspaces.push(workspace)
+
+    workspace.writeFile('extra.txt', 'content')
+    expect(readFileSync(join(workspace.root, 'extra.txt'), 'utf-8')).toBe('content')
+  })
+
+  it('allows writing JSON files after creation', () => {
+    const workspace = createTempWorkspace()
+    workspaces.push(workspace)
+
+    workspace.writeJsonFile('config.json', { key: 'value' })
+    const content = JSON.parse(readFileSync(join(workspace.root, 'config.json'), 'utf-8'))
+    expect(content).toEqual({ key: 'value' })
+  })
+
+  it('removes the workspace when cleanup() is called', () => {
+    const workspace = createTempWorkspace()
+    const rootPath = workspace.root
+
+    workspace.cleanup()
+
+    expect(existsSync(rootPath)).toBe(false)
+  })
+
+  it('handles multiple cleanup() calls safely', () => {
+    const workspace = createTempWorkspace()
+
+    expect(() => {
+      workspace.cleanup()
+      workspace.cleanup()
+      workspace.cleanup()
+    }).not.toThrow()
+  })
+
+  it('uses custom prefix when provided', () => {
+    const workspace = createTempWorkspace({ prefix: 'my-custom-test-' })
+    workspaces.push(workspace)
+
+    expect(workspace.root).toContain('my-custom-test-')
+  })
+})
+
+describe('createTempWorkspaceManager', () => {
+  it('creates workspaces and tracks them', () => {
+    const manager = createTempWorkspaceManager()
+
+    const ws1 = manager.create()
+    const ws2 = manager.create()
+
+    expect(manager.count).toBe(2)
+    expect(existsSync(ws1.root)).toBe(true)
+    expect(existsSync(ws2.root)).toBe(true)
+
+    manager.cleanupAll()
+  })
+
+  it('cleans up all tracked workspaces', () => {
+    const manager = createTempWorkspaceManager()
+
+    const ws1 = manager.create()
+    const ws2 = manager.create()
+    const root1 = ws1.root
+    const root2 = ws2.root
+
+    manager.cleanupAll()
+
+    expect(existsSync(root1)).toBe(false)
+    expect(existsSync(root2)).toBe(false)
+    expect(manager.count).toBe(0)
+  })
+
+  it('passes config through to created workspaces', () => {
+    const manager = createTempWorkspaceManager()
+
+    const workspace = manager.create({
+      projectJson: { projectType: 'library' },
+    })
+
+    const content = JSON.parse(readFileSync(join(workspace.root, 'project.json'), 'utf-8'))
+    expect(content.projectType).toBe('library')
+
+    manager.cleanupAll()
+  })
+})

--- a/tools/eslint-rules/src/testing/temp-workspace.ts
+++ b/tools/eslint-rules/src/testing/temp-workspace.ts
@@ -1,6 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { stringify } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+import { entries } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { createRuleLogger } from '../utils/logger'
 
 const logger = createRuleLogger('testing:temp-workspace')
@@ -181,7 +183,7 @@ export function createTempWorkspace(config: TempWorkspaceConfig = {}): TempWorks
   }
 
   const writeJsonFile = (relativePath: string, content: object): void => {
-    writeFile(relativePath, JSON.stringify(content, null, 2))
+    writeFile(relativePath, stringify(content, null, 2))
   }
 
   const createDirectory = (relativePath: string): void => {
@@ -218,7 +220,7 @@ export function createTempWorkspace(config: TempWorkspaceConfig = {}): TempWorks
 
   // Write additional files
   if (config.files) {
-    for (const [relativePath, content] of Object.entries(config.files)) {
+    for (const [relativePath, content] of entries(config.files)) {
       writeFile(relativePath, content)
     }
   }

--- a/tools/eslint-rules/src/testing/temp-workspace.ts
+++ b/tools/eslint-rules/src/testing/temp-workspace.ts
@@ -1,0 +1,299 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRuleLogger } from '../utils/logger'
+
+const logger = createRuleLogger('testing:temp-workspace')
+
+/**
+ * Configuration for creating a temporary workspace.
+ */
+export interface TempWorkspaceConfig {
+  /**
+   * Content for project.json (Nx project configuration).
+   * Will be serialized to JSON.
+   */
+  projectJson?: object
+
+  /**
+   * Content for package.json.
+   * Will be serialized to JSON.
+   */
+  packageJson?: object
+
+  /**
+   * Content for README.md.
+   */
+  readme?: string
+
+  /**
+   * Content for tsconfig.json.
+   * Will be serialized to JSON.
+   */
+  tsconfigJson?: object
+
+  /**
+   * Additional files to create.
+   * Keys are relative paths, values are file contents.
+   *
+   * @example
+   * ```typescript
+   * files: {
+   *   'src/index.ts': 'export const foo = 1',
+   *   'src/utils/helper.ts': 'export function helper() {}'
+   * }
+   * ```
+   */
+  files?: Record<string, string>
+
+  /**
+   * Additional directories to create (without files).
+   * Directories specified in `files` are created automatically.
+   */
+  directories?: string[]
+
+  /**
+   * Prefix for the temporary directory name.
+   *
+   * @default 'eslint-test-'
+   */
+  prefix?: string
+}
+
+/**
+ * Represents a temporary workspace for testing.
+ */
+export interface TempWorkspace {
+  /**
+   * Absolute path to the root of the temporary workspace.
+   */
+  readonly root: string
+
+  /**
+   * Returns the absolute path to a file within the workspace.
+   *
+   * @param relativePath - Path relative to workspace root
+   * @returns Absolute path
+   *
+   * @example
+   * ```typescript
+   * workspace.getPath('src/index.ts')
+   * // => '/tmp/eslint-test-abc123/src/index.ts'
+   * ```
+   */
+  getPath(relativePath: string): string
+
+  /**
+   * Writes a file to the workspace.
+   * Creates parent directories as needed.
+   *
+   * @param relativePath - Path relative to workspace root
+   * @param content - File content
+   */
+  writeFile(relativePath: string, content: string): void
+
+  /**
+   * Writes a JSON file to the workspace.
+   * Creates parent directories as needed.
+   *
+   * @param relativePath - Path relative to workspace root
+   * @param content - Object to serialize as JSON
+   */
+  writeJsonFile(relativePath: string, content: object): void
+
+  /**
+   * Creates a directory in the workspace.
+   * Creates parent directories as needed.
+   *
+   * @param relativePath - Path relative to workspace root
+   */
+  createDirectory(relativePath: string): void
+
+  /**
+   * Removes the workspace and all its contents.
+   * Safe to call multiple times.
+   */
+  cleanup(): void
+}
+
+/**
+ * Manages multiple temporary workspaces for a test suite.
+ * Ensures all workspaces are cleaned up in afterAll.
+ */
+export interface TempWorkspaceManager {
+  /**
+   * Creates a new temporary workspace.
+   * The workspace is automatically tracked for cleanup.
+   */
+  create(config?: TempWorkspaceConfig): TempWorkspace
+
+  /**
+   * Removes all tracked workspaces.
+   * Call this in afterAll().
+   */
+  cleanupAll(): void
+
+  /**
+   * Number of workspaces currently tracked.
+   */
+  readonly count: number
+}
+
+/**
+ * Creates a temporary workspace for testing ESLint rules.
+ *
+ * @param config - Workspace configuration
+ * @returns A TempWorkspace instance
+ *
+ * @example
+ * ```typescript
+ * const workspace = createTempWorkspace({
+ *   projectJson: { projectType: 'library', targets: { build: {}, publish: {} } },
+ *   packageJson: { name: '@test/lib', version: '1.0.0' },
+ *   files: {
+ *     'src/index.ts': 'export const foo = 1'
+ *   }
+ * })
+ *
+ * // Use in test
+ * const filePath = workspace.getPath('package.json')
+ *
+ * // Cleanup
+ * workspace.cleanup()
+ * ```
+ */
+export function createTempWorkspace(config: TempWorkspaceConfig = {}): TempWorkspace {
+  const prefix = config.prefix ?? 'eslint-test-'
+  const root = mkdtempSync(join(tmpdir(), prefix))
+
+  logger.debug(`Created temp workspace: ${root}`)
+
+  const writeFile = (relativePath: string, content: string): void => {
+    const fullPath = join(root, relativePath)
+    const dirPath = join(root, relativePath.split('/').slice(0, -1).join('/'))
+
+    if (dirPath !== root) {
+      mkdirSync(dirPath, { recursive: true, mode: 0o700 })
+    }
+
+    writeFileSync(fullPath, content, { mode: 0o600 })
+    logger.debug(`Wrote file: ${relativePath}`)
+  }
+
+  const writeJsonFile = (relativePath: string, content: object): void => {
+    writeFile(relativePath, JSON.stringify(content, null, 2))
+  }
+
+  const createDirectory = (relativePath: string): void => {
+    mkdirSync(join(root, relativePath), { recursive: true, mode: 0o700 })
+    logger.debug(`Created directory: ${relativePath}`)
+  }
+
+  // Create default src directory (common pattern)
+  mkdirSync(join(root, 'src'), { recursive: true, mode: 0o700 })
+
+  // Write standard files
+  if (config.projectJson) {
+    writeJsonFile('project.json', config.projectJson)
+  }
+
+  if (config.packageJson) {
+    writeJsonFile('package.json', config.packageJson)
+  }
+
+  if (config.readme) {
+    writeFile('README.md', config.readme)
+  }
+
+  if (config.tsconfigJson) {
+    writeJsonFile('tsconfig.json', config.tsconfigJson)
+  }
+
+  // Create additional directories
+  if (config.directories) {
+    for (const dir of config.directories) {
+      createDirectory(dir)
+    }
+  }
+
+  // Write additional files
+  if (config.files) {
+    for (const [relativePath, content] of Object.entries(config.files)) {
+      writeFile(relativePath, content)
+    }
+  }
+
+  let cleanedUp = false
+
+  return {
+    root,
+
+    getPath(relativePath: string): string {
+      return join(root, relativePath)
+    },
+
+    writeFile,
+
+    writeJsonFile,
+
+    createDirectory,
+
+    cleanup(): void {
+      if (cleanedUp) return
+      cleanedUp = true
+
+      try {
+        rmSync(root, { recursive: true, force: true })
+        logger.debug(`Cleaned up workspace: ${root}`)
+      } catch (error) {
+        logger.warn(`Failed to cleanup workspace ${root}: ${error}`)
+      }
+    },
+  }
+}
+
+/**
+ * Creates a manager for multiple temporary workspaces.
+ * Use this in test files to track all workspaces and clean them up in afterAll.
+ *
+ * @returns A TempWorkspaceManager instance
+ *
+ * @example
+ * ```typescript
+ * const manager = createTempWorkspaceManager()
+ *
+ * afterAll(() => {
+ *   manager.cleanupAll()
+ * })
+ *
+ * it('should validate package.json', () => {
+ *   const workspace = manager.create({
+ *     packageJson: { name: '@test/lib' }
+ *   })
+ *   // workspace is automatically tracked for cleanup
+ * })
+ * ```
+ */
+export function createTempWorkspaceManager(): TempWorkspaceManager {
+  const workspaces: TempWorkspace[] = []
+
+  return {
+    create(config?: TempWorkspaceConfig): TempWorkspace {
+      const workspace = createTempWorkspace(config)
+      workspaces.push(workspace)
+      return workspace
+    },
+
+    cleanupAll(): void {
+      for (const workspace of workspaces) {
+        workspace.cleanup()
+      }
+      workspaces.length = 0
+      logger.debug('Cleaned up all workspaces')
+    },
+
+    get count(): number {
+      return workspaces.length
+    },
+  }
+}

--- a/tools/eslint-rules/src/utils/fs.spec.ts
+++ b/tools/eslint-rules/src/utils/fs.spec.ts
@@ -1,0 +1,153 @@
+import { createTempWorkspaceManager } from '../testing'
+import { exists, isDirectory, readDirectory, readFileContent, readFileIfExists, readJsonFile, readJsonFileIfExists } from './fs'
+
+const manager = createTempWorkspaceManager()
+
+afterAll(() => {
+  manager.cleanupAll()
+})
+
+describe('readFileContent', () => {
+  it('reads file contents', () => {
+    const workspace = manager.create({
+      files: { 'test.txt': 'hello world' },
+    })
+
+    const content = readFileContent(workspace.getPath('test.txt'))
+
+    expect(content).toBe('hello world')
+  })
+
+  it('throws for missing file', () => {
+    const workspace = manager.create()
+
+    expect(() => readFileContent(workspace.getPath('missing.txt'))).toThrow()
+  })
+})
+
+describe('readFileIfExists', () => {
+  it('returns file contents when file exists', () => {
+    const workspace = manager.create({
+      files: { 'test.txt': 'hello' },
+    })
+
+    const content = readFileIfExists(workspace.getPath('test.txt'))
+
+    expect(content).toBe('hello')
+  })
+
+  it('returns null for missing file', () => {
+    const workspace = manager.create()
+
+    const content = readFileIfExists(workspace.getPath('missing.txt'))
+
+    expect(content).toBeNull()
+  })
+})
+
+describe('readJsonFile', () => {
+  it('reads and parses JSON file', () => {
+    const workspace = manager.create({
+      packageJson: { name: 'test', version: '1.0.0' },
+    })
+
+    const content = readJsonFile<{ name: string }>(workspace.getPath('package.json'))
+
+    expect(content.name).toBe('test')
+  })
+
+  it('throws for missing file', () => {
+    const workspace = manager.create()
+
+    expect(() => readJsonFile(workspace.getPath('missing.json'))).toThrow()
+  })
+
+  it('returns default when file missing and default provided', () => {
+    const workspace = manager.create()
+
+    const content = readJsonFile(workspace.getPath('missing.json'), { default: { fallback: true } })
+
+    expect(content).toEqual({ fallback: true })
+  })
+})
+
+describe('readJsonFileIfExists', () => {
+  it('returns parsed JSON when file exists', () => {
+    const workspace = manager.create({
+      packageJson: { name: 'test' },
+    })
+
+    const content = readJsonFileIfExists<{ name: string }>(workspace.getPath('package.json'))
+
+    expect(content?.name).toBe('test')
+  })
+
+  it('returns null for missing file', () => {
+    const workspace = manager.create()
+
+    const content = readJsonFileIfExists(workspace.getPath('missing.json'))
+
+    expect(content).toBeNull()
+  })
+
+  it('returns null for invalid JSON', () => {
+    const workspace = manager.create({
+      files: { 'invalid.json': 'not json {{{' },
+    })
+
+    const content = readJsonFileIfExists(workspace.getPath('invalid.json'))
+
+    expect(content).toBeNull()
+  })
+})
+
+describe('exists', () => {
+  it('returns true for existing file', () => {
+    const workspace = manager.create({
+      files: { 'test.txt': 'content' },
+    })
+
+    expect(exists(workspace.getPath('test.txt'))).toBe(true)
+  })
+
+  it('returns false for missing file', () => {
+    const workspace = manager.create()
+
+    expect(exists(workspace.getPath('missing.txt'))).toBe(false)
+  })
+})
+
+describe('isDirectory', () => {
+  it('returns true for directory', () => {
+    const workspace = manager.create({
+      directories: ['mydir'],
+    })
+
+    expect(isDirectory(workspace.getPath('mydir'))).toBe(true)
+  })
+
+  it('returns false for file', () => {
+    const workspace = manager.create({
+      files: { 'myfile.txt': 'content' },
+    })
+
+    expect(isDirectory(workspace.getPath('myfile.txt'))).toBe(false)
+  })
+})
+
+describe('readDirectory', () => {
+  it('returns directory contents', () => {
+    const workspace = manager.create({
+      files: {
+        'file1.ts': '',
+        'file2.ts': '',
+      },
+    })
+
+    const entries = readDirectory(workspace.root)
+
+    expect(entries).toContain('file1.ts')
+    expect(entries).toContain('file2.ts')
+    expect(entries).toContain('src') // default src directory
+  })
+})

--- a/tools/eslint-rules/src/utils/fs.ts
+++ b/tools/eslint-rules/src/utils/fs.ts
@@ -1,0 +1,101 @@
+import {
+  exists as projectScopeExists,
+  isDirectory as projectScopeIsDirectory,
+  readDirectory as projectScopeReadDirectory,
+  readFileContent as projectScopeReadFileContent,
+  readFileIfExists as projectScopeReadFileIfExists,
+  readJsonFile as projectScopeReadJsonFile,
+  readJsonFileIfExists as projectScopeReadJsonFileIfExists,
+} from '@hyperfrontend/project-scope/core/fs'
+import { createRuleLogger } from './logger'
+
+const logger = createRuleLogger('fs')
+
+/**
+ * Read file contents as string.
+ * Throws on error.
+ *
+ * @param filePath - Path to file
+ * @returns File contents
+ * @throws {Error} If file doesn't exist or can't be read
+ */
+export const readFileContent = projectScopeReadFileContent
+
+/**
+ * Read file if exists, return null otherwise.
+ *
+ * @param filePath - Path to file
+ * @returns File contents or null
+ */
+export const readFileIfExists = projectScopeReadFileIfExists
+
+/**
+ * Check if path exists.
+ *
+ * @param path - Path to check
+ * @returns True if exists
+ */
+export const exists = projectScopeExists
+
+/**
+ * Check if path is a directory.
+ *
+ * @param path - Path to check
+ * @returns True if path is a directory
+ */
+export const isDirectory = projectScopeIsDirectory
+
+/**
+ * Read directory contents.
+ * Returns an array of entry names (strings) for simpler usage.
+ *
+ * @param dirPath - Path to directory
+ * @returns Array of entry names
+ */
+export function readDirectory(dirPath: string): string[] {
+  try {
+    const entries = projectScopeReadDirectory(dirPath)
+    return entries.map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Read and parse JSON file.
+ * Throws on error unless default is provided.
+ *
+ * @param filePath - Path to JSON file
+ * @param options - Options with optional default value
+ * @returns Parsed JSON
+ */
+export const readJsonFile = projectScopeReadJsonFile
+
+/**
+ * Read and parse JSON file if it exists.
+ * Returns null if file doesn't exist or parsing fails.
+ *
+ * This is the safe equivalent of the legacy parseJsonFile function.
+ * Use this when you need to handle missing files gracefully.
+ *
+ * @param filePath - Path to JSON file
+ * @returns Parsed JSON or null
+ *
+ * @example
+ * ```typescript
+ * const projectJson = readJsonFileIfExists<ProjectJson>('./project.json')
+ * if (projectJson) {
+ *   // process project.json
+ * }
+ * ```
+ */
+export function readJsonFileIfExists<T>(filePath: string): T | null {
+  logger.debug('Reading JSON file', { path: filePath })
+
+  try {
+    return projectScopeReadJsonFileIfExists<T>(filePath)
+  } catch (error) {
+    logger.debug('Failed to read/parse JSON file', { path: filePath, error })
+    return null
+  }
+}

--- a/tools/eslint-rules/src/utils/import-validation.spec.ts
+++ b/tools/eslint-rules/src/utils/import-validation.spec.ts
@@ -1,0 +1,49 @@
+import { createLogger } from '@hyperfrontend/logging'
+import {
+  findWorkspaceRoot,
+  findProjectRoot,
+  readJsonFile,
+  readJsonFileIfExists,
+  createScopedLogger,
+  exists,
+  isDirectory,
+  readDirectory,
+} from '@hyperfrontend/project-scope'
+
+describe('Import Validation', () => {
+  it('imports findWorkspaceRoot from project-scope', () => {
+    expect(typeof findWorkspaceRoot).toBe('function')
+  })
+
+  it('imports findProjectRoot from project-scope', () => {
+    expect(typeof findProjectRoot).toBe('function')
+  })
+
+  it('imports readJsonFile from project-scope', () => {
+    expect(typeof readJsonFile).toBe('function')
+  })
+
+  it('imports readJsonFileIfExists from project-scope', () => {
+    expect(typeof readJsonFileIfExists).toBe('function')
+  })
+
+  it('imports createLogger from logging', () => {
+    expect(typeof createLogger).toBe('function')
+  })
+
+  it('imports createScopedLogger from project-scope', () => {
+    expect(typeof createScopedLogger).toBe('function')
+  })
+
+  it('imports exists from project-scope', () => {
+    expect(typeof exists).toBe('function')
+  })
+
+  it('imports isDirectory from project-scope', () => {
+    expect(typeof isDirectory).toBe('function')
+  })
+
+  it('imports readDirectory from project-scope', () => {
+    expect(typeof readDirectory).toBe('function')
+  })
+})

--- a/tools/eslint-rules/src/utils/index.ts
+++ b/tools/eslint-rules/src/utils/index.ts
@@ -1,0 +1,27 @@
+export type { ScopedLogger, ScopedLoggerOptions } from './logger'
+export type { PackageJson, ProjectJson, PublishableLibrary } from './nx-project'
+export { createNxScopedLogger, createRuleLogger, logger } from './logger'
+export {
+  findNxWorkspaceRoot,
+  findProjectRoot,
+  findRootDirectory,
+  findTypeScriptWorkspaceRoot,
+  findUpwardWhere,
+  findWorkspaceRoot,
+  findWorkspaceRootByMarker,
+  isWithinWorkspace,
+} from './workspace'
+export { exists, isDirectory, readDirectory, readFileContent, readFileIfExists, readJsonFile, readJsonFileIfExists } from './fs'
+export {
+  findLibraryDirectories,
+  findPublishableLibraryDirectories,
+  getAllPublishableLibraries,
+  isPublishableLibrary,
+  isPublishableLibraryDir,
+  isPublishableProjectJson,
+  looksLikeLibraryDir,
+  readPackageJson,
+  readProjectJson,
+} from './nx-project'
+export * from './import-analysis'
+export * from './node-builtins'

--- a/tools/eslint-rules/src/utils/logger.spec.ts
+++ b/tools/eslint-rules/src/utils/logger.spec.ts
@@ -1,0 +1,167 @@
+// Mock @nx/devkit logger - must be defined before jest.mock hoisting
+jest.mock('@nx/devkit', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    log: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+const { logger: mockNxLogger } = require('@nx/devkit')
+
+import { logger, createRuleLogger, createNxScopedLogger } from './logger'
+
+describe('logger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('exposes standard log methods', () => {
+    expect(typeof logger.error).toBe('function')
+    expect(typeof logger.warn).toBe('function')
+    expect(typeof logger.log).toBe('function')
+    expect(typeof logger.info).toBe('function')
+    expect(typeof logger.debug).toBe('function')
+  })
+
+  it('exposes log level control methods', () => {
+    expect(typeof logger.setLogLevel).toBe('function')
+    expect(typeof logger.getLogLevel).toBe('function')
+  })
+
+  it('defaults to error log level', () => {
+    const testLogger = createNxScopedLogger('test')
+    expect(testLogger.getLogLevel()).toBe('error')
+  })
+})
+
+describe('createNxScopedLogger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('creates a logger with default options', () => {
+    const scopedLogger = createNxScopedLogger('test-namespace')
+    expect(typeof scopedLogger.error).toBe('function')
+    expect(typeof scopedLogger.warn).toBe('function')
+    expect(typeof scopedLogger.log).toBe('function')
+    expect(typeof scopedLogger.info).toBe('function')
+    expect(typeof scopedLogger.debug).toBe('function')
+    expect(typeof scopedLogger.setLogLevel).toBe('function')
+    expect(typeof scopedLogger.getLogLevel).toBe('function')
+  })
+
+  it('respects custom log level option', () => {
+    const scopedLogger = createNxScopedLogger('test-namespace', { level: 'debug' })
+    expect(scopedLogger.getLogLevel()).toBe('debug')
+  })
+
+  it('allows changing log level via setLogLevel', () => {
+    const scopedLogger = createNxScopedLogger('test-namespace')
+    expect(scopedLogger.getLogLevel()).toBe('error')
+    scopedLogger.setLogLevel('info')
+    expect(scopedLogger.getLogLevel()).toBe('info')
+  })
+})
+
+describe('createNxScopedLogger invocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('invokes nxLogger.error with namespaced message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'error' })
+    scopedLogger.error('Something went wrong')
+    expect(mockNxLogger.error).toHaveBeenCalledWith('[my-namespace] Something went wrong')
+  })
+
+  it('invokes nxLogger.warn with namespaced message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'warn' })
+    scopedLogger.warn('Warning message')
+    expect(mockNxLogger.warn).toHaveBeenCalledWith('[my-namespace] Warning message')
+  })
+
+  it('invokes nxLogger.log with namespaced message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'log' })
+    scopedLogger.log('Log message')
+    expect(mockNxLogger.log).toHaveBeenCalledWith('[my-namespace] Log message')
+  })
+
+  it('invokes nxLogger.info with namespaced message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'info' })
+    scopedLogger.info('Info message')
+    expect(mockNxLogger.info).toHaveBeenCalledWith('[my-namespace] Info message')
+  })
+
+  it('invokes nxLogger.debug with namespaced message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'debug' })
+    scopedLogger.debug('Debug message')
+    expect(mockNxLogger.debug).toHaveBeenCalledWith('[my-namespace] Debug message')
+  })
+
+  it('appends stringified metadata to log message', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'info' })
+    scopedLogger.info('Processing file', { file: 'index.ts', line: 42 })
+    expect(mockNxLogger.info).toHaveBeenCalledWith('[my-namespace] Processing file {"file":"index.ts","line":42}')
+  })
+
+  it('sanitizes sensitive data in metadata', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'info' })
+    scopedLogger.info('Config loaded', { apiKey: 'secret123', name: 'app' })
+    expect(mockNxLogger.info).toHaveBeenCalledWith('[my-namespace] Config loaded {"apiKey":"[REDACTED]","name":"app"}')
+  })
+
+  it('respects log level filtering - does not invoke lower priority logs', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'warn' })
+    scopedLogger.debug('Debug message')
+    scopedLogger.info('Info message')
+    scopedLogger.log('Log message')
+    // These should not be called because level is 'warn'
+    expect(mockNxLogger.debug).not.toHaveBeenCalled()
+    expect(mockNxLogger.info).not.toHaveBeenCalled()
+    expect(mockNxLogger.log).not.toHaveBeenCalled()
+  })
+
+  it('invokes logs at or above the set level', () => {
+    const scopedLogger = createNxScopedLogger('my-namespace', { level: 'warn' })
+    scopedLogger.warn('Warning message')
+    scopedLogger.error('Error message')
+    expect(mockNxLogger.warn).toHaveBeenCalledWith('[my-namespace] Warning message')
+    expect(mockNxLogger.error).toHaveBeenCalledWith('[my-namespace] Error message')
+  })
+})
+
+describe('createRuleLogger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('creates a scoped logger instance', () => {
+    const ruleLogger = createRuleLogger('test-rule')
+    expect(typeof ruleLogger.error).toBe('function')
+    expect(typeof ruleLogger.warn).toBe('function')
+    expect(typeof ruleLogger.log).toBe('function')
+    expect(typeof ruleLogger.info).toBe('function')
+    expect(typeof ruleLogger.debug).toBe('function')
+  })
+
+  it('creates independent logger instances', () => {
+    const logger1 = createRuleLogger('rule-1')
+    const logger2 = createRuleLogger('rule-2')
+    expect(logger1).not.toBe(logger2)
+  })
+
+  it('creates logger with default error level', () => {
+    const ruleLogger = createRuleLogger('test-rule')
+    expect(ruleLogger.getLogLevel()).toBe('error')
+  })
+
+  it('uses eslint-rules:scope namespace format', () => {
+    const ruleLogger = createRuleLogger('deepest-import-path')
+    ruleLogger.setLogLevel('error')
+    ruleLogger.error('Rule violation')
+    expect(mockNxLogger.error).toHaveBeenCalledWith('[eslint-rules:deepest-import-path] Rule violation')
+  })
+})

--- a/tools/eslint-rules/src/utils/logger.ts
+++ b/tools/eslint-rules/src/utils/logger.ts
@@ -1,0 +1,131 @@
+import type { Logger, LogLevel } from '@hyperfrontend/logging'
+import { logger as nxLogger } from '@nx/devkit'
+import { stringify } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { keys } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createLogger } from '@hyperfrontend/logging'
+import { sanitize } from '@hyperfrontend/project-scope/core/logger'
+
+export type { LogLevel, Logger } from '@hyperfrontend/logging'
+
+/**
+ * A scoped logger instance with namespace prefix and secret sanitization.
+ * Uses `@nx/devkit` logger under the hood for proper Nx integration.
+ */
+export interface ScopedLogger {
+  /** Log at error level */
+  error: (message: string, meta?: object) => void
+  /** Log at warn level */
+  warn: (message: string, meta?: object) => void
+  /** Log at log level */
+  log: (message: string, meta?: object) => void
+  /** Log at info level */
+  info: (message: string, meta?: object) => void
+  /** Log at debug level */
+  debug: (message: string, meta?: object) => void
+  /** Set the current log level */
+  setLogLevel: (level: LogLevel) => void
+  /** Get the current log level */
+  getLogLevel: () => LogLevel
+}
+
+/**
+ * Options for creating a scoped logger.
+ */
+export interface ScopedLoggerOptions {
+  /**
+   * Initial log level.
+   *
+   * @default 'error'
+   */
+  level?: LogLevel
+}
+
+/**
+ * Formats a log message with optional metadata.
+ *
+ * @param namespace - Logger namespace for prefixing (e.g., 'eslint-rules', 'eslint-rules:deepest-import-path')
+ * @param message - The main log message
+ * @param meta - Optional metadata object to include in the log
+ * @returns A formatted log message string with namespace prefix and sanitized metadata
+ */
+function formatMessage(namespace: string, message: string, meta?: object): string {
+  const prefix = `[${namespace}]`
+  if (meta && keys(meta).length > 0) {
+    const sanitizedMeta = sanitize(meta)
+    return `${prefix} ${message} ${stringify(sanitizedMeta)}`
+  }
+  return `${prefix} ${message}`
+}
+
+/**
+ * Creates a scoped logger that uses `@nx/devkit` logger under the hood.
+ * Provides namespace prefixing and automatic secret sanitization.
+ *
+ * @param namespace - Logger namespace (e.g., 'eslint-rules', 'eslint-rules:deepest-import-path')
+ * @param options - Logger configuration options
+ * @returns A configured scoped logger instance
+ *
+ * @example
+ * ```typescript
+ * const logger = createNxScopedLogger('eslint-rules')
+ * logger.setLogLevel('debug')
+ * logger.debug('Processing file', { file: 'index.ts' })
+ * // Output: [eslint-rules] Processing file {"file":"index.ts"}
+ * ```
+ */
+export function createNxScopedLogger(namespace: string, options: ScopedLoggerOptions = {}): ScopedLogger {
+  const { level = 'error' } = options
+
+  // Create wrapper functions that add namespace prefix (sanitization happens in formatMessage)
+  const createLogFn =
+    (baseFn: (message: string) => void) =>
+    (message: string, meta?: object): void => {
+      baseFn(formatMessage(namespace, message, meta))
+    }
+
+  // Create base logger using @nx/devkit logger methods
+  const baseLogger: Logger = createLogger(
+    createLogFn((msg) => nxLogger.error(msg)),
+    createLogFn((msg) => nxLogger.warn(msg)),
+    createLogFn((msg) => nxLogger.log(msg)),
+    createLogFn((msg) => nxLogger.info(msg)),
+    createLogFn((msg) => nxLogger.debug(msg))
+  )
+
+  // Set initial log level
+  baseLogger.setLogLevel(level)
+
+  return freeze({
+    error: (message: string, meta?: object) => baseLogger.error(message, meta),
+    warn: (message: string, meta?: object) => baseLogger.warn(message, meta),
+    log: (message: string, meta?: object) => baseLogger.log(message, meta),
+    info: (message: string, meta?: object) => baseLogger.info(message, meta),
+    debug: (message: string, meta?: object) => baseLogger.debug(message, meta),
+    setLogLevel: baseLogger.setLogLevel,
+    getLogLevel: baseLogger.getLogLevel,
+  })
+}
+
+/**
+ * Scoped logger for eslint-rules.
+ * Uses `@nx/devkit` logger under the hood with 'eslint-rules' prefix.
+ */
+export const logger: ScopedLogger = createNxScopedLogger('eslint-rules')
+
+/**
+ * Create a sub-scoped logger for a specific rule or module.
+ *
+ * @param scope - The scope name (e.g., 'deepest-import-path')
+ * @returns A scoped logger instance
+ *
+ * @example
+ * ```typescript
+ * const ruleLogger = createRuleLogger('deepest-import-path')
+ * ruleLogger.debug('Processing file', { file: 'index.ts' })
+ * // Output: [eslint-rules:deepest-import-path] Processing file {"file":"index.ts"}
+ * ```
+ */
+export function createRuleLogger(scope: string): ScopedLogger {
+  return createNxScopedLogger(`eslint-rules:${scope}`)
+}

--- a/tools/eslint-rules/src/utils/node-builtins.ts
+++ b/tools/eslint-rules/src/utils/node-builtins.ts
@@ -1,8 +1,10 @@
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
+
 /**
  * List of Node.js built-in module names.
  * These modules can be imported with or without the `node:` prefix.
  */
-export const NODE_BUILTIN_MODULES: ReadonlySet<string> = new Set([
+export const NODE_BUILTIN_MODULES: ReadonlySet<string> = createSet([
   'assert',
   'async_hooks',
   'buffer',

--- a/tools/eslint-rules/src/utils/nx-project.spec.ts
+++ b/tools/eslint-rules/src/utils/nx-project.spec.ts
@@ -1,0 +1,357 @@
+import { createTempWorkspaceManager, PUBLISHABLE_LIBRARY_PROJECT_JSON } from '../testing'
+import {
+  findLibraryDirectories,
+  findPublishableLibraryDirectories,
+  getAllPublishableLibraries,
+  isPublishableLibrary,
+  isPublishableLibraryDir,
+  isPublishableProjectJson,
+  looksLikeLibraryDir,
+  readPackageJson,
+  readProjectJson,
+} from './nx-project'
+
+const manager = createTempWorkspaceManager()
+
+afterAll(() => {
+  manager.cleanupAll()
+})
+
+describe('isPublishableLibrary', () => {
+  it('returns true for publishable library', () => {
+    const workspace = manager.create({
+      projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
+    })
+
+    expect(isPublishableLibrary(workspace.root)).toBe(true)
+  })
+
+  it('returns false for library without publish target', () => {
+    const workspace = manager.create({
+      projectJson: { projectType: 'library', targets: { build: {} } },
+    })
+
+    expect(isPublishableLibrary(workspace.root)).toBe(false)
+  })
+
+  it('returns false for application', () => {
+    const workspace = manager.create({
+      projectJson: { projectType: 'application', targets: { build: {}, publish: {} } },
+    })
+
+    expect(isPublishableLibrary(workspace.root)).toBe(false)
+  })
+})
+
+describe('isPublishableLibraryDir', () => {
+  it('works as alias for isPublishableLibrary', () => {
+    const workspace = manager.create({
+      projectJson: PUBLISHABLE_LIBRARY_PROJECT_JSON,
+    })
+
+    expect(isPublishableLibraryDir(workspace.root)).toBe(true)
+  })
+})
+
+describe('isPublishableProjectJson', () => {
+  it('returns true for publishable library config', () => {
+    expect(
+      isPublishableProjectJson({
+        projectType: 'library',
+        targets: { build: {}, publish: {} },
+      })
+    ).toBe(true)
+  })
+
+  it('returns false for missing publish target', () => {
+    expect(
+      isPublishableProjectJson({
+        projectType: 'library',
+        targets: { build: {} },
+      })
+    ).toBe(false)
+  })
+})
+
+describe('looksLikeLibraryDir', () => {
+  it('returns true for directory with project.json and src', () => {
+    const workspace = manager.create({
+      projectJson: { projectType: 'library' },
+      directories: ['src'],
+    })
+
+    expect(looksLikeLibraryDir(workspace.root)).toBe(true)
+  })
+
+  it('returns true for directory with project.json and index.ts', () => {
+    const workspace = manager.create({
+      files: {
+        'project.json': JSON.stringify({ projectType: 'library' }),
+        'index.ts': 'export {}',
+      },
+    })
+
+    expect(looksLikeLibraryDir(workspace.root)).toBe(true)
+  })
+
+  it('returns true for directory with project.json and main.ts', () => {
+    const workspace = manager.create({
+      files: {
+        'project.json': JSON.stringify({ projectType: 'library' }),
+        'main.ts': 'export {}',
+      },
+    })
+
+    expect(looksLikeLibraryDir(workspace.root)).toBe(true)
+  })
+
+  it('returns false for directory without project.json', () => {
+    const workspace = manager.create({
+      directories: ['src'],
+    })
+
+    expect(looksLikeLibraryDir(workspace.root)).toBe(false)
+  })
+
+  it('returns false for directory with project.json but no src, index.ts, or main.ts', () => {
+    const workspace = manager.create({
+      files: {
+        'project.json': JSON.stringify({ projectType: 'library' }),
+      },
+    })
+
+    // Remove the default src directory that createTempWorkspace creates
+    const { rmSync } = require('node:fs')
+    rmSync(workspace.getPath('src'), { recursive: true, force: true })
+
+    expect(looksLikeLibraryDir(workspace.root)).toBe(false)
+  })
+})
+
+describe('findLibraryDirectories', () => {
+  it('finds library directories', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/lib-a/project.json': JSON.stringify({ projectType: 'library' }),
+        'libs/lib-a/src/index.ts': '',
+        'libs/lib-b/project.json': JSON.stringify({ projectType: 'library' }),
+        'libs/lib-b/src/index.ts': '',
+        'apps/app-a/project.json': JSON.stringify({ projectType: 'application' }),
+      },
+    })
+
+    const result = findLibraryDirectories(workspace.getPath('libs'))
+
+    expect(result).toHaveLength(2)
+    expect(result).toContain(workspace.getPath('libs/lib-a'))
+    expect(result).toContain(workspace.getPath('libs/lib-b'))
+  })
+
+  it('returns empty array when path is not a directory', () => {
+    const workspace = manager.create({
+      files: {
+        'some-file.txt': 'content',
+      },
+    })
+
+    const result = findLibraryDirectories(workspace.getPath('some-file.txt'))
+
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array for non-existent path', () => {
+    const result = findLibraryDirectories('/non/existent/path')
+
+    expect(result).toEqual([])
+  })
+
+  it('skips hidden directories, node_modules, and dist', () => {
+    const workspace = manager.create({
+      files: {
+        '.hidden/project.json': JSON.stringify({ projectType: 'library' }),
+        'node_modules/pkg/project.json': JSON.stringify({ projectType: 'library' }),
+        'dist/build/project.json': JSON.stringify({ projectType: 'library' }),
+        'libs/valid/project.json': JSON.stringify({ projectType: 'library' }),
+      },
+    })
+
+    const result = findLibraryDirectories(workspace.root)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('valid')
+  })
+
+  it('recursively searches subdirectories without project.json', () => {
+    const workspace = manager.create({
+      files: {
+        'packages/scope/lib-a/project.json': JSON.stringify({ projectType: 'library' }),
+        'packages/scope/lib-b/project.json': JSON.stringify({ projectType: 'library' }),
+      },
+    })
+
+    const result = findLibraryDirectories(workspace.getPath('packages'))
+
+    expect(result).toHaveLength(2)
+    expect(result).toContain(workspace.getPath('packages/scope/lib-a'))
+    expect(result).toContain(workspace.getPath('packages/scope/lib-b'))
+  })
+
+  it('skips files in the directory', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/README.md': 'readme',
+        'libs/lib-a/project.json': JSON.stringify({ projectType: 'library' }),
+      },
+    })
+
+    const result = findLibraryDirectories(workspace.getPath('libs'))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('lib-a')
+  })
+})
+
+describe('findPublishableLibraryDirectories', () => {
+  it('finds only publishable libraries', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/pub-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {}, publish: {} },
+        }),
+        'libs/internal-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {} },
+        }),
+      },
+    })
+
+    const result = findPublishableLibraryDirectories(workspace.getPath('libs'))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('pub-lib')
+  })
+})
+
+describe('getAllPublishableLibraries', () => {
+  it('returns publishable library metadata', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/my-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {}, publish: {} },
+        }),
+        'libs/my-lib/package.json': JSON.stringify({
+          name: '@test/my-lib',
+          version: '1.0.0',
+        }),
+      },
+    })
+
+    const result = getAllPublishableLibraries(workspace.root)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('@test/my-lib')
+    expect(result[0].packageJson?.version).toBe('1.0.0')
+  })
+
+  it('returns empty array when libs directory does not exist', () => {
+    const workspace = manager.create()
+
+    const result = getAllPublishableLibraries(workspace.root)
+
+    expect(result).toEqual([])
+  })
+
+  it('uses directory name when package.json has no name', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/my-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {}, publish: {} },
+        }),
+        'libs/my-lib/package.json': JSON.stringify({
+          version: '1.0.0',
+        }),
+      },
+    })
+
+    const result = getAllPublishableLibraries(workspace.root)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('my-lib')
+  })
+
+  it('uses directory name when package.json does not exist', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/standalone-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {}, publish: {} },
+        }),
+      },
+    })
+
+    const result = getAllPublishableLibraries(workspace.root)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('standalone-lib')
+    expect(result[0].packageJson).toBeNull()
+  })
+
+  it('supports custom libs directory', () => {
+    const workspace = manager.create({
+      files: {
+        'packages/my-lib/project.json': JSON.stringify({
+          projectType: 'library',
+          targets: { build: {}, publish: {} },
+        }),
+      },
+    })
+
+    const result = getAllPublishableLibraries(workspace.root, 'packages')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('my-lib')
+  })
+})
+
+describe('readProjectJson', () => {
+  it('reads project.json', () => {
+    const workspace = manager.create({
+      projectJson: { projectType: 'library' },
+    })
+
+    const result = readProjectJson(workspace.root)
+
+    expect(result?.projectType).toBe('library')
+  })
+
+  it('returns null when not found', () => {
+    const workspace = manager.create()
+
+    const result = readProjectJson(workspace.root)
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('readPackageJson', () => {
+  it('reads package.json', () => {
+    const workspace = manager.create({
+      packageJson: { name: 'test' },
+    })
+
+    const result = readPackageJson(workspace.root)
+
+    expect(result?.name).toBe('test')
+  })
+
+  it('returns null when not found', () => {
+    const workspace = manager.create()
+
+    const result = readPackageJson(workspace.root)
+
+    expect(result).toBeNull()
+  })
+})

--- a/tools/eslint-rules/src/utils/nx-project.ts
+++ b/tools/eslint-rules/src/utils/nx-project.ts
@@ -1,15 +1,21 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
+import { exists, isDirectory, readDirectory, readJsonFileIfExists } from './fs'
+import { createRuleLogger } from './logger'
+
+const logger = createRuleLogger('nx-project')
 
 /**
  * Represents the structure of a project.json file.
  */
 export interface ProjectJson {
-  projectType?: string
+  projectType?: 'library' | 'application'
   targets?: {
     build?: unknown
     publish?: unknown
+    [key: string]: unknown
   }
+  tags?: string[]
+  [key: string]: unknown
 }
 
 /**
@@ -17,56 +23,69 @@ export interface ProjectJson {
  */
 export interface PackageJson {
   name?: string
+  version?: string
   exports?: Record<string, string | Record<string, string>>
   main?: string
+  module?: string
+  types?: string
+  files?: string[]
+  workspaces?: string[]
+  [key: string]: unknown
 }
 
 /**
- * Finds the project root by locating project.json.
- *
- * @param startDir - The directory to start searching from.
- * @returns The project root path, or null if not found.
+ * Represents a publishable library.
  */
-export function findProjectRoot(startDir: string): string | null {
-  let dir = startDir
-  while (dir !== '/') {
-    if (existsSync(join(dir, 'project.json'))) {
-      return dir
-    }
-    dir = dirname(dir)
-  }
-  return null
-}
-
-/**
- * Parses a JSON file safely.
- *
- * @param filePath - The path to the JSON file.
- * @returns The parsed JSON object, or null if parsing fails.
- */
-export function parseJsonFile<T>(filePath: string): T | null {
-  try {
-    const content = readFileSync(filePath, 'utf-8')
-    return <T>JSON.parse(content)
-  } catch {
-    return null
-  }
+export interface PublishableLibrary {
+  name: string
+  root: string
+  projectJson: ProjectJson
+  packageJson: PackageJson | null
 }
 
 /**
  * Checks if the project at the given root is a publishable library.
  *
+ * A publishable library must have:
+ * - projectType === 'library'
+ * - targets.build defined
+ * - targets.publish defined
+ *
  * @param projectRoot - The root directory of the project.
  * @returns True if the project is a publishable library, false otherwise.
  */
 export function isPublishableLibrary(projectRoot: string): boolean {
+  logger.debug('Checking if publishable library', { projectRoot })
+
   const projectJsonPath = join(projectRoot, 'project.json')
-  const projectJson = parseJsonFile<ProjectJson>(projectJsonPath)
+  const projectJson = readJsonFileIfExists<ProjectJson>(projectJsonPath)
 
   if (!projectJson) {
+    logger.debug('No project.json found')
     return false
   }
 
+  return isPublishableProjectJson(projectJson)
+}
+
+/**
+ * Checks if a directory contains a publishable library.
+ * Alternative signature that takes the directory path directly.
+ *
+ * @param projectDir - The directory to check.
+ * @returns True if the directory contains a publishable library.
+ */
+export function isPublishableLibraryDir(projectDir: string): boolean {
+  return isPublishableLibrary(projectDir)
+}
+
+/**
+ * Check if a project.json represents a publishable library.
+ *
+ * @param projectJson - The parsed project.json content.
+ * @returns True if it's a publishable library configuration.
+ */
+export function isPublishableProjectJson(projectJson: ProjectJson): boolean {
   if (projectJson.projectType !== 'library') {
     return false
   }
@@ -76,4 +95,145 @@ export function isPublishableLibrary(projectRoot: string): boolean {
   }
 
   return true
+}
+
+/**
+ * Check if a directory looks like a library directory.
+ * Checks for common library structure indicators.
+ *
+ * @param dirPath - Directory path to check.
+ * @returns True if it looks like a library directory.
+ */
+export function looksLikeLibraryDir(dirPath: string): boolean {
+  // Must have project.json
+  if (!exists(join(dirPath, 'project.json'))) {
+    return false
+  }
+
+  // Must have src directory or an entry point file
+  const hasSrcDir = isDirectory(join(dirPath, 'src'))
+  const hasIndexTs = exists(join(dirPath, 'index.ts'))
+  const hasMainTs = exists(join(dirPath, 'main.ts'))
+
+  return hasSrcDir || hasIndexTs || hasMainTs
+}
+
+/**
+ * Find all library directories under a given path.
+ * Recursively searches for directories containing project.json
+ * with projectType: 'library'.
+ *
+ * @param searchDir - Directory to search in.
+ * @returns Array of absolute paths to library directories.
+ */
+export function findLibraryDirectories(searchDir: string): string[] {
+  logger.debug('Finding library directories', { searchDir })
+
+  const libraries: string[] = []
+
+  if (!isDirectory(searchDir)) {
+    return libraries
+  }
+
+  const entries = readDirectory(searchDir)
+
+  for (const entry of entries) {
+    // Skip hidden and common ignore patterns
+    if (entry.startsWith('.') || entry === 'node_modules' || entry === 'dist') {
+      continue
+    }
+
+    const entryPath = join(searchDir, entry)
+
+    if (!isDirectory(entryPath)) {
+      continue
+    }
+
+    // Check if this directory is a library
+    const projectJsonPath = join(entryPath, 'project.json')
+    const projectJson = readJsonFileIfExists<ProjectJson>(projectJsonPath)
+
+    if (projectJson?.projectType === 'library') {
+      libraries.push(entryPath)
+    } else {
+      // Recursively search subdirectories
+      libraries.push(...findLibraryDirectories(entryPath))
+    }
+  }
+
+  logger.debug('Found library directories', { count: libraries.length })
+  return libraries
+}
+
+/**
+ * Find all publishable library directories under a given path.
+ *
+ * @param searchDir - Directory to search in.
+ * @returns Array of absolute paths to publishable library directories.
+ */
+export function findPublishableLibraryDirectories(searchDir: string): string[] {
+  return findLibraryDirectories(searchDir).filter(isPublishableLibraryDir)
+}
+
+/**
+ * Get all publishable libraries with their metadata.
+ *
+ * @param workspaceRoot - Workspace root directory.
+ * @param libsDir - Libraries directory (default: 'libs').
+ * @returns Array of PublishableLibrary objects.
+ */
+export function getAllPublishableLibraries(workspaceRoot: string, libsDir = 'libs'): PublishableLibrary[] {
+  logger.debug('Getting all publishable libraries', { workspaceRoot, libsDir })
+
+  const libsPath = join(workspaceRoot, libsDir)
+
+  if (!isDirectory(libsPath)) {
+    logger.debug('Libs directory does not exist', { libsPath })
+    return []
+  }
+
+  const libraryDirs = findPublishableLibraryDirectories(libsPath)
+  const libraries: PublishableLibrary[] = []
+
+  for (const dir of libraryDirs) {
+    const projectJson = readJsonFileIfExists<ProjectJson>(join(dir, 'project.json'))
+    const packageJson = readJsonFileIfExists<PackageJson>(join(dir, 'package.json'))
+
+    if (!projectJson) {
+      continue
+    }
+
+    // Derive name from package.json or directory name
+    const name = packageJson?.name ?? dir.split('/').pop() ?? 'unknown'
+
+    libraries.push({
+      name,
+      root: dir,
+      projectJson,
+      packageJson,
+    })
+  }
+
+  logger.debug('Found publishable libraries', { count: libraries.length })
+  return libraries
+}
+
+/**
+ * Read project.json from a directory.
+ *
+ * @param projectRoot - Project root directory.
+ * @returns ProjectJson or null if not found.
+ */
+export function readProjectJson(projectRoot: string): ProjectJson | null {
+  return readJsonFileIfExists<ProjectJson>(join(projectRoot, 'project.json'))
+}
+
+/**
+ * Read package.json from a directory.
+ *
+ * @param projectRoot - Project root directory.
+ * @returns PackageJson or null if not found.
+ */
+export function readPackageJson(projectRoot: string): PackageJson | null {
+  return readJsonFileIfExists<PackageJson>(join(projectRoot, 'package.json'))
 }

--- a/tools/eslint-rules/src/utils/workspace.spec.ts
+++ b/tools/eslint-rules/src/utils/workspace.spec.ts
@@ -1,0 +1,148 @@
+import { createTempWorkspaceManager } from '../testing'
+import {
+  findNxWorkspaceRoot,
+  findProjectRoot,
+  findRootDirectory,
+  findTypeScriptWorkspaceRoot,
+  findUpwardWhere,
+  findWorkspaceRoot,
+  findWorkspaceRootByMarker,
+  isWithinWorkspace,
+} from './workspace'
+
+const manager = createTempWorkspaceManager()
+
+afterAll(() => {
+  manager.cleanupAll()
+})
+
+describe('findProjectRoot', () => {
+  it('finds project root with project.json', () => {
+    const workspace = manager.create({
+      projectJson: { projectType: 'library' },
+    })
+
+    const result = findProjectRoot(workspace.getPath('src'))
+
+    expect(result).toBe(workspace.root)
+  })
+})
+
+describe('findWorkspaceRoot', () => {
+  it('finds workspace root with nx.json', () => {
+    const workspace = manager.create({
+      files: {
+        'nx.json': '{}',
+        'libs/my-lib/src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findWorkspaceRoot(workspace.getPath('libs/my-lib/src'))
+
+    expect(result).toBe(workspace.root)
+  })
+})
+
+describe('findWorkspaceRootByMarker', () => {
+  it('finds root with custom marker', () => {
+    const workspace = manager.create({
+      files: {
+        'tsconfig.base.json': '{}',
+        'libs/my-lib/src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findWorkspaceRootByMarker(workspace.getPath('libs/my-lib'), 'tsconfig.base.json')
+
+    expect(result).toBe(workspace.root)
+  })
+
+  it('returns null when marker not found', () => {
+    const workspace = manager.create({
+      files: {
+        'libs/my-lib/src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findWorkspaceRootByMarker(workspace.getPath('libs/my-lib'), 'nonexistent.json')
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('findTypeScriptWorkspaceRoot', () => {
+  it('finds root with tsconfig.base.json', () => {
+    const workspace = manager.create({
+      files: {
+        'tsconfig.base.json': '{}',
+        'src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findTypeScriptWorkspaceRoot(workspace.getPath('src'))
+
+    expect(result).toBe(workspace.root)
+  })
+})
+
+describe('findNxWorkspaceRoot', () => {
+  it('finds root with nx.json', () => {
+    const workspace = manager.create({
+      files: {
+        'nx.json': '{}',
+        'src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findNxWorkspaceRoot(workspace.getPath('src'))
+
+    expect(result).toBe(workspace.root)
+  })
+})
+
+describe('isWithinWorkspace', () => {
+  it('returns true for paths within workspace', () => {
+    expect(isWithinWorkspace('/workspace/libs/my-lib', '/workspace')).toBe(true)
+  })
+
+  it('returns false for paths outside workspace', () => {
+    expect(isWithinWorkspace('/other/path', '/workspace')).toBe(false)
+  })
+})
+
+describe('findRootDirectory', () => {
+  it('finds root with specified markers', () => {
+    const workspace = manager.create({
+      files: {
+        'custom-marker.json': '{}',
+        'libs/my-lib/src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findRootDirectory(workspace.getPath('libs/my-lib'), ['custom-marker.json'])
+
+    expect(result).toBe(workspace.root)
+  })
+})
+
+describe('findUpwardWhere', () => {
+  it('finds directory matching predicate', () => {
+    const workspace = manager.create({
+      files: {
+        'marker-file.txt': 'marker',
+        'libs/my-lib/src/index.ts': 'export {}',
+      },
+    })
+
+    const result = findUpwardWhere(workspace.getPath('libs/my-lib/src'), (dir) => {
+      try {
+        const fs = require('node:fs')
+        return fs.existsSync(require('node:path').join(dir, 'marker-file.txt'))
+      } catch {
+        return false
+      }
+    })
+
+    expect(result).toBe(workspace.root)
+  })
+})

--- a/tools/eslint-rules/src/utils/workspace.ts
+++ b/tools/eslint-rules/src/utils/workspace.ts
@@ -1,0 +1,113 @@
+/**
+ * Workspace and project root detection utilities.
+ *
+ * Re-exports from `@hyperfrontend/project-scope` with additional
+ * eslint-rules-specific utilities.
+ *
+ * @module utils/workspace
+ */
+
+import { findUpwardWhere } from '@hyperfrontend/project-scope/core/fs'
+import {
+  findProjectRoot as projectScopeFindProjectRoot,
+  findRootDirectory,
+  findWorkspaceRoot as projectScopeFindWorkspaceRoot,
+} from '@hyperfrontend/project-scope/project/root'
+import { createRuleLogger } from './logger'
+
+const logger = createRuleLogger('workspace')
+
+/**
+ * Re-export findProjectRoot from project-scope.
+ * Finds the nearest directory containing package.json with source files
+ * or project.json.
+ *
+ * @param startPath - Starting path for search
+ * @returns Project root path or null
+ */
+export const findProjectRoot = projectScopeFindProjectRoot
+
+/**
+ * Re-export findWorkspaceRoot from project-scope.
+ * Finds workspace/monorepo root by looking for workspace markers
+ * (nx.json, turbo.json, etc.) or package.json with workspaces field.
+ *
+ * @param startPath - Starting path for search
+ * @returns Workspace root path or null
+ */
+export const findWorkspaceRoot = projectScopeFindWorkspaceRoot
+
+/**
+ * Find workspace root by looking for a specific marker file.
+ * Use this when you need to find a root with a specific file
+ * (e.g., tsconfig.base.json).
+ *
+ * @param startPath - Starting path for search
+ * @param markerFile - File name to search for (e.g., 'tsconfig.base.json')
+ * @returns Root directory path or null
+ *
+ * @example
+ * ```typescript
+ * // Find root with tsconfig.base.json
+ * const root = findWorkspaceRootByMarker('/path/to/file', 'tsconfig.base.json')
+ * ```
+ */
+export function findWorkspaceRootByMarker(startPath: string, markerFile: string): string | null {
+  logger.debug('Finding workspace root by marker', { startPath, marker: markerFile })
+
+  const result = findRootDirectory(startPath, [markerFile])
+
+  if (result) {
+    logger.debug('Found workspace root', { root: result })
+  } else {
+    logger.debug('Workspace root not found')
+  }
+
+  return result
+}
+
+/**
+ * Find workspace root specifically for TypeScript projects.
+ * Searches for tsconfig.base.json.
+ *
+ * @param startPath - Starting path for search
+ * @returns Root directory containing tsconfig.base.json or null
+ */
+export function findTypeScriptWorkspaceRoot(startPath: string): string | null {
+  return findWorkspaceRootByMarker(startPath, 'tsconfig.base.json')
+}
+
+/**
+ * Find workspace root specifically for Nx projects.
+ * Searches for nx.json.
+ *
+ * @param startPath - Starting path for search
+ * @returns Root directory containing nx.json or null
+ */
+export function findNxWorkspaceRoot(startPath: string): string | null {
+  return findWorkspaceRootByMarker(startPath, 'nx.json')
+}
+
+/**
+ * Check if a path is within a workspace.
+ *
+ * @param targetPath - Path to check
+ * @param workspaceRoot - Workspace root path
+ * @returns True if targetPath is within workspaceRoot
+ */
+export function isWithinWorkspace(targetPath: string, workspaceRoot: string): boolean {
+  const normalizedTarget = targetPath.split('/').join('/')
+  const normalizedRoot = workspaceRoot.split('/').join('/')
+
+  return normalizedTarget.startsWith(normalizedRoot)
+}
+
+/**
+ * Re-export findRootDirectory for advanced usage.
+ */
+export { findRootDirectory }
+
+/**
+ * Re-export findUpwardWhere for custom upward searches.
+ */
+export { findUpwardWhere }

--- a/tools/package/eslint.config.cjs
+++ b/tools/package/eslint.config.cjs
@@ -3,12 +3,6 @@ const baseConfig = require('../../eslint.base.config.cjs')
 module.exports = [
   ...baseConfig,
   {
-    files: ['**/*.ts'],
-    rules: {
-      'workspace/no-unsafe-builtin-methods': 'off',
-    },
-  },
-  {
     files: ['**/*.json'],
     rules: {
       '@nx/dependency-checks': [

--- a/tools/package/src/executors/build/executor.ts
+++ b/tools/package/src/executors/build/executor.ts
@@ -5,6 +5,10 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { joinPathFragments } from '@nx/devkit'
 import { rollup } from 'rollup'
+import {isArray} from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
+import {dateNow} from '@hyperfrontend/immutable-api-utils/built-in-copy/date'
+import {keys} from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import {createPromise} from '@hyperfrontend/immutable-api-utils/built-in-copy/promise'
 import { copyAssets, copyDefaultAssets, copyFundingAsset, copyThirdPartyLicensesAsset } from './lib/assets'
 import { createCJSEntryConfig } from './lib/config-cjs'
 import { createESMEntryConfig } from './lib/config-esm'
@@ -57,7 +61,7 @@ class MemoryMonitor {
       heapTotal: mem.heapTotal,
       external: mem.external,
       rss: mem.rss,
-      timestamp: Date.now(),
+      timestamp: dateNow(),
     }
 
     if (snap.heapUsed > this.peakHeapUsed) {
@@ -175,7 +179,7 @@ class MemoryMonitor {
     const gcTriggered = this.tryGC()
 
     // Yield to event loop
-    await new Promise<void>((resolve) => setImmediate(resolve))
+    await createPromise<void>((resolve) => setImmediate(resolve))
 
     const after = this.snapshot()
     const recovered = before.heapUsed - after.heapUsed
@@ -196,7 +200,7 @@ class MemoryMonitor {
  */
 function normalizeToArray<T>(config: T | T[] | undefined): T[] {
   if (config === undefined) return []
-  return Array.isArray(config) ? config : [config]
+  return isArray(config) ? config : [config]
 }
 
 /**
@@ -221,7 +225,7 @@ async function executeRollupConfig(
   let bundle = await rollup(config)
 
   try {
-    const outputs = Array.isArray(config.output) ? config.output : config.output ? [config.output] : []
+    const outputs = isArray(config.output) ? config.output : config.output ? [config.output] : []
     for (const output of outputs) {
       logger.debug(`Writing output for ${entryLabel}`)
       await bundle.write(output)
@@ -234,7 +238,7 @@ async function executeRollupConfig(
   }
 
   // Clear config reference (caller's copy remains)
-  const configKeys = <(keyof RollupOptions)[]>Object.keys(config)
+  const configKeys = <(keyof RollupOptions)[]>keys(config)
   for (const key of configKeys) {
     ;(<Record<string, unknown>>config)[key] = undefined
   }
@@ -376,7 +380,7 @@ export default async function runExecutor(options: BuildExecutorOptions, context
     umd: [],
   }
 
-  const buildStart = Date.now()
+  const buildStart = dateNow()
 
   try {
     // Build ESM - one entry at a time for memory efficiency
@@ -494,12 +498,12 @@ export default async function runExecutor(options: BuildExecutorOptions, context
       copyAssets(assets, projectRoot, outputPath, workspaceRoot)
     }
 
-    const totalTime = Date.now() - buildStart
+    const totalTime = dateNow() - buildStart
     logger.info(`Successfully built ${projectName} in ${totalTime}ms`)
     memMonitor.logSummary()
     return { success: true }
   } catch (error) {
-    const totalTime = Date.now() - buildStart
+    const totalTime = dateNow() - buildStart
     logger.error(`Failed to build ${projectName} after ${totalTime}ms`)
     memMonitor.logSummary()
     if (error instanceof Error) {

--- a/tools/package/src/executors/build/lib/assets.ts
+++ b/tools/package/src/executors/build/lib/assets.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, copyFileSync, readdirSync, readFileSync, writeFi
 import { join, dirname, basename, relative } from 'node:path'
 import { logger, readJsonFile } from '@nx/devkit'
 import { globSync } from 'glob'
+import {keys} from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { parseRepositoryUrl } from '@hyperfrontend/versioning/repository/parse'
 
 /** License information for a third-party dependency */
@@ -142,11 +143,9 @@ export function getExternalDependencies(projectRoot: string): string[] {
   if (!existsSync(pkgPath)) {
     return []
   }
-
   const pkg = readJsonFile<PackageJson>(pkgPath)
   const deps = pkg.dependencies ?? {}
-
-  return Object.keys(deps).filter((name) => !name.startsWith('@hyperfrontend/'))
+  return keys(deps).filter((name) => !name.startsWith('@hyperfrontend/'))
 }
 
 /**

--- a/tools/package/src/executors/build/lib/declarations.ts
+++ b/tools/package/src/executors/build/lib/declarations.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, cpSync, rmSync, readdirSync, statSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { logger } from '@nx/devkit'
+import {createError} from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
 
 /**
  * Generates TypeScript declarations for all entry points.
@@ -55,7 +56,7 @@ export function generateDeclarations(
   }
 
   if (result.status !== 0) {
-    throw new Error(`tsc failed with exit code ${result.status}`)
+    throw createError(`tsc failed with exit code ${result.status}`)
   }
 
   flattenDeclarationPaths(projectRoot, outputPath, workspaceRoot, discovery)

--- a/tools/package/src/executors/build/lib/entry-resolver.ts
+++ b/tools/package/src/executors/build/lib/entry-resolver.ts
@@ -2,6 +2,7 @@ import type { EntryPoint, EntryPointCategory, EntryPointDiscovery, FormatEntryCo
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { minimatch } from 'minimatch'
+import {isArray} from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
 
 /** Known platform directory names */
 const PLATFORM_DIRS = <const>['browser', 'node']
@@ -211,12 +212,12 @@ export function resolveEntries(config: FormatEntryConfig, discoveredEntries: Ent
   let entries = discoveredEntries
 
   if (entryPatterns !== undefined) {
-    const patterns = Array.isArray(entryPatterns) ? entryPatterns : [entryPatterns]
+    const patterns = isArray(entryPatterns) ? entryPatterns : [entryPatterns]
     entries = entries.filter((entry) => patterns.some((pattern) => matchesPattern(entry, pattern)))
   }
 
   if (excludePatterns !== undefined) {
-    const patterns = Array.isArray(excludePatterns) ? excludePatterns : [excludePatterns]
+    const patterns = isArray(excludePatterns) ? excludePatterns : [excludePatterns]
     entries = entries.filter((entry) => !patterns.some((pattern) => matchesPattern(entry, pattern)))
   }
 

--- a/tools/package/src/executors/build/lib/externals.ts
+++ b/tools/package/src/executors/build/lib/externals.ts
@@ -1,6 +1,11 @@
 import type { PackageJson } from './types'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import {from} from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
+import {createError} from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
+import {parse} from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+import {keys} from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import {createSet} from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
 /**
  * Reads and parses a package.json file.
@@ -10,7 +15,7 @@ import { join } from 'node:path'
  */
 function readPackageJson(packageJsonPath: string): PackageJson {
   if (!existsSync(packageJsonPath)) return {}
-  return <PackageJson>JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+  return <PackageJson>parse(readFileSync(packageJsonPath, 'utf-8'))
 }
 
 /**
@@ -40,8 +45,8 @@ export function isWorkspacePackage(packageName: string): boolean {
 export function getExternalDependencies(packageJsonPath: string, additionalExternal: string[] = [], bundleWorkspaceDeps: boolean): string[] {
   const pkg = readPackageJson(packageJsonPath)
 
-  const deps = Object.keys(pkg.dependencies ?? {})
-  const peerDeps = Object.keys(pkg.peerDependencies ?? {})
+  const deps = keys(pkg.dependencies ?? {})
+  const peerDeps = keys(pkg.peerDependencies ?? {})
 
   // When bundleWorkspaceDeps is true, filter out workspace packages (they'll be bundled)
   // When bundleWorkspaceDeps is false, keep ALL dependencies as external (npm-style)
@@ -50,7 +55,7 @@ export function getExternalDependencies(packageJsonPath: string, additionalExter
   const externalAdditional = bundleWorkspaceDeps ? additionalExternal.filter((dep) => !isWorkspacePackage(dep)) : additionalExternal
 
   // Peer dependencies are ALWAYS external (even workspace packages) since they are optional
-  return Array.from(new Set([...externalRegularDeps, ...peerDeps, ...externalAdditional]))
+  return from(createSet([...externalRegularDeps, ...peerDeps, ...externalAdditional]))
 }
 
 /**
@@ -61,7 +66,7 @@ export function getExternalDependencies(packageJsonPath: string, additionalExter
  * @returns Function that determines if a module ID is external
  */
 export function createExternalFn(external: string[]): (id: string) => boolean {
-  const externalSet = new Set(external)
+  const externalSet = createSet(external)
   return (id: string): boolean => {
     return externalSet.has(id)
   }
@@ -80,7 +85,7 @@ export function validateExternalsConfig(external: string[] | undefined, globals:
 
   const missingGlobals = external.filter((dep) => !globals?.[dep])
   if (missingGlobals.length > 0) {
-    throw new Error(
+    throw createError(
       `IIFE/UMD build failed: Missing globals mapping for external dependencies:\n` +
         missingGlobals.map((d) => `  - ${d}`).join('\n') +
         `\n\nAdd globals mapping or remove from external list to inline.`
@@ -101,7 +106,7 @@ export function createBundleExternalFn(external: string[] | undefined): (id: str
     return () => false
   }
 
-  const externalSet = new Set<string>(external)
+  const externalSet = createSet(external)
   return (id: string): boolean => externalSet.has(id)
 }
 

--- a/tools/package/src/executors/build/lib/logger.ts
+++ b/tools/package/src/executors/build/lib/logger.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@hyperfrontend/logging'
 import { logger as nxLogger } from '@nx/devkit'
+import {dateNow} from '@hyperfrontend/immutable-api-utils/built-in-copy/date'
 import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { createLogger } from '@hyperfrontend/logging'
 
@@ -46,27 +47,27 @@ export const getLogger = () => {
       getLogLevel: logger.getLogLevel,
       channel: (channelPrefix: string) => createApi(prefix ? `${prefix}:${channelPrefix}` : channelPrefix),
       timed<T>(label: string, fn: () => T): T {
-        const start = Date.now()
+        const start = dateNow()
         try {
           const result = fn()
-          const elapsed = Date.now() - start
+          const elapsed = dateNow() - start
           debugFn(prefixMsg(`${label} completed in ${elapsed}ms`))
           return result
         } catch (error) {
-          const elapsed = Date.now() - start
+          const elapsed = dateNow() - start
           errorFn(prefixMsg(`${label} failed after ${elapsed}ms: ${error instanceof Error ? error.message : String(error)}`))
           throw error
         }
       },
       async timedAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
-        const start = Date.now()
+        const start = dateNow()
         try {
           const result = await fn()
-          const elapsed = Date.now() - start
+          const elapsed = dateNow() - start
           debugFn(prefixMsg(`${label} completed in ${elapsed}ms`))
           return result
         } catch (error) {
-          const elapsed = Date.now() - start
+          const elapsed = dateNow() - start
           errorFn(prefixMsg(`${label} failed after ${elapsed}ms: ${error instanceof Error ? error.message : String(error)}`))
           if (error instanceof Error && error.stack) {
             debugFn(prefixMsg(`Stack trace:\n${error.stack}`))

--- a/tools/package/src/executors/build/lib/package-json.ts
+++ b/tools/package/src/executors/build/lib/package-json.ts
@@ -8,6 +8,8 @@ import type {
 } from './types'
 import { join } from 'node:path'
 import { readJsonFile, writeJsonFile } from '@nx/devkit'
+import {entries, fromEntries} from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import {createSet} from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { isWorkspacePackage } from './externals'
 
 /** Fields to inherit from root package.json */
@@ -149,14 +151,14 @@ export function generateExportsFromFormats(
     './package.json': './package.json',
   }
 
-  const esmPaths = new Set(formatOutputs.esm.map((e) => e.exportPath))
-  const cjsPaths = new Set(formatOutputs.cjs.map((e) => e.exportPath))
+  const esmPaths = createSet(formatOutputs.esm.map((e) => e.exportPath))
+  const cjsPaths = createSet(formatOutputs.cjs.map((e) => e.exportPath))
 
   // Source exports are authoritative
   const srcExports = srcPkg?.exports
   if (srcExports && typeof srcExports === 'object') {
     // Parse source exports and generate ONLY those
-    for (const [exportKey, srcPath] of Object.entries(srcExports)) {
+    for (const [exportKey, srcPath] of entries(srcExports)) {
       // Skip package.json export (already added)
       if (exportKey === './package.json') continue
 
@@ -214,9 +216,9 @@ function filterWorkspaceDependencies(srcPkg: PackageJson): PackageJson {
   const filtered = { ...srcPkg }
 
   if (filtered.dependencies) {
-    const externalDeps = Object.entries(filtered.dependencies).filter(([name]) => !isWorkspacePackage(name))
+    const externalDeps = entries(filtered.dependencies).filter(([name]) => !isWorkspacePackage(name))
     if (externalDeps.length > 0) {
-      filtered.dependencies = Object.fromEntries(externalDeps)
+      filtered.dependencies = fromEntries(externalDeps)
     } else {
       delete filtered.dependencies
     }

--- a/tools/package/src/executors/build/lib/rollup-plugins.ts
+++ b/tools/package/src/executors/build/lib/rollup-plugins.ts
@@ -4,6 +4,7 @@ import json from '@rollup/plugin-json'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
+import {createError} from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
 
 /**
  * Creates a node-resolve plugin for entry point builds.
@@ -77,7 +78,7 @@ export function createTypescriptPlugin(
   // multiple workspace packages. Declarations are generated separately via tsc.
   if (bundleWorkspaceDeps) {
     if (!workspaceRoot) {
-      throw new Error('workspaceRoot is required when bundleWorkspaceDeps is true')
+      throw createError('workspaceRoot is required when bundleWorkspaceDeps is true')
     }
     return <Plugin>typescript({
       tsconfig: tsConfigPath,

--- a/tools/package/src/executors/e2e/executor.ts
+++ b/tools/package/src/executors/e2e/executor.ts
@@ -4,6 +4,8 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, unlinkSync, mkdirSync, renameSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '@nx/devkit'
+import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
+import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 
 /**
  * Reads package info from dist package.json.
@@ -14,9 +16,9 @@ import { logger } from '@nx/devkit'
 function getPackageInfo(distPath: string): { name: string; version: string } {
   const pkgPath = join(distPath, 'package.json')
   if (!existsSync(pkgPath)) {
-    throw new Error(`Package.json not found at ${pkgPath}. Has the library been built?`)
+    throw createError(`Package.json not found at ${pkgPath}. Has the library been built?`)
   }
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+  const pkg = parse(readFileSync(pkgPath, 'utf-8'))
   return { name: pkg.name, version: pkg.version }
 }
 
@@ -36,11 +38,11 @@ function packPackage(distPath: string, workspaceRoot: string): string {
     stdio: ['pipe', 'pipe', 'pipe'],
   })
 
-  const packResult = JSON.parse(result)
+  const packResult = parse(result)
   const tarballFilename = packResult[0]?.filename
 
   if (!tarballFilename) {
-    throw new Error('npm pack did not return a tarball filename')
+    throw createError('npm pack did not return a tarball filename')
   }
 
   // Move tarball from dist to tmp/e2e-packs to avoid accidental publishing

--- a/tools/package/src/executors/publish/executor.ts
+++ b/tools/package/src/executors/publish/executor.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '@nx/devkit'
+import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 
 /**
  * Verifies the project is a publishable library.
@@ -35,7 +36,7 @@ function getDistPath(projectRelativePath: string, workspaceRoot: string): string
  */
 function getPackageName(distPath: string): string {
   const pkgPath = join(distPath, 'package.json')
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+  const pkg = parse(readFileSync(pkgPath, 'utf-8'))
   return pkg.name
 }
 
@@ -47,7 +48,7 @@ function getPackageName(distPath: string): string {
  */
 function getPackageVersion(distPath: string): string {
   const pkgPath = join(distPath, 'package.json')
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+  const pkg = parse(readFileSync(pkgPath, 'utf-8'))
   return pkg.version
 }
 

--- a/tools/package/src/executors/version-batch/executor.ts
+++ b/tools/package/src/executors/version-batch/executor.ts
@@ -1,6 +1,7 @@
 import type { ExecutorContext } from '@nx/devkit'
 import type { VersionBatchExecutorSchema } from './schema'
 import { createProjectGraphAsync } from '@nx/devkit'
+import { keys } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { getCurrentBranch } from '@hyperfrontend/versioning/git/operations'
 import { isInUnstableGitState } from '../version/lib/is-in-unstable-git-state'
 import { getLogger } from '../version/lib/logger'
@@ -76,7 +77,7 @@ export default async function versionBatchExecutor(
 
     // Get project graph
     const projectGraph = await createProjectGraphAsync()
-    logger.debug(`Loaded project graph with ${Object.keys(projectGraph.nodes).length} nodes`)
+    logger.debug(`Loaded project graph with ${keys(projectGraph.nodes).length} nodes`)
 
     // Detect affected libraries
     const affectedLibraries = await getAffectedLibraries(workspaceRoot, projectGraph, base, head)

--- a/tools/package/src/executors/version-batch/lib/create-batch-commit.ts
+++ b/tools/package/src/executors/version-batch/lib/create-batch-commit.ts
@@ -1,3 +1,4 @@
+import { createError } from '@hyperfrontend/immutable-api-utils/built-in-copy/error'
 import { commit, stage } from '@hyperfrontend/versioning/git/operations'
 
 /**
@@ -10,17 +11,17 @@ import { commit, stage } from '@hyperfrontend/versioning/git/operations'
  */
 export async function createBatchCommit(workspaceRoot: string, files: string[], libraries: string[]): Promise<string> {
   if (files.length === 0) {
-    throw new Error('No files to commit')
+    throw createError('No files to commit')
   }
 
   if (libraries.length === 0) {
-    throw new Error('No libraries to include in commit message')
+    throw createError('No libraries to include in commit message')
   }
 
   // Stage all modified files
   const staged = stage(files, { cwd: workspaceRoot })
   if (!staged) {
-    throw new Error('Failed to stage files for commit')
+    throw createError('Failed to stage files for commit')
   }
 
   // Create commit message

--- a/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
+++ b/tools/package/src/executors/version-batch/lib/get-affected-libraries.ts
@@ -1,4 +1,7 @@
 import type { ProjectGraph } from '@nx/devkit'
+import { from } from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
+import { entries } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { getChangedFilesBetween } from '@hyperfrontend/versioning/git/operations'
 
 /**
@@ -27,7 +30,7 @@ export async function getAffectedLibraries(
   }
 
   // Map files to projects
-  const affectedProjects = new Set<string>()
+  const affectedProjects = createSet<string>()
 
   for (const file of changedFiles) {
     const project = findProjectForFile(file, projectGraph)
@@ -37,7 +40,7 @@ export async function getAffectedLibraries(
   }
 
   // Filter to libraries with version target
-  const librariesWithVersionTarget = Array.from(affectedProjects).filter((projectName) => {
+  const librariesWithVersionTarget = from(affectedProjects).filter((projectName) => {
     const project = projectGraph.nodes[projectName]
     if (!project) {
       return false
@@ -67,7 +70,7 @@ function findProjectForFile(filePath: string, projectGraph: ProjectGraph): strin
 
   // Find the project whose root is a prefix of the file path
   // Sort by root length descending to find the most specific match
-  const projects = Object.entries(projectGraph.nodes)
+  const projects = entries(projectGraph.nodes)
     .map(([name, node]) => ({
       name,
       root: node.data.root,

--- a/tools/package/src/executors/version/lib/replace-dependency-version.ts
+++ b/tools/package/src/executors/version/lib/replace-dependency-version.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
+import { parse, stringify } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 
 /**
  * Dependency sections in package.json that can contain version references.
@@ -16,7 +17,7 @@ const DEPENDENCY_SECTIONS: readonly string[] = ['dependencies', 'devDependencies
  */
 export function replaceDependencyVersion(filePath: string, packageName: string, newVersion: string): boolean {
   const content = readFileSync(filePath, 'utf-8')
-  const pkg = <Record<string, unknown>>JSON.parse(content)
+  const pkg = <Record<string, unknown>>parse(content)
 
   let changed = false
 
@@ -32,7 +33,7 @@ export function replaceDependencyVersion(filePath: string, packageName: string, 
     return false
   }
 
-  const newContent = JSON.stringify(pkg, null, 2) + '\n'
+  const newContent = stringify(pkg, null, 2) + '\n'
   writeFileSync(filePath, newContent, 'utf-8')
   return true
 }
@@ -78,7 +79,7 @@ function replaceTgzInValue(value: string, tgzPrefix: string, newTgzName: string)
  */
 export function replaceTgzReference(filePath: string, packageName: string, tgzPrefix: string, newTgzName: string): boolean {
   const content = readFileSync(filePath, 'utf-8')
-  const pkg = <Record<string, unknown>>JSON.parse(content)
+  const pkg = <Record<string, unknown>>parse(content)
 
   let changed = false
 
@@ -100,7 +101,7 @@ export function replaceTgzReference(filePath: string, packageName: string, tgzPr
     return false
   }
 
-  const newContent = JSON.stringify(pkg, null, 2) + '\n'
+  const newContent = stringify(pkg, null, 2) + '\n'
   writeFileSync(filePath, newContent, 'utf-8')
   return true
 }


### PR DESCRIPTION
## Description

This PR delivers two security fixes and a broad refactoring of internal tooling to adopt `immutable-api-utils` and eliminate duplicated test/utility code across the ESLint rules package.

## Type of Change

<!-- Uncomment the relevant type(s) -->
🐛 Bug fix | ♻️ Refactor | 🔒 Security | 🔧 Build/Config

## Changes Made

- **Security:** Patched vulnerable `serialize-javascript` transitive dependency via `package.json` overrides (bumped from `7.0.3` to `>=7.0.5`)
- **Security:** Added `--` end-of-options separator to `git fetch` and `git pull` calls in `lib-versioning` to prevent git argument injection attacks
- **Refactor:** Migrated `plugin-features`, `tool-app`, `tool-package`, and `tools/eslint-rules` to use `immutable-api-utils` instead of mutable alternatives; removed redundant `eslint.config.cjs` overrides that are no longer needed after this migration
- **Refactor:** Extracted shared testing infrastructure in `tools/eslint-rules` into dedicated modules (`src/testing/fixtures.ts`, `src/testing/rule-tester.ts`, `src/testing/temp-workspace.ts`) and shared utilities (`src/utils/fs.ts`, `src/utils/logger.ts`, `src/utils/workspace.ts`, `src/utils/nx-project.ts`) to eliminate code duplication across all ESLint rule implementations and their specs
- **Chore:** Added `eslint-rules` Copilot skill (`.github/skills/eslint-rules/SKILL.md`) to capture authoring conventions for custom ESLint rules in this monorepo
- **Chore:** Updated `lib-versioning` package version

## Testing

- Existing unit tests in `tools/eslint-rules/src/rules/**/*.spec.ts` cover the refactored rule implementations
- New dedicated spec files added for each new testing/utility module: `fixtures.spec.ts`, `rule-tester.spec.ts`, `temp-workspace.spec.ts`, `fs.spec.ts`, `logger.spec.ts`, `workspace.spec.ts`, `nx-project.spec.ts`, `import-validation.spec.ts`
- Security fix for git argument injection is covered by the existing `lib-versioning` test suite and validated by code inspection of the `--` separator addition

## Screenshots/Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## AI Assistance

GitHub Copilot (Claude Sonnet 4.6) was used to draft this PR description based on the branch diff. All code changes were authored by the contributor; AI was not involved in writing the implementation.

## Additional Notes

The `serialize-javascript` vulnerability affects `@rollup/plugin-terser`. The override pins it to `>=7.0.5` which resolves the known CVE while staying current with future patches.

The git argument injection fix (`lib-versioning`) is low-risk: inserting `--` before the remote name in `git fetch` and `git pull` is the idiomatic POSIX convention to prevent user-controlled strings from being interpreted as CLI flags (e.g. `--upload-pack=<cmd>`). No behavioral change for valid remote names.
