### PR TITLE
Week 2026 04 06 1

### DIFF
--- a/apps/docs-site/project.json
+++ b/apps/docs-site/project.json
@@ -21,7 +21,7 @@
     "build": {
       "executor": "@hyperfrontend/app:build",
       "dependsOn": ["install"],
-      "outputs": ["{projectRoot}/.next", "{projectRoot}/out"],
+      "outputs": ["{projectRoot}/.generated", "{projectRoot}/.next", "{projectRoot}/out"],
       "options": {
         "command": "npm run build"
       }

--- a/apps/docs-site/scripts/generate-docs.ts
+++ b/apps/docs-site/scripts/generate-docs.ts
@@ -10,6 +10,8 @@ import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 import { createURL } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
 import { logger } from '@hyperfrontend/logging'
 
+logger.setLogLevel('log')
+
 /**
  * Checks if a line contains a URL pointing to the docs site (www.hyperfrontend.dev).
  * Uses proper URL parsing to validate the host instead of substring matching.

--- a/apps/docs-site/scripts/validate-links.ts
+++ b/apps/docs-site/scripts/validate-links.ts
@@ -4,6 +4,8 @@ import { resolve, join, dirname, relative } from 'node:path'
 import { glob } from 'glob'
 import { logger } from '@hyperfrontend/logging'
 
+logger.setLogLevel('log')
+
 const WORKSPACE_ROOT = resolve(__dirname, '../../..')
 const DOCS_SITE_ROOT = resolve(__dirname, '..')
 const GENERATED_DIR = join(DOCS_SITE_ROOT, '.generated')

--- a/apps/package-e2e/nexus/package-lock.json
+++ b/apps/package-e2e/nexus/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hyperfrontend/e2e-nexus",
       "version": "0.0.0",
       "dependencies": {
-        "@hyperfrontend/nexus": "file:../../../tmp/e2e-packs/hyperfrontend-nexus-1.1.0.tgz"
+        "@hyperfrontend/nexus": "file:../../../tmp/e2e-packs/hyperfrontend-nexus-1.1.1.tgz"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -517,9 +517,9 @@
       "license": "MIT"
     },
     "node_modules/@hyperfrontend/nexus": {
-      "version": "1.1.0",
-      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-nexus-1.1.0.tgz",
-      "integrity": "sha512-0SxbqOqbGiK61NUUoLECEyK+ceBmNaRFohGA9pxD35nOcLUDxRSkoHPvTJ+2Kq2F7YLSFz4ZEY8WmG3bM4ATyg==",
+      "version": "1.1.1",
+      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-nexus-1.1.1.tgz",
+      "integrity": "sha512-hn9jabzp26s4KVbsJ0Na2mO+SeQSxl3fPNYCLiz+9zhr2pv9atpmGbeQcpUn9FReRWuz7JUnhBHC2N1gU0n+tA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0",

--- a/apps/package-e2e/project-scope/package-lock.json
+++ b/apps/package-e2e/project-scope/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hyperfrontend/e2e-project-scope",
       "version": "0.0.0",
       "dependencies": {
-        "@hyperfrontend/project-scope": "file:../../../tmp/e2e-packs/hyperfrontend-project-scope-0.2.0.tgz"
+        "@hyperfrontend/project-scope": "file:../../../tmp/e2e-packs/hyperfrontend-project-scope-0.2.1.tgz"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -516,9 +516,9 @@
       "license": "MIT"
     },
     "node_modules/@hyperfrontend/project-scope": {
-      "version": "0.2.0",
-      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-project-scope-0.2.0.tgz",
-      "integrity": "sha512-LAp5GpdfhefWjjpUM5AyquBvgNAPW68L+SFh/GDDwCVxFjIJHtXuXcEhj5cVEvagzOpWWI//D/OTBCcbSyl+qQ==",
+      "version": "0.2.1",
+      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-project-scope-0.2.1.tgz",
+      "integrity": "sha512-bLq0NjTCXe3lWz/f+PCDlERE27rlunbQcykjWK2a0tWYIkiLwETnvz5TZ42nlXRRtSJf7k6lpbvlW+/ebPLrAA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0",

--- a/apps/package-e2e/ui-utils/package-lock.json
+++ b/apps/package-e2e/ui-utils/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hyperfrontend/e2e-ui-utils",
       "version": "0.0.0",
       "dependencies": {
-        "@hyperfrontend/ui-utils": "file:../../../tmp/e2e-packs/hyperfrontend-ui-utils-0.0.4.tgz"
+        "@hyperfrontend/ui-utils": "file:../../../tmp/e2e-packs/hyperfrontend-ui-utils-0.0.5.tgz"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -517,9 +517,9 @@
       "license": "MIT"
     },
     "node_modules/@hyperfrontend/ui-utils": {
-      "version": "0.0.4",
-      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-ui-utils-0.0.4.tgz",
-      "integrity": "sha512-S7zqDs8p2QR5FrqhIXrW5/qRsoJb0OoGW+2ih013kiZtk48TeZF4Xu0t/a8snYDRKHInaJ8P77w7bx0w0eTH5Q==",
+      "version": "0.0.5",
+      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-ui-utils-0.0.5.tgz",
+      "integrity": "sha512-95RRCBL5bMiv7esw9zxxgO1ni1eYmXfOhyU5QoOkqt3ywO72wpIaA/KvcNhAt9/pBMtR65GiO+uMDitNXS0xsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0",

--- a/apps/package-e2e/versioning/package-lock.json
+++ b/apps/package-e2e/versioning/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hyperfrontend/e2e-versioning",
       "version": "0.0.0",
       "dependencies": {
-        "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.1.tgz"
+        "@hyperfrontend/versioning": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.2.tgz"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -516,9 +516,9 @@
       "license": "MIT"
     },
     "node_modules/@hyperfrontend/versioning": {
-      "version": "0.5.1",
-      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.1.tgz",
-      "integrity": "sha512-DPQ4HHjwUER4KKnLInX5EHZbxsEiYHmooo1cxLA2ZEise3rpz1GJz8cSuIuPeiqqDqGGZ7z2qSAciopx1Ki8vA==",
+      "version": "0.5.2",
+      "resolved": "file:../../../tmp/e2e-packs/hyperfrontend-versioning-0.5.2.tgz",
+      "integrity": "sha512-b/EIAJ9YrxEbOQLH/N9EIcT4mADlwfHBU76VkFeIHKvwCijWucXVo4j22OAfYuNIj9+G1dq1HoYAIXJ+dJQzbA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0",


### PR DESCRIPTION
## Description

This PR improves docs-site generation reliability and observability in CI and Vercel/Nx builds, and refreshes package-e2e lockfile integrity metadata.

## Type of Change

- 🐛 Bug fix
- 🔧 Build/Config

## Changes Made

- Added `.generated` to docs-site build outputs in Nx project config so generated API/docs artifacts are tracked as part of build outputs and not treated as stale cache state.
- Enabled explicit log-level output in docs-site scripts to surface site generation and link-validation details during builds.
- Updated `package-lock.json` integrity entries for package-e2e apps (`nexus`, `project-scope`, `ui-utils`, `versioning`) under workspace package updates.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests as needed
- [ ] I have updated relevant documentation
- [ ] I have used `npm run commit` for conventional commit messages

## AI Assistance

GitHub Copilot was used to generate this PR description.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
