### PR TITLE
Add Library Architecture Pages and Fix Docs-Site API Reference

### DIFF
--- a/apps/docs-site/next.config.js
+++ b/apps/docs-site/next.config.js
@@ -1,17 +1,12 @@
-const { join } = require('node:path')
-
-const isProduction = process.env.NODE_ENV === 'production'
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Only use static export for production builds
-  ...(isProduction && { output: 'export' }),
+  // Only use static export on Vercel (VERCEL env var is set automatically)
+  ...(process.env.VERCEL && { output: 'export' }),
   trailingSlash: true,
   images: {
     unoptimized: true,
   },
-  outputFileTracingRoot: join(__dirname, '../../'),
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/docs-site/package.json
+++ b/apps/docs-site/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run generate && npm run validate-links && next build",
+    "build": "npm run generate && npm run validate-links && NODE_OPTIONS='--max-old-space-size=4096' next build",
     "dev": "npm run build && next start --port 3000",
     "start": "next start",
     "generate": "npx tsx scripts/generate-docs.ts",

--- a/apps/docs-site/package.json
+++ b/apps/docs-site/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3000",
     "build": "npm run generate && npm run validate-links && next build",
+    "dev": "npm run build && next start --port 3000",
     "start": "next start",
     "generate": "npx tsx scripts/generate-docs.ts",
     "validate-links": "npx tsx scripts/validate-links.ts"

--- a/apps/docs-site/src/app/architecture/page.tsx
+++ b/apps/docs-site/src/app/architecture/page.tsx
@@ -1,13 +1,34 @@
 import { Footer } from '@/components/footer'
 import { Header } from '@/components/header'
+import { ReadmeContent } from '@/components/readme-content'
+import { getRootArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
 
-export default function ArchitecturePage() {
+export default async function ArchitecturePage() {
+  const content = getRootArchitecture()
+
+  if (!content) {
+    return (
+      <>
+        <Header />
+        <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+          <h1 className="font-display text-4xl font-bold text-slate-900 dark:text-white">Architecture</h1>
+          <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">Architecture documentation is coming soon. Check back later.</p>
+        </main>
+        <Footer />
+      </>
+    )
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
   return (
     <>
       <Header />
       <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <h1 className="font-display text-4xl font-bold text-slate-900 dark:text-white">Architecture</h1>
-        <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">Architecture documentation is coming soon. Check back later.</p>
+        <ReadmeContent html={html} mermaidDiagrams={diagrams} />
       </main>
       <Footer />
     </>

--- a/apps/docs-site/src/app/docs/libraries/network-protocol/architecture/page.tsx
+++ b/apps/docs-site/src/app/docs/libraries/network-protocol/architecture/page.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb } from '@/components/breadcrumb'
+import { ReadmeContent } from '@/components/readme-content'
+import { getLibraryArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export default async function NetworkProtocolArchitecturePage() {
+  const content = getLibraryArchitecture('network-protocol')
+
+  if (!content) {
+    notFound()
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
+  return (
+    <>
+      <Breadcrumb />
+
+      <div className="mb-6">
+        <Link href="/docs/libraries/network-protocol" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          ← Back to @hyperfrontend/network-protocol
+        </Link>
+      </div>
+
+      <ReadmeContent html={html} mermaidDiagrams={diagrams} />
+    </>
+  )
+}

--- a/apps/docs-site/src/app/docs/libraries/nexus/architecture/page.tsx
+++ b/apps/docs-site/src/app/docs/libraries/nexus/architecture/page.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb } from '@/components/breadcrumb'
+import { ReadmeContent } from '@/components/readme-content'
+import { getLibraryArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export default async function NexusArchitecturePage() {
+  const content = getLibraryArchitecture('nexus')
+
+  if (!content) {
+    notFound()
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
+  return (
+    <>
+      <Breadcrumb />
+
+      <div className="mb-6">
+        <Link href="/docs/libraries/nexus" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          ← Back to @hyperfrontend/nexus
+        </Link>
+      </div>
+
+      <ReadmeContent html={html} mermaidDiagrams={diagrams} />
+    </>
+  )
+}

--- a/apps/docs-site/src/app/docs/libraries/project-scope/architecture/page.tsx
+++ b/apps/docs-site/src/app/docs/libraries/project-scope/architecture/page.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb } from '@/components/breadcrumb'
+import { ReadmeContent } from '@/components/readme-content'
+import { getLibraryArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export default async function ProjectScopeArchitecturePage() {
+  const content = getLibraryArchitecture('project-scope')
+
+  if (!content) {
+    notFound()
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
+  return (
+    <>
+      <Breadcrumb />
+
+      <div className="mb-6">
+        <Link href="/docs/libraries/project-scope" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          ← Back to @hyperfrontend/project-scope
+        </Link>
+      </div>
+
+      <ReadmeContent html={html} mermaidDiagrams={diagrams} />
+    </>
+  )
+}

--- a/apps/docs-site/src/app/docs/libraries/state-machine/architecture/page.tsx
+++ b/apps/docs-site/src/app/docs/libraries/state-machine/architecture/page.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb } from '@/components/breadcrumb'
+import { ReadmeContent } from '@/components/readme-content'
+import { getLibraryArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export default async function StateMachineArchitecturePage() {
+  const content = getLibraryArchitecture('state-machine')
+
+  if (!content) {
+    notFound()
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
+  return (
+    <>
+      <Breadcrumb />
+
+      <div className="mb-6">
+        <Link href="/docs/libraries/state-machine" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          ← Back to @hyperfrontend/state-machine
+        </Link>
+      </div>
+
+      <ReadmeContent html={html} mermaidDiagrams={diagrams} />
+    </>
+  )
+}

--- a/apps/docs-site/src/app/docs/libraries/versioning/architecture/page.tsx
+++ b/apps/docs-site/src/app/docs/libraries/versioning/architecture/page.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb } from '@/components/breadcrumb'
+import { ReadmeContent } from '@/components/readme-content'
+import { getLibraryArchitecture } from '@/lib/docs-loader'
+import { markdownToHtml } from '@/lib/markdown'
+import { extractMermaidBlocks } from '@/lib/mermaid-utils'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export default async function VersioningArchitecturePage() {
+  const content = getLibraryArchitecture('versioning')
+
+  if (!content) {
+    notFound()
+  }
+
+  const { processedContent, diagrams } = extractMermaidBlocks(content)
+  const html = await markdownToHtml(processedContent)
+
+  return (
+    <>
+      <Breadcrumb />
+
+      <div className="mb-6">
+        <Link href="/docs/libraries/versioning" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          ← Back to @hyperfrontend/versioning
+        </Link>
+      </div>
+
+      <ReadmeContent html={html} mermaidDiagrams={diagrams} />
+    </>
+  )
+}

--- a/apps/docs-site/src/components/api-reference/module-grouped-view.tsx
+++ b/apps/docs-site/src/components/api-reference/module-grouped-view.tsx
@@ -236,7 +236,12 @@ export function ModuleGroupedView({ data, searchQuery = '' }: ModuleGroupedViewP
 function formatModuleName(name: string): string {
   return name
     .split('/')
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .map((part) =>
+      part
+        .split('-')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    )
     .join(' / ')
 }
 

--- a/apps/docs-site/src/components/api-reference/parameter-list.tsx
+++ b/apps/docs-site/src/components/api-reference/parameter-list.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import type { Parameter } from './types'
 import { TypeLink } from './type-link'
+import { getDescription } from './type-utils'
 
 interface ParameterListProps {
   parameters: Parameter[]
@@ -23,7 +26,7 @@ export function ParameterList({ parameters, paramDescriptions = {} }: ParameterL
           </thead>
           <tbody>
             {parameters.map((param) => {
-              const description = paramDescriptions[param.name] || ''
+              const description = paramDescriptions[param.name] || getDescription(param.comment)
               const isOptional = param.flags?.isOptional
               const isRest = param.flags?.isRest
 

--- a/apps/docs-site/src/components/api-reference/type-utils.ts
+++ b/apps/docs-site/src/components/api-reference/type-utils.ts
@@ -164,7 +164,8 @@ export function getParamDescriptions(comment: Comment | undefined): Record<strin
     .filter((tag) => tag.tag === '@param' && tag.name)
     .forEach((tag) => {
       if (tag.name) {
-        result[tag.name] = renderTextBlocks(tag.content)
+        const raw = renderTextBlocks(tag.content).trim()
+        result[tag.name] = raw.startsWith('-') ? raw.slice(1).trim() : raw
       }
     })
   return result

--- a/apps/docs-site/src/components/breadcrumb.tsx
+++ b/apps/docs-site/src/components/breadcrumb.tsx
@@ -11,6 +11,7 @@ const pathLabels: Record<string, string> = {
   contributing: 'Contributing',
   'quick-start': 'Quick Start',
   'core-concepts': 'Core Concepts',
+  architecture: 'Architecture',
   nexus: '@hyperfrontend/nexus',
   'network-protocol': '@hyperfrontend/network-protocol',
   cryptography: '@hyperfrontend/cryptography',
@@ -19,6 +20,8 @@ const pathLabels: Record<string, string> = {
   utils: '@hyperfrontend/utils',
   logging: '@hyperfrontend/logging',
   features: '@hyperfrontend/features',
+  'project-scope': '@hyperfrontend/project-scope',
+  versioning: '@hyperfrontend/versioning',
 }
 
 export function Breadcrumb() {


### PR DESCRIPTION
## Description

Adds architecture pages for five libraries in the docs-site, fixes parameter description extraction in the API reference, and improves the dev and build workflow for the docs-site.

## Type of Change

✨ Feature | 🐛 Bug fix | 🔧 Build/Config

## Changes Made

- Added architecture sub-pages for `network-protocol`, `nexus`, `project-scope`, `state-machine`, and `versioning` libraries, each rendering Mermaid diagrams extracted from ARCHITECTURE.md files
- Improved the top-level `/architecture` page to use the same Mermaid-aware rendering approach
- Fixed `getParamDescriptions` to strip leading dashes from JSDoc `@param` tag content, preventing malformed descriptions in the API reference
- Added fallback in `ParameterList` to resolve a parameter's description from its inline `comment` field when no entry exists in `paramDescriptions`
- Fixed `formatModuleName` to properly title-case hyphenated module names (e.g. `state-machine` → `State Machine`)
- Changed `next.config.js` to use the `VERCEL` environment variable for static export detection instead of `NODE_ENV === 'production'`, enabling local `next dev` to serve a dynamic build
- Increased Node.js heap to 4 GB during `next build` to prevent OOM failures
- Updated the `dev` script to run a full build before starting the server (`npm run build && next start`) so link validation and doc generation always run locally

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests as needed
- [ ] I have updated relevant documentation
- [ ] I have used `npm run commit` for conventional commit messages

## AI Assistance

GitHub Copilot was used to generate this PR description.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
