### PR TITLE
Add No-Inline-Type-Literal ESLint Rule and Apply Across Workspace

### DIFF
--- a/apps/docs-site/src/app/docs/acknowledgments/page.tsx
+++ b/apps/docs-site/src/app/docs/acknowledgments/page.tsx
@@ -11,8 +11,14 @@ export const metadata: Metadata = {
   description: 'Credits and gratitude to supporters, contributors, and sources of inspiration for hyperfrontend.',
 }
 
+/** Display metadata (icon + label) for a contribution type */
+type ContributionEmoji = {
+  emoji: string
+  label: string
+}
+
 /** Map contribution types to emoji and label */
-const CONTRIBUTION_EMOJI: Record<string, { emoji: string; label: string }> = {
+const CONTRIBUTION_EMOJI: Record<string, ContributionEmoji> = {
   code: { emoji: '💻', label: 'Code' },
   doc: { emoji: '📖', label: 'Documentation' },
   infra: { emoji: '🚇', label: 'Infrastructure' },
@@ -47,7 +53,10 @@ const CONTRIBUTION_EMOJI: Record<string, { emoji: string; label: string }> = {
   research: { emoji: '🔬', label: 'Research' },
 }
 
-function ContributorCard({ contributor }: { contributor: Contributor }) {
+/** Props for the inline {@link ContributorCard} component */
+type ContributorCardProps = { contributor: Contributor }
+
+function ContributorCard({ contributor }: ContributorCardProps) {
   return (
     <a
       href={contributor.profile}
@@ -78,7 +87,10 @@ function ContributorCard({ contributor }: { contributor: Contributor }) {
   )
 }
 
-function ContributorsSection({ contributors }: { contributors: Contributor[] }) {
+/** Props for the inline {@link ContributorsSection} component */
+type ContributorsSectionProps = { contributors: Contributor[] }
+
+function ContributorsSection({ contributors }: ContributorsSectionProps) {
   if (contributors.length === 0) {
     return null
   }

--- a/apps/docs-site/src/app/docs/contributing/page.tsx
+++ b/apps/docs-site/src/app/docs/contributing/page.tsx
@@ -203,7 +203,9 @@ export default function ContributingPage() {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function CheckIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path
@@ -215,7 +217,7 @@ function CheckIcon({ className }: { className?: string }) {
   )
 }
 
-function GitHubIcon({ className }: { className?: string }) {
+function GitHubIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="currentColor" viewBox="0 0 24 24">
       <path
@@ -227,7 +229,7 @@ function GitHubIcon({ className }: { className?: string }) {
   )
 }
 
-function DocumentIcon({ className }: { className?: string }) {
+function DocumentIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path

--- a/apps/docs-site/src/app/docs/core-concepts/page.tsx
+++ b/apps/docs-site/src/app/docs/core-concepts/page.tsx
@@ -184,7 +184,9 @@ export default function CoreConceptsPage() {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+type CheckIconProps = { className?: string }
+
+function CheckIcon({ className }: CheckIconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path

--- a/apps/docs-site/src/app/docs/layout.tsx
+++ b/apps/docs-site/src/app/docs/layout.tsx
@@ -2,7 +2,9 @@ import { Footer } from '@/components/footer'
 import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
 
-export default function DocsLayout({ children }: { children: React.ReactNode }) {
+type DocsLayoutProps = { children: React.ReactNode }
+
+export default function DocsLayout({ children }: DocsLayoutProps) {
   return (
     <>
       <Header />

--- a/apps/docs-site/src/app/docs/libraries/libraries-page-content.tsx
+++ b/apps/docs-site/src/app/docs/libraries/libraries-page-content.tsx
@@ -313,6 +313,11 @@ export function LibrariesPageContent() {
   )
 }
 
+/** Props for {@link ApiCard}: a library card extended with its position in the grid */
+interface ApiCardProps extends LibraryCardData {
+  index: number
+}
+
 /**
  * API Card component with flash animation
  * @param root0
@@ -322,7 +327,7 @@ export function LibrariesPageContent() {
  * @param root0.keywords
  * @param root0.index
  */
-function ApiCard({ title, description, href, keywords, index }: LibraryCardData & { index: number }) {
+function ApiCard({ title, description, href, keywords, index }: ApiCardProps) {
   const cardRef = useRef<HTMLAnchorElement>(null)
   const [flashColor, setFlashColor] = useState<string | null>(null)
   const [flashDirection, setFlashDirection] = useState<'left' | 'right'>('left')
@@ -398,7 +403,9 @@ function ApiCard({ title, description, href, keywords, index }: LibraryCardData 
   )
 }
 
-function SearchIcon({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function SearchIcon({ className }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path
@@ -410,7 +417,7 @@ function SearchIcon({ className }: { className?: string }) {
   )
 }
 
-function CloseIcon({ className }: { className?: string }) {
+function CloseIcon({ className }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -418,7 +425,7 @@ function CloseIcon({ className }: { className?: string }) {
   )
 }
 
-function ArrowRightIcon({ className }: { className?: string }) {
+function ArrowRightIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />

--- a/apps/docs-site/src/app/docs/page.tsx
+++ b/apps/docs-site/src/app/docs/page.tsx
@@ -134,7 +134,9 @@ export default function DocsPage() {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+type CheckIconProps = { className?: string }
+
+function CheckIcon({ className }: CheckIconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path

--- a/apps/docs-site/src/app/layout.tsx
+++ b/apps/docs-site/src/app/layout.tsx
@@ -33,7 +33,9 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+type RootLayoutProps = { children: React.ReactNode }
+
+export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>

--- a/apps/docs-site/src/app/not-found.tsx
+++ b/apps/docs-site/src/app/not-found.tsx
@@ -111,13 +111,16 @@ export default function NotFound() {
   )
 }
 
+/** Props for {@link GlitchNumber} */
+type GlitchNumberProps = { digit: string; delay: number }
+
 /**
  * A glitchy animated number for the 404 display.
  * @param root0
  * @param root0.digit
  * @param root0.delay
  */
-function GlitchNumber({ digit, delay }: { digit: string; delay: number }) {
+function GlitchNumber({ digit, delay }: GlitchNumberProps) {
   return (
     <span
       className="relative inline-block font-display text-7xl font-black text-primary-600 dark:text-primary-400 sm:text-8xl md:text-9xl animate-pulse"
@@ -171,6 +174,9 @@ function FloatingZero() {
   )
 }
 
+/** Props for {@link Particle} */
+type ParticleProps = { className: string; size: 'sm' | 'md' | 'lg'; delay: number }
+
 /**
  * Floating decorative particle.
  * @param root0
@@ -178,7 +184,7 @@ function FloatingZero() {
  * @param root0.size
  * @param root0.delay
  */
-function Particle({ className, size, delay }: { className: string; size: 'sm' | 'md' | 'lg'; delay: number }) {
+function Particle({ className, size, delay }: ParticleProps) {
   const sizeClasses = {
     sm: 'h-1.5 w-1.5',
     md: 'h-2 w-2',
@@ -197,12 +203,15 @@ function Particle({ className, size, delay }: { className: string; size: 'sm' | 
   )
 }
 
+/** Props for {@link SuggestionCard} */
+type SuggestionCardProps = { suggestion: LinkSuggestion }
+
 /**
  * A card displaying a link suggestion.
  * @param root0
  * @param root0.suggestion
  */
-function SuggestionCard({ suggestion }: { suggestion: LinkSuggestion }) {
+function SuggestionCard({ suggestion }: SuggestionCardProps) {
   return (
     <Link
       href={suggestion.href}
@@ -219,7 +228,10 @@ function SuggestionCard({ suggestion }: { suggestion: LinkSuggestion }) {
   )
 }
 
-function HomeIcon({ className }: { className?: string }) {
+/** Common props for not-found icons */
+type IconProps = { className?: string }
+
+function HomeIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path
@@ -232,7 +244,7 @@ function HomeIcon({ className }: { className?: string }) {
   )
 }
 
-function BugIcon({ className }: { className?: string }) {
+function BugIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
@@ -240,7 +252,7 @@ function BugIcon({ className }: { className?: string }) {
   )
 }
 
-function ArrowRightIcon({ className }: { className?: string }) {
+function ArrowRightIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />

--- a/apps/docs-site/src/app/page.tsx
+++ b/apps/docs-site/src/app/page.tsx
@@ -5,10 +5,20 @@ import { ScrollToExplore } from '@/components/scroll-to-explore'
 import { ValueProposition } from '@/components/value-proposition'
 
 /**
+ * Featured package tile shown on the landing page: display name, link target,
+ * and a priority used to sort the list ascending.
+ */
+type FeaturedPackage = {
+  name: string
+  href: string
+  priority: number
+}
+
+/**
  * High-value packages to display on the landing page, sorted by priority.
  * Lower priority numbers appear first.
  */
-const FEATURED_PACKAGES: Array<{ name: string; href: string; priority: number }> = [
+const FEATURED_PACKAGES: Array<FeaturedPackage> = [
   { name: '@hyperfrontend/nexus', href: '/docs/libraries/nexus', priority: 1 },
   { name: '@hyperfrontend/state-machine', href: '/docs/libraries/state-machine', priority: 2 },
   { name: '@hyperfrontend/data-utils', href: '/docs/libraries/utils/data', priority: 3 },
@@ -130,7 +140,10 @@ export default function HomePage() {
   )
 }
 
-function PackageTag({ name, href }: { name: string; href: string }) {
+/** Props for {@link PackageTag} */
+type PackageTagProps = { name: string; href: string }
+
+function PackageTag({ name, href }: PackageTagProps) {
   return (
     <a
       href={href}
@@ -141,7 +154,10 @@ function PackageTag({ name, href }: { name: string; href: string }) {
   )
 }
 
-function NpmIcon({ className }: { className?: string }) {
+/** Common props for landing-page icons */
+type IconProps = { className?: string }
+
+function NpmIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331zM10.665 10H12v2.667h-1.335V10z" />
@@ -149,7 +165,15 @@ function NpmIcon({ className }: { className?: string }) {
   )
 }
 
-function ArchitectureCard({ title, description, icon, href }: { title: string; description: string; icon: React.ReactNode; href: string }) {
+/** Props for {@link ArchitectureCard} */
+type ArchitectureCardProps = {
+  title: string
+  description: string
+  icon: React.ReactNode
+  href: string
+}
+
+function ArchitectureCard({ title, description, icon, href }: ArchitectureCardProps) {
   return (
     <a
       href={href}
@@ -196,7 +220,7 @@ function BrokerIcon() {
   )
 }
 
-function ArrowRightIcon({ className }: { className?: string }) {
+function ArrowRightIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />

--- a/apps/docs-site/src/components/api-reference/api-search-filter.tsx
+++ b/apps/docs-site/src/components/api-reference/api-search-filter.tsx
@@ -3,17 +3,22 @@
 import { useState, useCallback } from 'react'
 import { values } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
+/**
+ * Per-category counts displayed alongside the API search filter buttons.
+ */
+interface ApiCategoryCounts {
+  functions: number
+  classes: number
+  interfaces: number
+  types: number
+  variables: number
+  enums: number
+}
+
 interface ApiSearchFilterProps {
   onSearch: (query: string) => void
   onFilterChange: (filters: ApiFilterState) => void
-  counts: {
-    functions: number
-    classes: number
-    interfaces: number
-    types: number
-    variables: number
-    enums: number
-  }
+  counts: ApiCategoryCounts
 }
 
 export interface ApiFilterState {
@@ -177,7 +182,9 @@ function FilterButton({ active, onClick, color, children }: FilterButtonProps) {
   )
 }
 
-function SearchIcon({ className = '' }: { className?: string }) {
+type IconProps = { className?: string }
+
+function SearchIcon({ className = '' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path
@@ -189,7 +196,7 @@ function SearchIcon({ className = '' }: { className?: string }) {
   )
 }
 
-function CloseIcon({ className = '' }: { className?: string }) {
+function CloseIcon({ className = '' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />

--- a/apps/docs-site/src/components/api-reference/copy-button.tsx
+++ b/apps/docs-site/src/components/api-reference/copy-button.tsx
@@ -83,7 +83,9 @@ export function CopyButton({ text, className = '', size = 'sm' }: CopyButtonProp
   )
 }
 
-function CopyIcon({ className = '' }: { className?: string }) {
+type CopyIconProps = { className?: string }
+
+function CopyIcon({ className = '' }: CopyIconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={className}>
       <path
@@ -95,7 +97,9 @@ function CopyIcon({ className = '' }: { className?: string }) {
   )
 }
 
-function CheckIcon({ className = '' }: { className?: string }) {
+type CheckIconProps = { className?: string }
+
+function CheckIcon({ className = '' }: CheckIconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />

--- a/apps/docs-site/src/components/api-reference/index.tsx
+++ b/apps/docs-site/src/components/api-reference/index.tsx
@@ -13,6 +13,17 @@ import { TypeDefinition } from './type-definition'
 import { buildNodeLookup, resolveReference } from './type-utils'
 import { ReflectionKind } from './types'
 
+/** Marker added to a flattened export pointing at the module it came from */
+interface SourceModuleAttribution {
+  sourceModule?: string
+}
+
+/**
+ * A TypeDoc node decorated with the module that originally exported it.
+ * Used while flattening per-module exports into a single deduplicated list.
+ */
+type ExportWithSourceModule = TypeDocNode & SourceModuleAttribution
+
 type ViewMode = 'flat' | 'grouped'
 
 interface ApiReferenceProps {
@@ -43,7 +54,7 @@ export function ApiReference({ data }: ApiReferenceProps) {
 
     if (hasModules) {
       const lookup = buildNodeLookup(data)
-      const exports: Array<TypeDocNode & { sourceModule?: string }> = []
+      const exports: Array<ExportWithSourceModule> = []
       const seenIds = createSet<number>()
 
       for (const module of data.children) {
@@ -307,7 +318,12 @@ export function ApiReference({ data }: ApiReferenceProps) {
   )
 }
 
-function VariableItem({ node }: { node: TypeDocNode }) {
+/**
+ * Props for the inline {@link VariableItem} renderer used in the API reference list.
+ */
+type VariableItemProps = { node: TypeDocNode }
+
+function VariableItem({ node }: VariableItemProps) {
   return (
     <div className="py-4" id={`api-${node.name}`}>
       <div className="flex items-start gap-2">

--- a/apps/docs-site/src/components/api-reference/module-grouped-view.tsx
+++ b/apps/docs-site/src/components/api-reference/module-grouped-view.tsx
@@ -392,7 +392,9 @@ function formatModuleName(name: string): string {
     .join(' / ')
 }
 
-function ChevronIcon({ expanded }: { expanded: boolean }) {
+type ChevronIconProps = { expanded: boolean }
+
+function ChevronIcon({ expanded }: ChevronIconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs-site/src/components/breadcrumb.tsx
+++ b/apps/docs-site/src/components/breadcrumb.tsx
@@ -63,7 +63,9 @@ export function Breadcrumb() {
   )
 }
 
-function ChevronIcon({ className }: { className?: string }) {
+type ChevronIconProps = { className?: string }
+
+function ChevronIcon({ className }: ChevronIconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/apps/docs-site/src/components/demo-showcase.tsx
+++ b/apps/docs-site/src/components/demo-showcase.tsx
@@ -4,6 +4,15 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { min, pow } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
 import { requestAnimationFrame, cancelAnimationFrame } from '@hyperfrontend/immutable-api-utils/built-in-copy/timers'
 
+/**
+ * Snapshot taken when fast-forward begins so the animation can interpolate from
+ * the time and progress at that moment.
+ */
+type FastForwardStart = {
+  time: number
+  progress: number
+}
+
 interface DemoShowcaseProps {
   /** Duration in milliseconds for full cycle (default: 60000ms = 1 minute) */
   cycleDuration?: number
@@ -31,7 +40,7 @@ export function DemoShowcase({
   const [isFastForwarding, setIsFastForwarding] = useState(false)
   const animationRef = useRef<number | null>(null)
   const startTimeRef = useRef<number>(0)
-  const fastForwardStartRef = useRef<{ time: number; progress: number } | null>(null)
+  const fastForwardStartRef = useRef<FastForwardStart | null>(null)
 
   const currentDemoIndex = controlledDemo ?? internalDemo
 
@@ -126,7 +135,10 @@ export function DemoShowcase({
   )
 }
 
-function ProgressBorder({ progress }: { progress: number }) {
+/** Props for {@link ProgressBorder} */
+type ProgressBorderProps = { progress: number }
+
+function ProgressBorder({ progress }: ProgressBorderProps) {
   if (progress <= 0) return null
 
   const angle = (progress / 100) * 360
@@ -152,7 +164,10 @@ function ProgressBorder({ progress }: { progress: number }) {
   )
 }
 
-function DemoPlaceholder({ index }: { index: number }) {
+/** Props for {@link DemoPlaceholder} */
+type DemoPlaceholderProps = { index: number }
+
+function DemoPlaceholder({ index }: DemoPlaceholderProps) {
   const demos = [
     { name: 'Chess', description: 'Multiplayer chess with real-time sync' },
     { name: 'Clock', description: 'Synchronized time across contexts' },
@@ -176,7 +191,10 @@ function DemoPlaceholder({ index }: { index: number }) {
   )
 }
 
-function SkipIcon({ className }: { className?: string }) {
+/** Common props for showcase icons */
+type IconProps = { className?: string }
+
+function SkipIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M5.055 7.06C3.805 6.347 2.25 7.25 2.25 8.69v6.62c0 1.44 1.555 2.343 2.805 1.628L12 13.471v3.839c0 1.44 1.555 2.343 2.805 1.628l7.108-4.061c1.26-.72 1.26-2.536 0-3.256l-7.108-4.061C13.555 6.347 12 7.25 12 8.69v3.839L5.055 7.06z" />
@@ -184,7 +202,7 @@ function SkipIcon({ className }: { className?: string }) {
   )
 }
 
-function DemoIcon({ className }: { className?: string }) {
+function DemoIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
       <path

--- a/apps/docs-site/src/components/diagram-modal.tsx
+++ b/apps/docs-site/src/components/diagram-modal.tsx
@@ -148,7 +148,9 @@ export function DiagramModal({ svg, onClose, isOpen }: DiagramModalProps) {
   return createPortal(modalContent, document.body)
 }
 
-function CloseIcon({ className }: { className?: string }) {
+type CloseIconProps = { className?: string }
+
+function CloseIcon({ className }: CloseIconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />

--- a/apps/docs-site/src/components/header.tsx
+++ b/apps/docs-site/src/components/header.tsx
@@ -38,7 +38,9 @@ export function Header() {
   )
 }
 
-function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
+type NavLinkProps = { href: string; children: React.ReactNode }
+
+function NavLink({ href, children }: NavLinkProps) {
   return (
     <Link href={href} className="text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
       {children}
@@ -46,7 +48,9 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
   )
 }
 
-function Logo({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function Logo({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 32 32" fill="none">
       <rect width="32" height="32" rx="8" className="fill-primary-600 dark:fill-primary-500" />
@@ -56,7 +60,7 @@ function Logo({ className }: { className?: string }) {
   )
 }
 
-function GitHubIcon({ className }: { className?: string }) {
+function GitHubIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="currentColor" viewBox="0 0 24 24">
       <path

--- a/apps/docs-site/src/components/library-doc-page.tsx
+++ b/apps/docs-site/src/components/library-doc-page.tsx
@@ -149,7 +149,9 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
   )
 }
 
-function DocumentationIcon({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function DocumentationIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path
@@ -161,7 +163,7 @@ function DocumentationIcon({ className }: { className?: string }) {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+function CheckIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path

--- a/apps/docs-site/src/components/library-stub-page.tsx
+++ b/apps/docs-site/src/components/library-stub-page.tsx
@@ -86,7 +86,9 @@ export function LibraryStubPage({ title, packageName, description, features }: S
   )
 }
 
-function DocumentationIcon({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function DocumentationIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path
@@ -98,7 +100,7 @@ function DocumentationIcon({ className }: { className?: string }) {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+function CheckIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path

--- a/apps/docs-site/src/components/markdown-content.tsx
+++ b/apps/docs-site/src/components/markdown-content.tsx
@@ -3,9 +3,18 @@
 import { useEffect, useState } from 'react'
 import { MermaidDiagram } from './mermaid-diagram'
 
+/**
+ * Inline mermaid diagram payload extracted from a markdown source: a stable id
+ * for placeholder lookup paired with the raw chart text.
+ */
+interface MermaidDiagramEntry {
+  id: string
+  chart: string
+}
+
 interface MarkdownContentProps {
   html: string
-  mermaidDiagrams?: { id: string; chart: string }[]
+  mermaidDiagrams?: MermaidDiagramEntry[]
   className?: string
 }
 
@@ -31,7 +40,7 @@ export function MarkdownContent({ html, mermaidDiagrams = [], className = '' }: 
 }
 
 interface MermaidRendererProps {
-  diagrams: { id: string; chart: string }[]
+  diagrams: MermaidDiagramEntry[]
 }
 
 function MermaidRenderer({ diagrams }: MermaidRendererProps) {

--- a/apps/docs-site/src/components/mermaid-diagram.tsx
+++ b/apps/docs-site/src/components/mermaid-diagram.tsx
@@ -121,7 +121,9 @@ export function MermaidDiagram({ chart, className = '' }: MermaidDiagramProps) {
   )
 }
 
-function ExpandIcon({ className }: { className?: string }) {
+type ExpandIconProps = { className?: string }
+
+function ExpandIcon({ className }: ExpandIconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path

--- a/apps/docs-site/src/components/mobile-menu.tsx
+++ b/apps/docs-site/src/components/mobile-menu.tsx
@@ -52,18 +52,25 @@ function useMobileNavContext() {
 }
 
 /**
+ * Match descriptor used while resolving the active mobile nav path: the
+ * matched item path, the href length (for tie-breaking), and whether the path
+ * was an exact hit.
+ */
+type MobileNavMatch = {
+  itemPath: string[]
+  hrefLength: number
+  exact: boolean
+}
+
+/**
  * Finds all potential matches for the current pathname.
  * @param items
  * @param pathname
  * @param currentPath
  */
-function findAllMatches(
-  items: NavItem[],
-  pathname: string,
-  currentPath: string[] = []
-): Array<{ itemPath: string[]; hrefLength: number; exact: boolean }> {
+function findAllMatches(items: NavItem[], pathname: string, currentPath: string[] = []): Array<MobileNavMatch> {
   const normalizedPathname = normalizePath(pathname)
-  const matches: Array<{ itemPath: string[]; hrefLength: number; exact: boolean }> = []
+  const matches: Array<MobileNavMatch> = []
 
   for (const item of items) {
     const itemPath = [...currentPath, item.title]
@@ -286,19 +293,16 @@ export function MobileMenu() {
   )
 }
 
-function MobileNavSection({
-  section,
-  pathname,
-  onClose,
-  path,
-  depth = 0,
-}: {
+/** Props for the inline {@link MobileNavSection} renderer */
+type MobileNavSectionProps = {
   section: NavItem
   pathname: string
   onClose: () => void
   path: string[]
   depth?: number
-}) {
+}
+
+function MobileNavSection({ section, pathname, onClose, path, depth = 0 }: MobileNavSectionProps) {
   const { expandedSections, toggleSection } = useMobileNavContext()
   const pathKey = path.join('/')
   const isOpen = expandedSections.has(pathKey)
@@ -397,7 +401,10 @@ function checkIfChildActive(children: NavItem[], pathname: string): boolean {
   })
 }
 
-function MenuIcon({ className }: { className?: string }) {
+/** Common props for mobile-menu icons */
+type IconProps = { className?: string }
+
+function MenuIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -405,7 +412,7 @@ function MenuIcon({ className }: { className?: string }) {
   )
 }
 
-function CloseIcon({ className }: { className?: string }) {
+function CloseIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -413,7 +420,7 @@ function CloseIcon({ className }: { className?: string }) {
   )
 }
 
-function ChevronIcon({ className }: { className?: string }) {
+function ChevronIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/apps/docs-site/src/components/readme-content.tsx
+++ b/apps/docs-site/src/components/readme-content.tsx
@@ -8,9 +8,18 @@ import { useHashNavigation } from '../hooks/use-hash-navigation'
 import { generateSlug } from '../lib/markdown'
 import { MermaidDiagram } from './mermaid-diagram'
 
+/**
+ * Inline mermaid diagram payload referenced from rendered README markdown:
+ * a stable id used to swap a placeholder, paired with the raw chart text.
+ */
+interface MermaidDiagramEntry {
+  id: string
+  chart: string
+}
+
 interface ReadmeContentProps {
   html: string
-  mermaidDiagrams: { id: string; chart: string }[]
+  mermaidDiagrams: MermaidDiagramEntry[]
 }
 
 /**
@@ -197,6 +206,24 @@ function injectHeadingAnchors(container: HTMLElement): () => void {
   }
 }
 
+/** Raw HTML chunk in the README split sequence */
+interface ReadmeHtmlPart {
+  type: 'html'
+  content: string
+}
+
+/** Mermaid placeholder reference in the README split sequence */
+interface ReadmeMermaidPart {
+  type: 'mermaid'
+  id: string
+}
+
+/**
+ * Discriminated chunk emitted while splitting README HTML around mermaid
+ * placeholders so each chunk can be rendered inline in document order.
+ */
+type ReadmePart = ReadmeHtmlPart | ReadmeMermaidPart
+
 export function ReadmeContent({ html, mermaidDiagrams }: ReadmeContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -207,7 +234,7 @@ export function ReadmeContent({ html, mermaidDiagrams }: ReadmeContentProps) {
   const parts = useMemo(() => {
     // note: Regex captures the ID from: <div data-mermaid-id="mermaid-block-0"></div>
     const placeholderPattern = /<div data-mermaid-id="([^"]+)"><\/div>/g
-    const result: Array<{ type: 'html'; content: string } | { type: 'mermaid'; id: string }> = []
+    const result: ReadmePart[] = []
 
     let lastIndex = 0
     let match: RegExpExecArray | null

--- a/apps/docs-site/src/components/scroll-to-explore.tsx
+++ b/apps/docs-site/src/components/scroll-to-explore.tsx
@@ -12,7 +12,9 @@ export function ScrollToExplore() {
   )
 }
 
-function ChevronDownIcon({ className }: { className?: string }) {
+type ChevronDownIconProps = { className?: string }
+
+function ChevronDownIcon({ className }: ChevronDownIconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />

--- a/apps/docs-site/src/components/sidebar.tsx
+++ b/apps/docs-site/src/components/sidebar.tsx
@@ -44,18 +44,24 @@ function useSidebarContext() {
 }
 
 /**
+ * Match descriptor used while resolving the current sidebar path: the chain of
+ * titles, the matched href length, and whether it was an exact-path hit.
+ */
+type SidebarMatch = {
+  path: string[]
+  hrefLength: number
+  exact: boolean
+}
+
+/**
  * Finds all potential matches for the current pathname and returns the most specific one.
  * @param items
  * @param pathname
  * @param currentPath
  */
-function findAllMatches(
-  items: NavItem[],
-  pathname: string,
-  currentPath: string[] = []
-): Array<{ path: string[]; hrefLength: number; exact: boolean }> {
+function findAllMatches(items: NavItem[], pathname: string, currentPath: string[] = []): Array<SidebarMatch> {
   const normalizedPathname = pathname.replace(/\/$/, '')
-  const matches: Array<{ path: string[]; hrefLength: number; exact: boolean }> = []
+  const matches: Array<SidebarMatch> = []
 
   for (const item of items) {
     const itemPath = [...currentPath, item.title]
@@ -174,7 +180,10 @@ export function Sidebar() {
   )
 }
 
-function SidebarItem({ item, pathname, path }: { item: NavItem; pathname: string; path: string[] }) {
+/** Props for the inline {@link SidebarItem} renderer */
+type SidebarItemProps = { item: NavItem; pathname: string; path: string[] }
+
+function SidebarItem({ item, pathname, path }: SidebarItemProps) {
   const { expandedPath, setExpandedPath } = useSidebarContext()
   const hasChildren = item.children && item.children.length > 0
   const isActive = item.href ? normalizePath(item.href) === normalizePath(pathname) : false
@@ -264,7 +273,10 @@ function SidebarItem({ item, pathname, path }: { item: NavItem; pathname: string
   )
 }
 
-function ChevronIcon({ className }: { className?: string }) {
+/** Common props for sidebar icons */
+type IconProps = { className?: string }
+
+function ChevronIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -272,7 +284,7 @@ function ChevronIcon({ className }: { className?: string }) {
   )
 }
 
-function CollapseIcon({ className }: { className?: string }) {
+function CollapseIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />

--- a/apps/docs-site/src/components/theme-provider.tsx
+++ b/apps/docs-site/src/components/theme-provider.tsx
@@ -24,7 +24,9 @@ export function useTheme(): ThemeContextValue {
   return context ?? defaultContext
 }
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
+type ThemeProviderProps = { children: React.ReactNode }
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>('system')
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
   const [mounted, setMounted] = useState(false)

--- a/apps/docs-site/src/components/theme-toggle.tsx
+++ b/apps/docs-site/src/components/theme-toggle.tsx
@@ -37,7 +37,9 @@ export function ThemeToggle() {
   )
 }
 
-function SunIcon({ className }: { className?: string }) {
+type IconProps = { className?: string }
+
+function SunIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path
@@ -49,7 +51,7 @@ function SunIcon({ className }: { className?: string }) {
   )
 }
 
-function MoonIcon({ className }: { className?: string }) {
+function MoonIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path
@@ -61,7 +63,7 @@ function MoonIcon({ className }: { className?: string }) {
   )
 }
 
-function SystemIcon({ className }: { className?: string }) {
+function SystemIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path

--- a/apps/docs-site/src/components/value-proposition.tsx
+++ b/apps/docs-site/src/components/value-proposition.tsx
@@ -11,7 +11,13 @@ import { abs, min } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
 import { cancelAnimationFrame, requestAnimationFrame, setTimeout } from '@hyperfrontend/immutable-api-utils/built-in-copy/timers'
 import { createTimer } from '@hyperfrontend/time-utils'
 
-type TextSegment = string | { bold: string } | { italic: string }
+/** Bold-emphasized inline segment within a narrative line */
+type BoldSegment = { bold: string }
+
+/** Italic-emphasized inline segment within a narrative line */
+type ItalicSegment = { italic: string }
+
+type TextSegment = string | BoldSegment | ItalicSegment
 
 interface Narrative {
   segments: TextSegment[]
@@ -499,7 +505,10 @@ function InstallCommand() {
   )
 }
 
-function CheckIcon({ className }: { className?: string }) {
+/** Common props for value-proposition icons */
+type IconProps = { className?: string }
+
+function CheckIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path
@@ -511,7 +520,7 @@ function CheckIcon({ className }: { className?: string }) {
   )
 }
 
-function CopyIcon({ className }: { className?: string }) {
+function CopyIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
       <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
@@ -520,7 +529,7 @@ function CopyIcon({ className }: { className?: string }) {
   )
 }
 
-function GitHubIcon({ className }: { className?: string }) {
+function GitHubIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="currentColor" viewBox="0 0 24 24">
       <path
@@ -532,7 +541,7 @@ function GitHubIcon({ className }: { className?: string }) {
   )
 }
 
-function StarIcon({ className }: { className?: string }) {
+function StarIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path
@@ -544,7 +553,7 @@ function StarIcon({ className }: { className?: string }) {
   )
 }
 
-function HeartIcon({ className }: { className?: string }) {
+function HeartIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor">
       <path d="M9.653 16.915l-.005-.003-.019-.01a20.759 20.759 0 01-1.162-.682 22.045 22.045 0 01-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 018-2.828A4.5 4.5 0 0118 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 01-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 01-.69.001l-.002-.001z" />
@@ -552,7 +561,7 @@ function HeartIcon({ className }: { className?: string }) {
   )
 }
 
-function ChevronLeftIcon({ className }: { className?: string }) {
+function ChevronLeftIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
@@ -560,7 +569,7 @@ function ChevronLeftIcon({ className }: { className?: string }) {
   )
 }
 
-function ChevronRightIcon({ className }: { className?: string }) {
+function ChevronRightIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />

--- a/apps/docs-site/src/lib/docs-loader.ts
+++ b/apps/docs-site/src/lib/docs-loader.ts
@@ -44,39 +44,49 @@ function resolveGeneratedSlug(slug: string): string {
 }
 
 /**
+ * Single library entry in the documentation manifest.
+ */
+interface ManifestLibrary {
+  /** Library display name */
+  name: string
+  /** npm package name */
+  packageName: string
+  /** URL slug */
+  slug: string
+  /** Library category */
+  category: string
+  /** Path to README file (null if missing) */
+  readme: string | null
+  /** Path to architecture doc (null if missing) */
+  architecture: string | null
+  /** Whether API docs exist */
+  hasApi: boolean
+  /** Keywords from package.json */
+  keywords: string[]
+  /** Description from package.json */
+  description: string
+}
+
+/**
+ * Availability flags for top-level (non-library) documentation pages.
+ */
+interface ManifestRootDocs {
+  /** Whether architecture doc exists */
+  architecture: boolean
+  /** Whether contributing doc exists */
+  contributing: boolean
+}
+
+/**
  * Documentation manifest containing library metadata and generation info.
  */
 interface Manifest {
   /** Timestamp when docs were generated */
   generatedAt: string
   /** Library metadata entries */
-  libraries: {
-    /** Library display name */
-    name: string
-    /** npm package name */
-    packageName: string
-    /** URL slug */
-    slug: string
-    /** Library category */
-    category: string
-    /** Path to README file (null if missing) */
-    readme: string | null
-    /** Path to architecture doc (null if missing) */
-    architecture: string | null
-    /** Whether API docs exist */
-    hasApi: boolean
-    /** Keywords from package.json */
-    keywords: string[]
-    /** Description from package.json */
-    description: string
-  }[]
+  libraries: ManifestLibrary[]
   /** Root documentation availability */
-  rootDocs: {
-    /** Whether architecture doc exists */
-    architecture: boolean
-    /** Whether contributing doc exists */
-    contributing: boolean
-  }
+  rootDocs: ManifestRootDocs
 }
 
 /**

--- a/apps/docs-site/src/lib/mermaid-utils.ts
+++ b/apps/docs-site/src/lib/mermaid-utils.ts
@@ -1,27 +1,34 @@
 /**
- * Process markdown content and replace mermaid code blocks with placeholders
- * for client-side rendering
- *
- * @param content - The markdown content to process
- * @returns An object containing the processed content and extracted diagrams
+ * A single mermaid diagram extracted from markdown source: a placeholder id
+ * paired with the chart text that should be rendered in its place.
  */
-export function extractMermaidBlocks(content: string): {
+export type MermaidDiagram = {
+  /** Unique identifier for the diagram placeholder */
+  id: string
+  /** The mermaid chart definition */
+  chart: string
+}
+
+/**
+ * Result of {@link extractMermaidBlocks}: the rewritten markdown plus all the
+ * diagrams pulled out of it.
+ */
+export type ExtractMermaidBlocksResult = {
   /** The markdown content with mermaid blocks replaced by placeholders */
   processedContent: string
   /** Array of extracted mermaid diagrams */
-  diagrams: {
-    /** Unique identifier for the diagram placeholder */
-    id: string
-    /** The mermaid chart definition */
-    chart: string
-  }[]
-} {
-  const diagrams: {
-    /** Unique identifier for the diagram placeholder */
-    id: string
-    /** The mermaid chart definition */
-    chart: string
-  }[] = []
+  diagrams: MermaidDiagram[]
+}
+
+/**
+ * Process markdown content and replace mermaid code blocks with placeholders
+ * for client-side rendering.
+ *
+ * @param content - The markdown content to process
+ * @returns The processed content paired with the extracted diagrams
+ */
+export function extractMermaidBlocks(content: string): ExtractMermaidBlocksResult {
+  const diagrams: MermaidDiagram[] = []
   let index = 0
 
   const processedContent = content.replace(/```mermaid\n([\s\S]*?)```/g, (_, chart) => {

--- a/eslint.base.config.cjs
+++ b/eslint.base.config.cjs
@@ -210,6 +210,13 @@ module.exports = [
     },
   },
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/jest.config.ts', '**/jest.setup.ts', '**/jest.setup.browser.ts', '**/*.spec.ts', '**/*.spec.tsx'],
+    rules: {
+      'workspace/no-inline-type-literal': 'error',
+    },
+  },
+  {
     files: ['**/*.spec.ts'],
     rules: {
       'workspace/assertive-test-names': 'error',

--- a/libs/network-protocol/src/lib/data/model.ts
+++ b/libs/network-protocol/src/lib/data/model.ts
@@ -3,6 +3,18 @@ import { parse, stringify } from '@hyperfrontend/immutable-api-utils/built-in-co
 import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * Brand attached to {@link JSONString} to enforce nominal typing.
+ *
+ * @template T - The logical type the JSON string represents when parsed
+ */
+type JSONStringBrand<T> = {
+  /** Brand symbol ensuring type safety for JSON strings */
+  readonly __jsonBrand: unique symbol
+  /** Phantom type parameter for the serialized type */
+  readonly __type: T
+}
+
+/**
  * Branded type representing a JSON-serialized string of type T.
  * This is a nominal type that carries information about what type
  * the string represents when parsed, while remaining a string at runtime.
@@ -15,12 +27,7 @@ import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
  * const parsed: { name: string } = JSON.parse(jsonStr)
  * ```
  */
-export type JSONString<T = unknown> = string & {
-  /** Brand symbol ensuring type safety for JSON strings */
-  readonly __jsonBrand: unique symbol
-  /** Phantom type parameter for the serialized type */
-  readonly __type: T
-}
+export type JSONString<T = unknown> = string & JSONStringBrand<T>
 
 /**
  * Serialized wire format for Data.

--- a/libs/network-protocol/src/lib/packet/security/obfuscation/time-interval-obfuscation-factory.ts
+++ b/libs/network-protocol/src/lib/packet/security/obfuscation/time-interval-obfuscation-factory.ts
@@ -7,6 +7,19 @@ import { isValidSerializedEncryptedPacket } from '../../validations/is-valid-ser
 import { isValidRefreshRate } from './is-valid-refresh-rate'
 
 /**
+ * Bundle of password producers for the current, previous, and next time windows.
+ * Used by the time-interval obfuscation factory to align password rotation with clock boundaries.
+ */
+type TimeWindowPasswords = {
+  /** Gets password for current time window */
+  current: () => Promise<string>
+  /** Gets password for previous time window */
+  previous: () => Promise<string>
+  /** Gets password for next time window */
+  next: () => Promise<string>
+}
+
+/**
  * Creates a factory for time-interval based obfuscation suites.
  *
  * This factory accepts packet obfuscation/deobfuscation functions and time-based password generators,
@@ -17,7 +30,7 @@ import { isValidRefreshRate } from './is-valid-refresh-rate'
  * @param {PacketObfuscater} obfuscatePacket - Function to obfuscate a packet with a password
  * @param {PacketDeobfuscater} deobfuscatePacket - Function to deobfuscate data with a password
  * @param {(date: Date, refreshRate: number, offset: number) => Promise<string>} getTimeBasedPassword - Function to get a time-based password
- * @param {(date: Date, refreshRate: number) => {current: () => Promise<string>, previous: () => Promise<string>, next: () => Promise<string>}} getTimeBasedPasswords - Function to get multiple time-based passwords
+ * @param {(date: Date, refreshRate: number) => TimeWindowPasswords} getTimeBasedPasswords - Function to get multiple time-based passwords
  * @returns {(refreshRate: number) => ObfuscationSuite} A factory function that accepts a refresh rate and returns an obfuscation suite
  *
  * @example Creating a time-interval obfuscation suite
@@ -36,17 +49,7 @@ export function createTimeIntervalObfuscationFactory(
   obfuscatePacket: PacketObfuscater,
   deobfuscatePacket: PacketDeobfuscater,
   getTimeBasedPassword: (date: Date, refreshRate: number, offset: number) => Promise<string>,
-  getTimeBasedPasswords: (
-    date: Date,
-    refreshRate: number
-  ) => {
-    /** Gets password for current time window */
-    current: () => Promise<string>
-    /** Gets password for previous time window */
-    previous: () => Promise<string>
-    /** Gets password for next time window */
-    next: () => Promise<string>
-  }
+  getTimeBasedPasswords: (date: Date, refreshRate: number) => TimeWindowPasswords
 ) {
   return (refreshRate = 1): ObfuscationSuite => {
     if (!isValidRefreshRate(refreshRate)) {

--- a/libs/nexus/src/broker/channels/list.ts
+++ b/libs/nexus/src/broker/channels/list.ts
@@ -3,6 +3,15 @@ import type { ChannelJSON } from '../../types/channel'
 import { getAll } from '../../core/registry/get-all'
 
 /**
+ * Minimal shape exposing the {@link ChannelJSON} serializer on a channel instance.
+ * Used to safely cast registry entries before serialization.
+ */
+type ChannelWithToJSON = {
+  /** Serializes channel to JSON */
+  toJSON: () => ChannelJSON
+}
+
+/**
  * Lists all channels in JSON format
  *
  * @param registry - Channel registry containing all registered channels
@@ -16,5 +25,5 @@ import { getAll } from '../../core/registry/get-all'
  */
 export function listChannels(registry: Registry): ChannelJSON[] {
   const channels = getAll(registry)
-  return channels.map((channel) => (<{ /** Serializes channel to JSON */ toJSON: () => ChannelJSON }>(<unknown>channel)).toJSON())
+  return channels.map((channel) => (<ChannelWithToJSON>(<unknown>channel)).toJSON())
 }

--- a/libs/nexus/src/broker/factory.ts
+++ b/libs/nexus/src/broker/factory.ts
@@ -40,6 +40,27 @@ import { filterOrigin } from './security/filter-origin'
 import { validatePolicy } from './security/validate-policy'
 
 /**
+ * Inputs for {@link createBroker}.
+ */
+type CreateBrokerConfig = {
+  /** Unique name for the broker instance */
+  name: string
+  /** Channel contract defining message protocols */
+  contract: IChannelContract
+  /** Optional configuration overrides for broker behavior */
+  settings?: Partial<BrokerConfig['settings']>
+}
+
+/**
+ * Mutable view of the broker state used to swap the contract during
+ * {@link BrokerHandle.extendContract}.
+ */
+type BrokerStateContractRef = {
+  /** The channel contract */
+  contract: unknown
+}
+
+/**
  * Creates a message broker instance
  *
  * @param config - Broker configuration
@@ -57,14 +78,7 @@ import { validatePolicy } from './security/validate-policy'
  * })
  * ```
  */
-export function createBroker(config: {
-  /** Unique name for the broker instance */
-  name: string
-  /** Channel contract defining message protocols */
-  contract: IChannelContract
-  /** Optional configuration overrides for broker behavior */
-  settings?: Partial<BrokerConfig['settings']>
-}): BrokerHandle {
+export function createBroker(config: CreateBrokerConfig): BrokerHandle {
   assertNoCircularRef(config.contract, 'config.contract')
   assertNoCircularRef(config.settings, 'config.settings')
   validateName(config.name)
@@ -198,12 +212,7 @@ export function createBroker(config: {
         throw createError('Original contract cannot be extended.')
       }
       validateContract(contract)
-      ;(<
-        {
-          /** The channel contract */
-          contract: unknown
-        }
-      >state).contract = mergeContracts(state.contract, contract)
+      ;(<BrokerStateContractRef>state).contract = mergeContracts(state.contract, contract)
       return broker
     },
 

--- a/libs/nexus/src/channel/types.ts
+++ b/libs/nexus/src/channel/types.ts
@@ -5,6 +5,42 @@ import type { IMessage } from '../types/message'
 import type { SecurityNegotiationRequest, SecurityNegotiationResponse, SecurityConfirmation } from '../types/security'
 
 /**
+ * Action creators a channel uses to talk to its broker. Each method returns the
+ * `IAction` that the broker would otherwise hand-build, with arguments threaded
+ * through to keep call sites readable.
+ */
+export interface ChannelActionCreators {
+  /** Requests a connection with optional security negotiation */
+  requestConnection(processId: string, security?: SecurityNegotiationRequest): IAction
+  /** Accepts a pending connection request */
+  acceptConnection(processId: string, security?: SecurityNegotiationResponse): IAction
+  /** Denies a connection request with a reason */
+  denyConnection(processId: string, reason: string): IAction
+  /** Cancels an ongoing connection attempt */
+  cancelConnection(processId: string): IAction
+  /** Opens an established connection */
+  openConnection(processId: string, security?: SecurityConfirmation): IAction
+  /** Closes an active connection */
+  closeConnection(processId: string): IAction
+  /** Destroys the connection entirely */
+  destroyConnection(): IAction
+  /** Sends a new message through the channel */
+  newMessage(data: unknown): IAction
+  /** Reports an invalid request error */
+  invalidRequest(processId: string, error: string): IAction
+}
+
+/**
+ * Minimal process-tracking interface a channel needs from its host broker.
+ */
+export interface ChannelProcessManager {
+  /** Creates a new process and returns its ID */
+  create(channel: unknown): string
+  /** Removes a process by ID */
+  remove(processId: string): void
+}
+
+/**
  * Internal channel API used by lifecycle, messaging, and subscription functions.
  * This interface provides access to channel state and dependencies without exposing
  * the public API surface.
@@ -32,26 +68,7 @@ export interface ChannelInternals {
   notifyMessage(message: IMessage): void
 
   /** Action creators bound to broker */
-  actions: {
-    /** Requests a connection with optional security negotiation */
-    requestConnection(processId: string, security?: SecurityNegotiationRequest): IAction
-    /** Accepts a pending connection request */
-    acceptConnection(processId: string, security?: SecurityNegotiationResponse): IAction
-    /** Denies a connection request with a reason */
-    denyConnection(processId: string, reason: string): IAction
-    /** Cancels an ongoing connection attempt */
-    cancelConnection(processId: string): IAction
-    /** Opens an established connection */
-    openConnection(processId: string, security?: SecurityConfirmation): IAction
-    /** Closes an active connection */
-    closeConnection(processId: string): IAction
-    /** Destroys the connection entirely */
-    destroyConnection(): IAction
-    /** Sends a new message through the channel */
-    newMessage(data: unknown): IAction
-    /** Reports an invalid request error */
-    invalidRequest(processId: string, error: string): IAction
-  }
+  actions: ChannelActionCreators
 
   /** Optional cleanup callback to remove channel from broker */
   cleanup?: () => void
@@ -65,12 +82,7 @@ export interface ChannelDependencies {
   actions: ChannelInternals['actions']
 
   /** Process manager for tracking connection processes */
-  processManager: {
-    /** Creates a new process and returns its ID */
-    create(channel: unknown): string
-    /** Removes a process by ID */
-    remove(processId: string): void
-  }
+  processManager: ChannelProcessManager
 
   /** Optional cleanup callback */
   cleanup?: () => void

--- a/libs/nexus/src/errors/connection-error.ts
+++ b/libs/nexus/src/errors/connection-error.ts
@@ -1,6 +1,20 @@
 import { setPrototypeOf } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * JSON representation of a {@link ConnectionError}.
+ */
+export type ConnectionErrorJSON = {
+  /** Error name */
+  name: string
+  /** Error message */
+  message: string
+  /** Channel ID if available */
+  channelId?: string
+  /** Origin if available */
+  origin?: string
+}
+
+/**
  * Custom error class for connection-related failures.
  *
  * @example Throwing connection error
@@ -25,16 +39,7 @@ export class ConnectionError extends Error {
    *
    * @returns JSON object with error details
    */
-  toJSON(): {
-    /** Error name */
-    name: string
-    /** Error message */
-    message: string
-    /** Channel ID if available */
-    channelId?: string
-    /** Origin if available */
-    origin?: string
-  } {
+  toJSON(): ConnectionErrorJSON {
     return {
       name: this.name,
       message: this.message,

--- a/libs/nexus/src/errors/contract-error.ts
+++ b/libs/nexus/src/errors/contract-error.ts
@@ -2,6 +2,18 @@ import type { IChannelContract } from '../types/contract'
 import { setPrototypeOf } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * JSON representation of a {@link ContractError}.
+ */
+export type ContractErrorJSON = {
+  /** Error name */
+  name: string
+  /** Error message */
+  message: string
+  /** Contract if available */
+  contract?: IChannelContract
+}
+
+/**
  * Custom error class for contract-related failures
  *
  * @example Throwing contract error
@@ -25,14 +37,7 @@ export class ContractError extends Error {
    *
    * @returns JSON object with error details
    */
-  toJSON(): {
-    /** Error name */
-    name: string
-    /** Error message */
-    message: string
-    /** Contract if available */
-    contract?: IChannelContract
-  } {
+  toJSON(): ContractErrorJSON {
     return {
       name: this.name,
       message: this.message,

--- a/libs/nexus/src/errors/validation-error.ts
+++ b/libs/nexus/src/errors/validation-error.ts
@@ -2,6 +2,18 @@ import type { ValidationError as IValidationError } from '../types/validation'
 import { setPrototypeOf } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * JSON representation of a {@link ValidationError}.
+ */
+export type ValidationErrorJSON = {
+  /** Error name */
+  name: string
+  /** Error message */
+  message: string
+  /** Validation errors */
+  errors: IValidationError[]
+}
+
+/**
  * Custom error class for validation failures
  *
  * @example Throwing validation error
@@ -25,14 +37,7 @@ export class ValidationError extends Error {
    *
    * @returns JSON object with error details
    */
-  toJSON(): {
-    /** Error name */
-    name: string
-    /** Error message */
-    message: string
-    /** Validation errors */
-    errors: IValidationError[]
-  } {
+  toJSON(): ValidationErrorJSON {
     return {
       name: this.name,
       message: this.message,

--- a/libs/nexus/src/security/transport/none-transport.ts
+++ b/libs/nexus/src/security/transport/none-transport.ts
@@ -17,6 +17,15 @@ import type { NoneTransportConfig, ReceiveHandler, TransportState } from './type
 import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * Internal test hook exposed on the none-transport instance.
+ * Lets tests deliver an inbound action without involving postMessage.
+ */
+type NoneTransportInternals = {
+  /** Processes incoming actions (for testing) */
+  handleReceive: (action: unknown) => void
+}
+
+/**
  * Creates a passthrough (no security) transport adapter.
  *
  * The none transport provides the same interface as secure transports
@@ -128,7 +137,7 @@ export function createNoneTransport(config: NoneTransportConfig): SecurityTransp
     return 'none'
   }
 
-  return freeze(<SecurityTransport & { /** Processes incoming actions (for testing) */ handleReceive: (action: unknown) => void }>{
+  return freeze(<SecurityTransport & NoneTransportInternals>{
     send,
     onReceive,
     stop,

--- a/libs/nexus/src/security/transport/secure-transport.ts
+++ b/libs/nexus/src/security/transport/secure-transport.ts
@@ -18,6 +18,15 @@ import { freeze } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { createSecurityErrorEventData } from '../errors'
 
 /**
+ * Internal test hook exposed on the secure-transport instance.
+ * Lets tests deliver a raw inbound packet without traversing postMessage.
+ */
+type SecureTransportInternals = {
+  /** @internal */
+  handleReceive: (packet: Uint8Array) => void
+}
+
+/**
  * Protocol interface from network-protocol.
  *
  * This is a minimal subset of the network-protocol Protocol interface
@@ -248,7 +257,7 @@ export function createSecureTransport(config: SecureTransportConfig): SecurityTr
     return protocol
   }
 
-  return freeze(<SecurityTransport & { /** @internal */ handleReceive: (packet: Uint8Array) => void }>{
+  return freeze(<SecurityTransport & SecureTransportInternals>{
     send,
     onReceive,
     stop,

--- a/libs/nexus/src/types/events.ts
+++ b/libs/nexus/src/types/events.ts
@@ -85,17 +85,31 @@ export interface SecurityErrorEventData {
 }
 
 /**
+ * Carrier shape for a single broker event: a discriminator (`event`) plus its
+ * typed payload (`data`). Reused by every variant in {@link EventData}.
+ *
+ * @template TEvent - String literal naming the event
+ * @template TData - Concrete payload type for that event
+ */
+type EventEnvelope<TEvent extends string, TData> = {
+  /** Event type */
+  event: TEvent
+  /** Event payload */
+  data: TData
+}
+
+/**
  * Discriminated union of all event data types
  */
 export type EventData =
-  | { /** Event type */ event: 'open'; /** Event payload */ data: OpenEventData }
-  | { /** Event type */ event: 'close'; /** Event payload */ data: CloseEventData }
-  | { /** Event type */ event: 'cancel'; /** Event payload */ data: CancelEventData }
-  | { /** Event type */ event: 'deny'; /** Event payload */ data: DenyEventData }
-  | { /** Event type */ event: 'invalid'; /** Event payload */ data: InvalidEventData }
-  | { /** Event type */ event: 'security-negotiated'; /** Event payload */ data: SecurityNegotiatedEventData }
-  | { /** Event type */ event: 'security-ready'; /** Event payload */ data: SecurityReadyEventData }
-  | { /** Event type */ event: 'security-error'; /** Event payload */ data: SecurityErrorEventData }
+  | EventEnvelope<'open', OpenEventData>
+  | EventEnvelope<'close', CloseEventData>
+  | EventEnvelope<'cancel', CancelEventData>
+  | EventEnvelope<'deny', DenyEventData>
+  | EventEnvelope<'invalid', InvalidEventData>
+  | EventEnvelope<'security-negotiated', SecurityNegotiatedEventData>
+  | EventEnvelope<'security-ready', SecurityReadyEventData>
+  | EventEnvelope<'security-error', SecurityErrorEventData>
 
 /**
  * Type-safe event handler for OPEN events

--- a/libs/nexus/src/types/security.ts
+++ b/libs/nexus/src/types/security.ts
@@ -58,6 +58,18 @@ export interface SecurityConfirmation {
 }
 
 /**
+ * Error payload delivered to a security transport's `onError` handler.
+ */
+export interface SecurityTransportError {
+  /** Human-readable error message */
+  message: string
+  /** Machine-readable error code */
+  code: string
+  /** Optional underlying cause */
+  cause?: Error
+}
+
+/**
  * Configuration for creating a security transport adapter.
  */
 export interface SecurityTransportConfig {
@@ -80,14 +92,7 @@ export interface SecurityTransportConfig {
   readonly origin?: string
 
   /** Optional error handler for security failures */
-  readonly onError?: (error: {
-    /** Human-readable error message */
-    message: string
-    /** Machine-readable error code */
-    code: string
-    /** Optional underlying cause */
-    cause?: Error
-  }) => void
+  readonly onError?: (error: SecurityTransportError) => void
 }
 
 /**
@@ -152,6 +157,16 @@ export interface SecurityTransport {
 export type ProtocolLoader = (version: 'v1' | 'v2', platform: 'browser' | 'node') => Promise<unknown>
 
 /**
+ * Bag of pre-registered security protocol providers indexed by protocol version.
+ */
+export interface SecurityProtocolProviders {
+  /** Protocol v1 provider */
+  v1?: unknown
+  /** Protocol v2 provider */
+  v2?: unknown
+}
+
+/**
  * Broker-level security configuration.
  *
  * Configures security defaults and protocol availability for all
@@ -159,12 +174,7 @@ export type ProtocolLoader = (version: 'v1' | 'v2', platform: 'browser' | 'node'
  */
 export interface BrokerSecurityConfig {
   /** Pre-registered protocol providers keyed by version */
-  readonly protocols?: Readonly<{
-    /** Protocol v1 provider */
-    v1?: unknown
-    /** Protocol v2 provider */
-    v2?: unknown
-  }>
+  readonly protocols?: Readonly<SecurityProtocolProviders>
 
   /** Protocol loader for lazy loading */
   readonly protocolLoader?: ProtocolLoader

--- a/libs/project-scope/src/core/cache.ts
+++ b/libs/project-scope/src/core/cache.ts
@@ -282,6 +282,27 @@ export function unregisterCache<K, V>(cache: Cache<K, V>): boolean {
 }
 
 /**
+ * Adds a `cache` accessor to a memoized function, exposing the underlying cache
+ * for direct inspection or invalidation.
+ *
+ * @template K - Cache key type
+ * @template V - Cached value type
+ */
+export type WithCache<K, V> = {
+  /** Underlying cache instance for direct access and control */
+  cache: Cache<K, V>
+}
+
+/**
+ * Function returned by {@link memoize}: behaves like the original function but
+ * exposes a `cache` for direct manipulation.
+ *
+ * @template K - Cache key type
+ * @template V - Cached value type
+ */
+export type MemoizedFunction<K, V> = ((key: K) => V) & WithCache<K, V>
+
+/**
  * Create a memoized version of a function with caching.
  *
  * The memoized function caches results based on the first argument (key).
@@ -306,13 +327,7 @@ export function unregisterCache<K, V>(cache: Cache<K, V>): boolean {
  * detectTechStackMemo.cache.clear()
  * ```
  */
-export function memoize<K, V>(
-  fn: (key: K) => V,
-  options?: CacheOptions
-): ((key: K) => V) & {
-  /** Underlying cache instance for direct access and control */
-  cache: Cache<K, V>
-} {
+export function memoize<K, V>(fn: (key: K) => V, options?: CacheOptions): MemoizedFunction<K, V> {
   const cache = createCache<K, V>(options)
 
   const memoized = (key: K): V => {
@@ -332,10 +347,5 @@ export function memoize<K, V>(
     enumerable: true,
   })
 
-  return <
-    ((key: K) => V) & {
-      /** Underlying cache instance for direct access and control */
-      cache: Cache<K, V>
-    }
-  >memoized
+  return <MemoizedFunction<K, V>>memoized
 }

--- a/libs/project-scope/src/core/encoding/detect.ts
+++ b/libs/project-scope/src/core/encoding/detect.ts
@@ -31,23 +31,31 @@ export const BINARY_SIGNATURES = <const>[
 ]
 
 /**
+ * Successful text-encoding detection.
+ */
+export type TextEncodingInfo = {
+  /** Content type indicator */
+  type: 'text'
+  /** Character encoding */
+  encoding: BufferEncoding
+  /** Whether BOM was detected */
+  hasBom: boolean
+}
+
+/**
+ * Successful binary-content detection.
+ */
+export type BinaryEncodingInfo = {
+  /** Content type indicator */
+  type: 'binary'
+  /** Binary format description */
+  format?: string
+}
+
+/**
  * Encoding detection result.
  */
-export type EncodingInfo =
-  | {
-      /** Content type indicator */
-      type: 'text'
-      /** Character encoding */
-      encoding: BufferEncoding
-      /** Whether BOM was detected */
-      hasBom: boolean
-    }
-  | {
-      /** Content type indicator */
-      type: 'binary'
-      /** Binary format description */
-      format?: string
-    }
+export type EncodingInfo = TextEncodingInfo | BinaryEncodingInfo
 
 /**
  * Detect if content is likely text or binary with encoding information.

--- a/libs/project-scope/src/core/fs/directory.ts
+++ b/libs/project-scope/src/core/fs/directory.ts
@@ -157,6 +157,14 @@ export function readDirectoryRecursive(dirPath: string, options?: RecursiveOptio
 }
 
 /**
+ * Options for {@link createDirectory}.
+ */
+export interface CreateDirectoryOptions {
+  /** Create parent directories if missing (default: true) */
+  recursive?: boolean
+}
+
+/**
  * Create a directory, optionally creating parent directories.
  *
  * @param dirPath - Path where the directory should be created
@@ -172,16 +180,20 @@ export function readDirectoryRecursive(dirPath: string, options?: RecursiveOptio
  * createDirectory('./logs', { recursive: false })
  * ```
  */
-export function createDirectory(
-  dirPath: string,
-  options?: {
-    /** Create parent directories if missing (default: true) */
-    recursive?: boolean
-  }
-): void {
+export function createDirectory(dirPath: string, options?: CreateDirectoryOptions): void {
   const recursive = options?.recursive ?? true
   fsDirLogger.debug('Creating directory', { path: dirPath, recursive })
   mkdirSync(dirPath, { recursive })
+}
+
+/**
+ * Options for {@link removeDirectory}.
+ */
+export interface RemoveDirectoryOptions {
+  /** Delete directory contents recursively */
+  recursive?: boolean
+  /** Ignore errors if directory doesn't exist */
+  force?: boolean
 }
 
 /**
@@ -201,15 +213,7 @@ export function createDirectory(
  * removeDirectory('./cache', { recursive: true, force: true })
  * ```
  */
-export function removeDirectory(
-  dirPath: string,
-  options?: {
-    /** Delete directory contents recursively */
-    recursive?: boolean
-    /** Ignore errors if directory doesn't exist */
-    force?: boolean
-  }
-): void {
+export function removeDirectory(dirPath: string, options?: RemoveDirectoryOptions): void {
   fsDirLogger.debug('Removing directory', { path: dirPath, recursive: options?.recursive, force: options?.force })
   rmSync(dirPath, {
     recursive: options?.recursive ?? false,

--- a/libs/project-scope/src/core/fs/write.ts
+++ b/libs/project-scope/src/core/fs/write.ts
@@ -105,6 +105,15 @@ export function writeFileBuffer(filePath: string, content: Buffer, options?: Wri
 }
 
 /**
+ * Minimal shape used to inspect the Node.js `code` property on filesystem errors
+ * without importing the full `NodeJS.ErrnoException` type.
+ */
+type ErrorWithCode = {
+  /** Error code */
+  code?: string
+}
+
+/**
  * Write JSON data to file with formatting.
  * Creates parent directories if needed.
  *
@@ -132,7 +141,7 @@ export function writeJsonFile<T>(filePath: string, data: T, options?: WriteJsonO
     writeFileContent(filePath, content, options)
     fsWriteLogger.debug('JSON file written successfully', { path: filePath })
   } catch (error) {
-    if ((<{ /** Error code */ code?: string }>error)?.code === 'FS_WRITE_ERROR') {
+    if ((<ErrorWithCode>error)?.code === 'FS_WRITE_ERROR') {
       throw error
     }
     fsWriteLogger.warn('Failed to write JSON file', { path: filePath, error: error instanceof Error ? error.message : String(error) })

--- a/libs/project-scope/src/nx/project-config.ts
+++ b/libs/project-scope/src/nx/project-config.ts
@@ -9,6 +9,26 @@ import { getNxWorkspaceInfo, isNxProject, NX_PROJECT_FILE } from './detect'
 const nxConfigLogger = createScopedLogger('project-scope:nx:config')
 
 /**
+ * Object form of an entry in `targets[*].dependsOn`: a target name plus the
+ * project(s) it should be looked up in.
+ */
+export interface NxTargetDependency {
+  /** Target name to depend on */
+  target: string
+  /** Project(s) containing the target */
+  projects: string | string[]
+}
+
+/**
+ * Top-level shape of `workspace.json` consumed by {@link discoverNxProjects}.
+ * Only the `projects` map is required; values may be paths or inline configs.
+ */
+interface NxWorkspaceJson {
+  /** Map of project name to configuration path or inline config */
+  projects?: Record<string, unknown>
+}
+
+/**
  * NX target configuration.
  */
 export interface NxTargetConfig {
@@ -23,15 +43,7 @@ export interface NxTargetConfig {
   /** Default configuration */
   defaultConfiguration?: string
   /** Depends on other targets */
-  dependsOn?: Array<
-    | string
-    | {
-        /** Target name to depend on */
-        target: string
-        /** Project(s) containing the target */
-        projects: string | string[]
-      }
-  >
+  dependsOn?: Array<string | NxTargetDependency>
   /** Target inputs for caching */
   inputs?: unknown[]
 }
@@ -235,10 +247,7 @@ function scanForProjects(
 export function discoverNxProjects(workspacePath: string): Map<string, NxProjectConfig> {
   const projects = createMap<string, NxProjectConfig>()
 
-  const workspaceJson = readJsonFileIfExists<{
-    /** Map of project name to configuration path or inline config */
-    projects?: Record<string, unknown>
-  }>(join(workspacePath, 'workspace.json'))
+  const workspaceJson = readJsonFileIfExists<NxWorkspaceJson>(join(workspacePath, 'workspace.json'))
 
   if (workspaceJson?.projects) {
     for (const [name, config] of entries(workspaceJson.projects)) {

--- a/libs/project-scope/src/project/package/read.ts
+++ b/libs/project-scope/src/project/package/read.ts
@@ -10,6 +10,15 @@ import { createScopedLogger } from '../../core/logger'
 const packageLogger = createScopedLogger('project-scope:project:package')
 
 /**
+ * Object form of the `workspaces` field in package.json
+ * (the alternative to an array of glob patterns).
+ */
+export interface WorkspacesObject {
+  /** Array of workspace glob patterns */
+  packages: string[]
+}
+
+/**
  * Package.json structure.
  */
 export interface PackageJson {
@@ -40,12 +49,7 @@ export interface PackageJson {
   /** Optional dependencies */
   optionalDependencies?: Record<string, string>
   /** Workspaces configuration */
-  workspaces?:
-    | string[]
-    | {
-        /** Array of workspace glob patterns */
-        packages: string[]
-      }
+  workspaces?: string[] | WorkspacesObject
   /** Exports map */
   exports?: Record<string, unknown>
   /** Engines */
@@ -73,13 +77,7 @@ function isStringRecord(value: unknown): value is Record<string, string> {
  * @param value - Raw workspaces value from package.json
  * @returns Normalized workspace patterns or undefined if invalid
  */
-function parseWorkspaces(value: unknown):
-  | string[]
-  | {
-      /** Array of workspace glob patterns */
-      packages: string[]
-    }
-  | undefined {
+function parseWorkspaces(value: unknown): string[] | WorkspacesObject | undefined {
   if (isArray(value) && value.every((v) => typeof v === 'string')) {
     return <string[]>value
   }

--- a/libs/project-scope/src/tech/monorepo/nx.ts
+++ b/libs/project-scope/src/tech/monorepo/nx.ts
@@ -1,6 +1,6 @@
 import type { PackageJson } from '../../project/package'
 import type { DetectionSource } from '../shared-utils/types'
-import type { MonorepoDetection } from './types'
+import type { MonorepoDetection, WorkspaceLayout } from './types'
 import { join } from 'node:path'
 import { min } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
 import { keys } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
@@ -39,7 +39,7 @@ export function nxDetector(workspacePath: string, packageJson?: PackageJson): Mo
   const sources: DetectionSource[] = []
   let confidence = 0
   let version: string | undefined
-  let workspaceLayout: { /** Applications directory */ appsDir: string; /** Libraries directory */ libsDir: string } | undefined
+  let workspaceLayout: WorkspaceLayout | undefined
 
   const nxJsonPath = join(workspacePath, 'nx.json')
   if (exists(nxJsonPath)) {

--- a/libs/project-scope/src/tech/monorepo/types.ts
+++ b/libs/project-scope/src/tech/monorepo/types.ts
@@ -2,6 +2,16 @@ import type { PackageJson } from '../../project/package'
 import type { DetectionSource } from '../shared-utils/types'
 
 /**
+ * Filesystem layout describing where applications and libraries live in a monorepo.
+ */
+export interface WorkspaceLayout {
+  /** Applications directory */
+  appsDir: string
+  /** Libraries directory */
+  libsDir: string
+}
+
+/**
  * Monorepo detection result.
  */
 export interface MonorepoDetection {
@@ -18,7 +28,7 @@ export interface MonorepoDetection {
   /** Detection sources */
   detectedFrom: DetectionSource[]
   /** Workspace layout */
-  workspaceLayout?: { /** Applications directory */ appsDir: string; /** Libraries directory */ libsDir: string }
+  workspaceLayout?: WorkspaceLayout
   /** Detected project paths */
   projects?: string[]
 }

--- a/libs/project-scope/src/vfs/diff.ts
+++ b/libs/project-scope/src/vfs/diff.ts
@@ -7,6 +7,21 @@ import { createScopedLogger } from '../core/logger'
 const diffLogger = createScopedLogger('project-scope:vfs:diff')
 
 /**
+ * Single LCS-backtrack operation produced while diffing two arrays of lines.
+ * Used as the intermediate representation before being filtered into a {@link DiffLine}.
+ */
+type LcsOperation = {
+  /** Operation type: same, add, or remove */
+  type: 'same' | 'add' | 'remove'
+  /** Index in the old lines array */
+  oldIdx: number
+  /** Index in the new lines array */
+  newIdx: number
+  /** Line content */
+  content: string
+}
+
+/**
  * Options for diff generation.
  */
 export interface DiffOptions {
@@ -54,30 +69,8 @@ function computeLcsTable(oldLines: string[], newLines: string[]): number[][] {
  * @param newLines - Lines from the new file version
  * @returns Array of diff operations (unfiltered, includes all lines)
  */
-function backtrackLcs(
-  table: number[][],
-  oldLines: string[],
-  newLines: string[]
-): {
-  /** Operation type: same, add, or remove */
-  type: 'same' | 'add' | 'remove'
-  /** Index in the old lines array */
-  oldIdx: number
-  /** Index in the new lines array */
-  newIdx: number
-  /** Line content */
-  content: string
-}[] {
-  const result: {
-    /** Operation type: same, add, or remove */
-    type: 'same' | 'add' | 'remove'
-    /** Index in the old lines array */
-    oldIdx: number
-    /** Index in the new lines array */
-    newIdx: number
-    /** Line content */
-    content: string
-  }[] = []
+function backtrackLcs(table: number[][], oldLines: string[], newLines: string[]): LcsOperation[] {
+  const result: LcsOperation[] = []
   let i = oldLines.length
   let j = newLines.length
 
@@ -105,19 +98,7 @@ function backtrackLcs(
  * @param contextLines - Number of context lines to include
  * @returns Filtered DiffLine array
  */
-function operationsToDiffLines(
-  operations: {
-    /** Operation type: same, add, or remove */
-    type: 'same' | 'add' | 'remove'
-    /** Index in the old lines array */
-    oldIdx: number
-    /** Index in the new lines array */
-    newIdx: number
-    /** Line content */
-    content: string
-  }[],
-  contextLines: number
-): DiffLine[] {
+function operationsToDiffLines(operations: LcsOperation[], contextLines: number): DiffLine[] {
   const include = new Array<boolean>(operations.length).fill(false)
 
   for (let i = 0; i < operations.length; i++) {

--- a/libs/utils/data/src/index.ts
+++ b/libs/utils/data/src/index.ts
@@ -26,7 +26,14 @@ export type {
   TraversalCreator,
   Traverse,
 } from './models'
-export type { SelectiveCopyPredicate, DataPointOperation, SelectiveCopyOptions, DataPoint, ReferenceLoop } from './selective-copy.model'
+export type {
+  SelectiveCopyPredicate,
+  DataPointOperation,
+  SelectiveCopyOptions,
+  DataPoint,
+  ReferenceLoop,
+  SelectiveCopyResult,
+} from './selective-copy.model'
 export { CircularReference } from './circular-reference'
 export { containsKeys } from './contains-keys'
 export { deregisterClassTypes } from './deregister-class-types'

--- a/libs/utils/data/src/selective-copy.model.ts
+++ b/libs/utils/data/src/selective-copy.model.ts
@@ -45,3 +45,15 @@ export interface ReferenceLoop {
   /** Path where the loop leads to */
   destinationPath: string[]
 }
+
+/**
+ * Result of {@link selectiveCopy}: the partial clone and any skipped data points.
+ *
+ * @template T - Original target type
+ */
+export interface SelectiveCopyResult<T> {
+  /** Cloned value */
+  clone: Partial<T>
+  /** Skipped data points */
+  skipped: DataPoint[]
+}

--- a/libs/utils/data/src/selective-copy.ts
+++ b/libs/utils/data/src/selective-copy.ts
@@ -5,7 +5,14 @@ import { getType } from './get-type'
 import { isIterableType } from './is-iterable-type'
 import { ReferenceStack } from './models'
 import { referenceStack } from './reference-stack'
-import { SelectiveCopyOptions, SelectiveCopyPredicate, DataPointOperation, DataPoint, ReferenceLoop } from './selective-copy.model'
+import {
+  SelectiveCopyOptions,
+  SelectiveCopyPredicate,
+  DataPointOperation,
+  DataPoint,
+  ReferenceLoop,
+  SelectiveCopyResult,
+} from './selective-copy.model'
 import { getConfig } from './shared/consts'
 
 /**
@@ -170,10 +177,7 @@ export const selectiveCopyForCircularReferencesRecursive = <T extends Record<str
  * // clone = { a: 1 }, skipped = [{ path: ['b'], ... }]
  * ```
  */
-export const selectiveCopy = <T = unknown>(
-  target: T,
-  options?: SelectiveCopyOptions
-): { /** Cloned value */ clone: Partial<T>; /** Skipped data points */ skipped: DataPoint[] } => {
+export const selectiveCopy = <T = unknown>(target: T, options?: SelectiveCopyOptions): SelectiveCopyResult<T> => {
   if (options !== void 0 && getType(options) !== 'object') throw createError('Invalid options argument.')
   if (!options) options = {}
   if (!options.skipFunctions) options.skipFunctions = false

--- a/libs/utils/json/src/generate/to-json-schema.ts
+++ b/libs/utils/json/src/generate/to-json-schema.ts
@@ -6,19 +6,24 @@ import { mergeSchemas } from './merge-schemas'
 import { getJsonType } from './type-detection'
 
 /**
+ * Configuration controlling how arrays are inspected when generating a schema.
+ */
+export interface ArrayGenerateOptions {
+  /**
+   * Array handling mode:
+   * - 'all': Merge all item schemas (default)
+   * - 'first': Use only the first item's schema
+   * - 'uniform': Assume all items have the same schema
+   */
+  mode?: 'all' | 'first' | 'uniform'
+}
+
+/**
  * Options for schema generation.
  */
 export interface GenerateOptions {
   /** Array handling mode */
-  arrays?: {
-    /**
-     * Array handling mode:
-     * - 'all': Merge all item schemas (default)
-     * - 'first': Use only the first item's schema
-     * - 'uniform': Assume all items have the same schema
-     */
-    mode?: 'all' | 'first' | 'uniform'
-  }
+  arrays?: ArrayGenerateOptions
   /** Whether to include required fields (default: true) */
   includeRequired?: boolean
   /** Whether to allow additional properties (default: true) */

--- a/libs/utils/json/src/validate/keywords/pattern-properties.ts
+++ b/libs/utils/json/src/validate/keywords/pattern-properties.ts
@@ -5,6 +5,17 @@ import { createRegExp } from '@hyperfrontend/immutable-api-utils/built-in-copy/r
 import { addError, pushPath, shouldContinue } from '../context'
 
 /**
+ * Compiled `patternProperties` entry: a regex paired with the schema to apply
+ * to keys it matches.
+ */
+type CompiledPatternProperty = {
+  /** Compiled regex pattern */
+  regex: RegExp
+  /** Schema to validate against */
+  schema: Schema
+}
+
+/**
  * Validates object 'patternProperties' keyword.
  *
  * @param instance - Object being validated
@@ -29,7 +40,7 @@ export function validatePatternProperties(instance: Record<string, unknown>, sch
   }
 
   let valid = true
-  const patterns: Array<{ /** Compiled regex pattern */ regex: RegExp; /** Schema to validate against */ schema: Schema }> = []
+  const patterns: Array<CompiledPatternProperty> = []
 
   for (const [pattern, patternSchema] of entries(schema.patternProperties)) {
     /* istanbul ignore if -- patternSafetyChecker branch tested in validate.spec.ts */

--- a/libs/utils/string/src/lib/utils/base64-to-url-safe-base64.ts
+++ b/libs/utils/string/src/lib/utils/base64-to-url-safe-base64.ts
@@ -1,4 +1,14 @@
 /**
+ * Options controlling how {@link base64ToUrlSafeBase64} rewrites the input.
+ */
+export type Base64ToUrlSafeBase64Options = {
+  /** Whether to apply URL-safe transformations */
+  urlSafe: boolean
+  /** Whether to preserve padding characters */
+  keepPadding: boolean
+}
+
+/**
  * Converts standard base64 encoding to URL-safe base64 encoding.
  * Optionally removes padding characters for more compact representation.
  *
@@ -20,16 +30,7 @@
  * // => 'SGVsbG8'
  * ```
  */
-export function base64ToUrlSafeBase64(
-  base64: string,
-  {
-    urlSafe,
-    keepPadding,
-  }: {
-    /** Whether to apply URL-safe transformations */ urlSafe: boolean
-    /** Whether to preserve padding characters */ keepPadding: boolean
-  }
-): string {
+export function base64ToUrlSafeBase64(base64: string, { urlSafe, keepPadding }: Base64ToUrlSafeBase64Options): string {
   if (urlSafe) {
     base64 = base64.replaceAll('+', '-').replaceAll('/', '_')
     if (keepPadding === false) {

--- a/libs/versioning/src/changelog/compare/diff.ts
+++ b/libs/versioning/src/changelog/compare/diff.ts
@@ -265,23 +265,26 @@ export function diffEntries(source: ChangelogEntry, target: ChangelogEntry): Ent
 }
 
 /**
- * Diffs two section arrays.
- *
- * @param sourceSections - Array of sections from the source changelog
- * @param targetSections - Array of sections from the target changelog
- * @returns Diff result with added, removed, and modified sections
+ * Result of {@link diffSections}: sections grouped by how they differ between
+ * the source and target changelogs.
  */
-function diffSections(
-  sourceSections: readonly ChangelogSection[],
-  targetSections: readonly ChangelogSection[]
-): {
+type SectionsDiffResult = {
   /** Sections present in target but not in source */
   added: ChangelogSection[]
   /** Sections present in source but not in target */
   removed: ChangelogSection[]
   /** Sections present in both with differences */
   modified: SectionDiff[]
-} {
+}
+
+/**
+ * Diffs two section arrays.
+ *
+ * @param sourceSections - Array of sections from the source changelog
+ * @param targetSections - Array of sections from the target changelog
+ * @returns Diff result with added, removed, and modified sections
+ */
+function diffSections(sourceSections: readonly ChangelogSection[], targetSections: readonly ChangelogSection[]): SectionsDiffResult {
   const sourceByType = createMap<string, ChangelogSection>()
   const targetByType = createMap<string, ChangelogSection>()
 

--- a/libs/versioning/src/changelog/parse/line.ts
+++ b/libs/versioning/src/changelog/parse/line.ts
@@ -3,6 +3,18 @@ import { max } from '@hyperfrontend/immutable-api-utils/built-in-copy/math'
 import { parseInt } from '@hyperfrontend/immutable-api-utils/built-in-copy/number'
 
 /**
+ * Parsed version-line metadata extracted from a CHANGELOG section heading.
+ */
+export type ParsedVersionHeading = {
+  /** The parsed version string */
+  version: string
+  /** The parsed date in YYYY-MM-DD format, or null if not found */
+  date: string | null
+  /** Optional URL for comparing versions */
+  compareUrl?: string
+}
+
+/**
  * Parses a version string from a heading.
  * Examples: "1.2.3", "v1.2.3", "[1.2.3]", "1.2.3 - 2024-01-01"
  *
@@ -18,14 +30,7 @@ import { parseInt } from '@hyperfrontend/immutable-api-utils/built-in-copy/numbe
  * // => { version: '2.0.0', date: null, compareUrl: undefined }
  * ```
  */
-export function parseVersionFromHeading(heading: string): {
-  /** The parsed version string */
-  version: string
-  /** The parsed date in YYYY-MM-DD format, or null if not found */
-  date: string | null
-  /** Optional URL for comparing versions */
-  compareUrl?: string
-} {
+export function parseVersionFromHeading(heading: string): ParsedVersionHeading {
   const trimmed = heading.trim()
 
   const lowerHeading = trimmed.toLowerCase()
@@ -113,17 +118,23 @@ export function parseVersionFromHeading(heading: string): {
 }
 
 /**
+ * Result of {@link extractDate}: the extracted date plus how many characters
+ * of the source were consumed.
+ */
+type DateExtraction = {
+  /** The extracted date string in YYYY-MM-DD format */
+  date: string
+  /** Number of characters consumed from the input */
+  length: number
+}
+
+/**
  * Extracts a date in YYYY-MM-DD format from a string.
  *
  * @param str - The string to extract a date from
  * @returns The extracted date and its length, or null if no date found
  */
-function extractDate(str: string): {
-  /** The extracted date string in YYYY-MM-DD format */
-  date: string
-  /** Number of characters consumed from the input */
-  length: number
-} | null {
+function extractDate(str: string): DateExtraction | null {
   let pos = 0
 
   if (str[pos] === '(') pos++
@@ -194,19 +205,25 @@ function slashToHyphen(input: string): string {
 }
 
 /**
- * Extracts a markdown link from a string.
- *
- * @param str - The string to extract a link from
- * @returns The extracted link text, url, and length, or null if no link found
+ * Result of {@link extractLink}: the link text/url plus how many characters of
+ * the source were consumed.
  */
-function extractLink(str: string): {
+type LinkExtraction = {
   /** The link text content */
   text: string
   /** The link URL */
   url: string
   /** Number of characters consumed from the input */
   length: number
-} | null {
+}
+
+/**
+ * Extracts a markdown link from a string.
+ *
+ * @param str - The string to extract a link from
+ * @returns The extracted link text, url, and length, or null if no link found
+ */
+function extractLink(str: string): LinkExtraction | null {
   if (str[0] !== '[') return null
 
   let pos = 1
@@ -339,6 +356,17 @@ export function parseIssueRefs(text: string, baseUrl?: string): IssueRef[] {
 }
 
 /**
+ * Result of {@link parseScopeFromItem}: optional scope plus the description
+ * that follows it.
+ */
+export type ScopeFromItem = {
+  /** Optional scope extracted from the text */
+  scope?: string
+  /** The description text after the scope */
+  description: string
+}
+
+/**
  * Parses the scope from a changelog item.
  * Example: "**scope:** description" -> { scope: "scope", description: "description" }
  *
@@ -354,12 +382,7 @@ export function parseIssueRefs(text: string, baseUrl?: string): IssueRef[] {
  * // => { scope: undefined, description: 'Simple change without scope' }
  * ```
  */
-export function parseScopeFromItem(text: string): {
-  /** Optional scope extracted from the text */
-  scope?: string
-  /** The description text after the scope */
-  description: string
-} {
+export function parseScopeFromItem(text: string): ScopeFromItem {
   const trimmed = text.trim()
 
   if (trimmed.startsWith('**')) {

--- a/libs/versioning/src/commits/author/__test-utils__/mock-terminal.ts
+++ b/libs/versioning/src/commits/author/__test-utils__/mock-terminal.ts
@@ -19,17 +19,23 @@ export const TestKey = freeze(<const>{
   Tab: '\t',
 })
 
-/** Mock readable stream with a raw-mode flag and a key enqueue helper. */
-export type MockInput = NodeJS.ReadStream & {
+/** Test-only extensions added to the readable mock stream. */
+export interface MockInputExtensions {
   /** Enqueues key strokes to be emitted on the `data` event asynchronously */
   enqueueKeys: (keys: readonly string[]) => void
 }
 
-/** Mock writable stream that captures written output for assertions. */
-export type MockOutput = NodeJS.WriteStream & {
+/** Mock readable stream with a raw-mode flag and a key enqueue helper. */
+export type MockInput = NodeJS.ReadStream & MockInputExtensions
+
+/** Test-only extensions added to the writable mock stream. */
+export interface MockOutputExtensions {
   /** Returns everything written so far as a single string */
   getWrittenData: () => string
 }
+
+/** Mock writable stream that captures written output for assertions. */
+export type MockOutput = NodeJS.WriteStream & MockOutputExtensions
 
 /** Paired mock streams usable as `input`/`output` for any lib-questions prompt. */
 export interface MockTerminal {

--- a/libs/versioning/src/commits/classify/classifier.ts
+++ b/libs/versioning/src/commits/classify/classifier.ts
@@ -178,6 +178,20 @@ function getDependencyVariations(depName: string): readonly string[] {
 }
 
 /**
+ * Optional inputs for {@link createClassificationContext}.
+ */
+export type ClassificationContextOptions = {
+  /** Map of dependency names to commit hashes touching them */
+  readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
+  /** Set of commit hashes touching infrastructure paths */
+  readonly infrastructureCommitHashes?: ReadonlySet<string>
+  /** Scopes to explicitly exclude from classification */
+  readonly excludeScopes?: readonly string[]
+  /** Additional scopes to include as direct matches */
+  readonly includeScopes?: readonly string[]
+}
+
+/**
  * Creates a classification context from common inputs.
  *
  * @param projectScopes - Scopes that match the project
@@ -201,16 +215,7 @@ function getDependencyVariations(depName: string): readonly string[] {
 export function createClassificationContext(
   projectScopes: readonly string[],
   fileCommitHashes: ReadonlySet<string>,
-  options?: {
-    /** Map of dependency names to commit hashes touching them */
-    readonly dependencyCommitMap?: ReadonlyMap<string, ReadonlySet<string>>
-    /** Set of commit hashes touching infrastructure paths */
-    readonly infrastructureCommitHashes?: ReadonlySet<string>
-    /** Scopes to explicitly exclude from classification */
-    readonly excludeScopes?: readonly string[]
-    /** Additional scopes to include as direct matches */
-    readonly includeScopes?: readonly string[]
-  }
+  options?: ClassificationContextOptions
 ): ClassificationContext {
   return {
     projectScopes,

--- a/libs/versioning/src/commits/classify/models.ts
+++ b/libs/versioning/src/commits/classify/models.ts
@@ -145,6 +145,16 @@ export function createEmptyClassificationSummary(): ClassificationSummary {
 }
 
 /**
+ * Optional metadata that can be attached when constructing a {@link ClassifiedCommit}.
+ */
+export type CreateClassifiedCommitOptions = {
+  /** Files in the project modified by this commit */
+  readonly touchedFiles?: readonly string[]
+  /** Chain of dependencies leading to indirect inclusion */
+  readonly dependencyPath?: readonly string[]
+}
+
+/**
  * Creates a classified commit.
  *
  * @param commit - The parsed conventional commit
@@ -167,12 +177,7 @@ export function createClassifiedCommit(
   commit: ConventionalCommit,
   raw: GitCommit,
   source: CommitSource,
-  options?: {
-    /** Files in the project modified by this commit */
-    readonly touchedFiles?: readonly string[]
-    /** Chain of dependencies leading to indirect inclusion */
-    readonly dependencyPath?: readonly string[]
-  }
+  options?: CreateClassifiedCommitOptions
 ): ClassifiedCommit {
   const include = isIncludedSource(source)
   const preserveScope = shouldPreserveScope(source)

--- a/libs/versioning/src/commits/models/conventional.ts
+++ b/libs/versioning/src/commits/models/conventional.ts
@@ -65,6 +65,20 @@ export function createCommitFooter(key: string, value: string, separator: ':' | 
 }
 
 /**
+ * Allows callers to bypass the `type`/`subject`/`scope` formatter and pass a
+ * pre-built raw commit string.
+ */
+type RawCommitOverride = {
+  /** Raw commit message string override */
+  raw?: string
+}
+
+/**
+ * Optional inputs accepted by {@link createConventionalCommit} on top of `type` and `subject`.
+ */
+export type CreateConventionalCommitOptions = Partial<Omit<ConventionalCommit, 'type' | 'subject' | 'raw'>> & RawCommitOverride
+
+/**
  * Creates a conventional commit.
  *
  * @param type - The commit type (e.g., 'feat', 'fix')
@@ -84,14 +98,7 @@ export function createCommitFooter(key: string, value: string, separator: ':' | 
  * // => { ..., scope: ['versioning', 'questions'], raw: 'feat(versioning,questions): add x' }
  * ```
  */
-export function createConventionalCommit(
-  type: CommitType,
-  subject: string,
-  options?: Partial<Omit<ConventionalCommit, 'type' | 'subject' | 'raw'>> & {
-    /** Raw commit message string override */
-    raw?: string
-  }
-): ConventionalCommit {
+export function createConventionalCommit(type: CommitType, subject: string, options?: CreateConventionalCommitOptions): ConventionalCommit {
   const raw = options?.raw ?? buildRaw(type, subject, options)
 
   return {

--- a/libs/versioning/src/flow/models/types.ts
+++ b/libs/versioning/src/flow/models/types.ts
@@ -193,17 +193,31 @@ export interface ScopeFilteringConfig {
 }
 
 /**
+ * Explicit `undefined` placeholders for the infrastructure-related extensions
+ * of the default config — they exist so the default object can be assigned to
+ * a strictly-required type while still leaving infra unconfigured.
+ */
+type DefaultInfrastructureFields = {
+  /** Infrastructure projects configuration (unused in default) */
+  infrastructure: undefined
+  /** Infrastructure matcher function (unused in default) */
+  infrastructureMatcher: undefined
+}
+
+/**
+ * Shape of the default scope filtering configuration: every required field plus
+ * explicit `undefined` placeholders for the infrastructure-related extensions.
+ */
+export type DefaultScopeFilteringConfig = Required<Omit<ScopeFilteringConfig, 'infrastructure' | 'infrastructureMatcher'>> &
+  DefaultInfrastructureFields
+
+/**
  * Default scope filtering configuration.
  *
  * Uses DEFAULT_EXCLUDE_SCOPES from commits/classify to ensure consistency
  * between flow-level filtering and commit classification.
  */
-export const DEFAULT_SCOPE_FILTERING_CONFIG: Required<Omit<ScopeFilteringConfig, 'infrastructure' | 'infrastructureMatcher'>> & {
-  /** Infrastructure projects configuration (unused in default) */
-  infrastructure: undefined
-  /** Infrastructure matcher function (unused in default) */
-  infrastructureMatcher: undefined
-} = {
+export const DEFAULT_SCOPE_FILTERING_CONFIG: DefaultScopeFilteringConfig = {
   strategy: 'hybrid',
   includeScopes: [],
   excludeScopes: DEFAULT_EXCLUDE_SCOPES,

--- a/libs/versioning/src/flow/steps/analyze-commits.ts
+++ b/libs/versioning/src/flow/steps/analyze-commits.ts
@@ -189,19 +189,22 @@ export function createAnalyzeCommitsStep(): FlowStep {
 }
 
 /**
+ * Minimal commit shape consumed by {@link resolveStrategy} when inferring the
+ * filtering strategy from existing commit messages.
+ */
+type CommitMessage = {
+  /** Commit message to analyze */
+  message: string
+}
+
+/**
  * Resolves the filtering strategy, handling 'inferred' by analyzing commits.
  *
  * @param strategy - The configured scope filtering strategy
  * @param commits - The commits to analyze for strategy inference
  * @returns The resolved strategy (never 'inferred')
  */
-function resolveStrategy(
-  strategy: ScopeFilteringStrategy,
-  commits: readonly {
-    /** Commit message to analyze */
-    message: string
-  }[]
-): Exclude<ScopeFilteringStrategy, 'inferred'> {
+function resolveStrategy(strategy: ScopeFilteringStrategy, commits: readonly CommitMessage[]): Exclude<ScopeFilteringStrategy, 'inferred'> {
   if (strategy !== 'inferred') {
     return strategy
   }
@@ -263,6 +266,14 @@ function getRelativePath(workspaceRoot: string, projectRoot: string): string {
 }
 
 /**
+ * Slice of a classification summary needed by {@link buildSummaryMessage}.
+ */
+type ClassificationSummary = {
+  /** Count of commits by source type */
+  bySource: Record<string, number>
+}
+
+/**
  * Builds a summary message for the step result.
  *
  * @param includedCount - Number of commits included in the release
@@ -272,15 +283,7 @@ function getRelativePath(workspaceRoot: string, projectRoot: string): string {
  * @param strategy - The filtering strategy used
  * @returns A human-readable summary message
  */
-function buildSummaryMessage(
-  includedCount: number,
-  totalCount: number,
-  summary: {
-    /** Count of commits by source type */
-    bySource: Record<string, number>
-  },
-  strategy: string
-): string {
+function buildSummaryMessage(includedCount: number, totalCount: number, summary: ClassificationSummary, strategy: string): string {
   if (includedCount === 0) {
     return `No releasable commits found for this project (${totalCount} total, strategy: ${strategy})`
   }
@@ -288,6 +291,15 @@ function buildSummaryMessage(
   const parts = [`Found ${includedCount} releasable commits`, `(${totalCount} total`, `strategy: ${strategy})`]
 
   return parts.join(' ')
+}
+
+/**
+ * Minimal logger interface accepted by analyze-commits helpers.
+ * Only `debug` is required; consumers may pass a richer logger.
+ */
+type DebugLogger = {
+  /** Debug logging function */
+  debug: (msg: string) => void
 }
 
 /**
@@ -314,10 +326,7 @@ function buildInfrastructureCommitHashes(
   rawCommits: readonly GitCommit[],
   parsedCommits: readonly CommitWithRaw[],
   config: ScopeFilteringConfig,
-  logger: {
-    /** Debug logging function */
-    debug: (msg: string) => void
-  },
+  logger: DebugLogger,
   maxFallback: number
 ): ReadonlySet<string> | undefined {
   let infraHashes = createSet<string>()
@@ -404,10 +413,7 @@ function buildDependencyCommitMap(
   workspaceRoot: string,
   projectName: string,
   baseCommit: string | null,
-  logger: {
-    /** Debug logging function */
-    debug: (msg: string) => void
-  },
+  logger: DebugLogger,
   maxFallback: number
 ): ReadonlyMap<string, ReadonlySet<string>> {
   let dependencyMap = createMap<string, ReadonlySet<string>>()

--- a/libs/versioning/src/flow/steps/generate-changelog.ts
+++ b/libs/versioning/src/flow/steps/generate-changelog.ts
@@ -177,6 +177,16 @@ function formatScopePrefix(scope: readonly string[]): string {
 }
 
 /**
+ * Section type/heading pair driving the order of changelog sections.
+ */
+type ChangelogSectionOrderEntry = {
+  /** Changelog section type identifier */
+  type: ChangelogSectionType
+  /** Display heading for the section */
+  heading: string
+}
+
+/**
  * Creates the generate-changelog step.
  *
  * This step:
@@ -279,12 +289,7 @@ export function createGenerateChangelogStep(): FlowStep {
 
         const groupedDirect = groupClassifiedCommitsBySection(directCommits, commitTypeMapping)
 
-        const sectionOrder: readonly {
-          /** Changelog section type identifier */
-          type: ChangelogSectionType
-          /** Display heading for the section */
-          heading: string
-        }[] = [
+        const sectionOrder: readonly ChangelogSectionOrderEntry[] = [
           { type: 'features', heading: 'Features' },
           { type: 'fixes', heading: 'Bug Fixes' },
           { type: 'performance', heading: 'Performance' },
@@ -331,12 +336,7 @@ export function createGenerateChangelogStep(): FlowStep {
           )
         }
 
-        const sectionOrder: readonly {
-          /** Changelog section type identifier */
-          type: ChangelogSectionType
-          /** Display heading for the section */
-          heading: string
-        }[] = [
+        const sectionOrder: readonly ChangelogSectionOrderEntry[] = [
           { type: 'features', heading: 'Features' },
           { type: 'fixes', heading: 'Bug Fixes' },
           { type: 'performance', heading: 'Performance' },

--- a/libs/versioning/src/git/operations/operation-state.ts
+++ b/libs/versioning/src/git/operations/operation-state.ts
@@ -16,6 +16,22 @@ import { DEFAULT_COMMIT_OPTIONS } from './commit'
 export type GitOperationStateReason = 'rebase-interactive' | 'rebase-apply' | 'merge-in-progress'
 
 /**
+ * Per-check details captured while inspecting git's operation state.
+ *
+ * Each flag corresponds to one of the `.git/` state files probed by
+ * {@link getOperationState}; useful for diagnostics or when multiple
+ * states could theoretically overlap.
+ */
+export interface GitOperationStateDetails {
+  /** True if an interactive/merge rebase is in progress */
+  readonly rebaseMerge: boolean
+  /** True if a non-interactive rebase is in progress */
+  readonly rebaseApply: boolean
+  /** True if a merge is in progress */
+  readonly mergeHead: boolean
+}
+
+/**
  * Result of checking git's operation state.
  */
 export interface GitOperationState {
@@ -32,14 +48,7 @@ export interface GitOperationState {
    * Detailed state for each check performed.
    * Useful for diagnostics or when multiple states could theoretically overlap.
    */
-  readonly details: {
-    /** True if an interactive/merge rebase is in progress */
-    readonly rebaseMerge: boolean
-    /** True if a non-interactive rebase is in progress */
-    readonly rebaseApply: boolean
-    /** True if a merge is in progress */
-    readonly mergeHead: boolean
-  }
+  readonly details: GitOperationStateDetails
 }
 
 /**

--- a/libs/versioning/src/registry/models/package-info.ts
+++ b/libs/versioning/src/registry/models/package-info.ts
@@ -36,6 +36,32 @@ export interface PackageInfo {
 }
 
 /**
+ * Inputs for {@link createPackageInfo}.
+ */
+export interface CreatePackageInfoOptions {
+  /** Package name, e.g., 'lodash' or '@scope/pkg' */
+  name: string
+  /** The most recently published semver string */
+  latestVersion: string
+  /** All published semver strings in chronological order */
+  versions: readonly string[]
+  /** Brief summary of package functionality */
+  description?: string
+  /** SPDX license identifier */
+  license?: string
+  /** URL to source code repository */
+  repository?: string
+  /** URL to project homepage or documentation site */
+  homepage?: string
+  /** List of maintainers with name and email */
+  maintainers?: readonly Maintainer[]
+  /** Search terms for npm registry discovery */
+  keywords?: readonly string[]
+  /** Time of last modification */
+  lastModified?: string
+}
+
+/**
  * Creates a new PackageInfo object.
  *
  * @param options - Configuration for the package info
@@ -61,28 +87,7 @@ export interface PackageInfo {
  * })
  * ```
  */
-export function createPackageInfo(options: {
-  /** Package name, e.g., 'lodash' or '@scope/pkg' */
-  name: string
-  /** The most recently published semver string */
-  latestVersion: string
-  /** All published semver strings in chronological order */
-  versions: readonly string[]
-  /** Brief summary of package functionality */
-  description?: string
-  /** SPDX license identifier */
-  license?: string
-  /** URL to source code repository */
-  repository?: string
-  /** URL to project homepage or documentation site */
-  homepage?: string
-  /** List of maintainers with name and email */
-  maintainers?: readonly Maintainer[]
-  /** Search terms for npm registry discovery */
-  keywords?: readonly string[]
-  /** Time of last modification */
-  lastModified?: string
-}): PackageInfo {
+export function createPackageInfo(options: CreatePackageInfoOptions): PackageInfo {
   return {
     name: options.name,
     description: options.description,

--- a/libs/versioning/src/registry/models/version-info.ts
+++ b/libs/versioning/src/registry/models/version-info.ts
@@ -57,6 +57,36 @@ export interface VersionInfo {
 }
 
 /**
+ * Inputs for {@link createVersionInfo}.
+ */
+export interface CreateVersionInfoOptions {
+  /** Semver version string (e.g., '1.2.3') */
+  version: string
+  /** ISO 8601 timestamp of publication */
+  publishedAt: string
+  /** URL to the package tarball */
+  tarball: string
+  /** Subresource integrity hash */
+  integrity?: string
+  /** Production dependencies map */
+  dependencies?: Record<string, string>
+  /** Development dependencies map */
+  devDependencies?: Record<string, string>
+  /** Peer dependencies map */
+  peerDependencies?: Record<string, string>
+  /** Optional dependencies map */
+  optionalDependencies?: Record<string, string>
+  /** Engine requirements (Node/npm) */
+  engines?: Record<string, string>
+  /** Node.js version used during publish */
+  nodeVersion?: string
+  /** npm version used during publish */
+  npmVersion?: string
+  /** Git commit hash at publish time */
+  gitHead?: string
+}
+
+/**
  * Creates a new VersionInfo object.
  *
  * @param options - Configuration for the release info
@@ -83,32 +113,7 @@ export interface VersionInfo {
  * })
  * ```
  */
-export function createVersionInfo(options: {
-  /** Semver version string (e.g., '1.2.3') */
-  version: string
-  /** ISO 8601 timestamp of publication */
-  publishedAt: string
-  /** URL to the package tarball */
-  tarball: string
-  /** Subresource integrity hash */
-  integrity?: string
-  /** Production dependencies map */
-  dependencies?: Record<string, string>
-  /** Development dependencies map */
-  devDependencies?: Record<string, string>
-  /** Peer dependencies map */
-  peerDependencies?: Record<string, string>
-  /** Optional dependencies map */
-  optionalDependencies?: Record<string, string>
-  /** Engine requirements (Node/npm) */
-  engines?: Record<string, string>
-  /** Node.js version used during publish */
-  nodeVersion?: string
-  /** npm version used during publish */
-  npmVersion?: string
-  /** Git commit hash at publish time */
-  gitHead?: string
-}): VersionInfo {
+export function createVersionInfo(options: CreateVersionInfoOptions): VersionInfo {
   return {
     version: options.version,
     publishedAt: options.publishedAt,

--- a/libs/versioning/src/registry/npm/client.ts
+++ b/libs/versioning/src/registry/npm/client.ts
@@ -10,14 +10,24 @@ import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 import { createCache } from './cache'
 
 /**
+ * Optional authentication token used when accessing private registries.
+ */
+type RegistryAuthToken = {
+  /** Optional authentication token for private registries */
+  authToken?: string
+}
+
+/**
+ * Resolved configuration: every required field plus the optional auth token.
+ */
+type ResolvedRegistryConfig = Required<Omit<RegistryConfig, 'authToken'>> & RegistryAuthToken
+
+/**
  * Internal state for the npm registry client.
  */
 interface NpmRegistryState {
   /** Resolved configuration settings */
-  readonly config: Required<Omit<RegistryConfig, 'authToken'>> & {
-    /** Optional authentication token for private registries */
-    authToken?: string
-  }
+  readonly config: ResolvedRegistryConfig
   /** Cache instance for storing results */
   readonly cache: Cache
 }

--- a/libs/versioning/src/workspace/discovery/dependencies.ts
+++ b/libs/versioning/src/workspace/discovery/dependencies.ts
@@ -231,17 +231,23 @@ export function buildDependencyGraph(projects: readonly Project[]): DependencyGr
 }
 
 /**
+ * Result of {@link detectCircularDependencies}: whether any cycle was found
+ * and the list of cycles for diagnostic output.
+ */
+type CircularDependencyDetection = {
+  /** Whether any circular dependency was detected */
+  hasCircular: boolean
+  /** List of detected dependency cycles */
+  cycles: string[][]
+}
+
+/**
  * Detects circular dependencies in the graph using DFS.
  *
  * @param reverseDependencyGraph - Map of package to its dependencies
  * @returns Detection result with cycle information
  */
-function detectCircularDependencies(reverseDependencyGraph: Map<string, string[]>): {
-  /** Whether any circular dependency was detected */
-  hasCircular: boolean
-  /** List of detected dependency cycles */
-  cycles: string[][]
-} {
+function detectCircularDependencies(reverseDependencyGraph: Map<string, string[]>): CircularDependencyDetection {
   const cycles: string[][] = []
   const visited = createSet<string>()
   const recursionStack = createSet<string>()

--- a/libs/versioning/src/workspace/discovery/packages.ts
+++ b/libs/versioning/src/workspace/discovery/packages.ts
@@ -269,6 +269,21 @@ function parsePackageJsonFilesFromTree(tree: Tree, workspaceRoot: string, packag
 }
 
 /**
+ * Internal-dependency annotation attached to project drafts so the dependency
+ * graph can be wired up after all projects are discovered.
+ */
+type InternalDependencyAnnotation = {
+  /** List of internal package dependencies */
+  internalDependencies: string[]
+}
+
+/**
+ * Project draft used by {@link buildProjectsWithDependencies}: the standard
+ * create-project options with internal dependencies attached for later wiring.
+ */
+type ProjectWithInternalDependencies = CreateProjectOptions & InternalDependencyAnnotation
+
+/**
  * Builds projects with internal dependency information.
  *
  * @param rawPackages - Raw package info objects
@@ -276,12 +291,7 @@ function parsePackageJsonFilesFromTree(tree: Tree, workspaceRoot: string, packag
  * @returns Array of Project objects with dependencies populated
  */
 function buildProjectsWithDependencies(rawPackages: RawPackageInfo[], packageNames: Set<string>): Project[] {
-  const projectsWithDeps: Array<
-    CreateProjectOptions & {
-      /** List of internal package dependencies */
-      internalDependencies: string[]
-    }
-  > = []
+  const projectsWithDeps: Array<ProjectWithInternalDependencies> = []
 
   for (const pkg of rawPackages) {
     const internalDeps = findInternalDependencies(pkg.packageJson, packageNames)

--- a/libs/versioning/src/workspace/models/workspace.ts
+++ b/libs/versioning/src/workspace/models/workspace.ts
@@ -101,6 +101,24 @@ export function createWorkspaceConfig(options?: Partial<WorkspaceConfig>): Works
 }
 
 /**
+ * Inputs for {@link createWorkspace}.
+ */
+export interface CreateWorkspaceOptions {
+  /** Absolute path to workspace root directory */
+  root: string
+  /** Type of workspace (nx, turbo, etc.) */
+  type: WorkspaceType
+  /** Map of project names to project objects */
+  projects: ReadonlyMap<string, Project>
+  /** Configuration used for workspace discovery */
+  config: WorkspaceConfig
+  /** Map of package names to their dependents */
+  dependencyGraph: ReadonlyMap<string, readonly string[]>
+  /** Map of package names to their dependencies */
+  reverseDependencyGraph: ReadonlyMap<string, readonly string[]>
+}
+
+/**
  * Creates a new workspace object.
  *
  * @param options - Workspace properties
@@ -127,20 +145,7 @@ export function createWorkspaceConfig(options?: Partial<WorkspaceConfig>): Works
  * })
  * ```
  */
-export function createWorkspace(options: {
-  /** Absolute path to workspace root directory */
-  root: string
-  /** Type of workspace (nx, turbo, etc.) */
-  type: WorkspaceType
-  /** Map of project names to project objects */
-  projects: ReadonlyMap<string, Project>
-  /** Configuration used for workspace discovery */
-  config: WorkspaceConfig
-  /** Map of package names to their dependents */
-  dependencyGraph: ReadonlyMap<string, readonly string[]>
-  /** Map of package names to their dependencies */
-  reverseDependencyGraph: ReadonlyMap<string, readonly string[]>
-}): Workspace {
+export function createWorkspace(options: CreateWorkspaceOptions): Workspace {
   const projectList = [...options.projects.values()].sort((a, b) => a.name.localeCompare(b.name))
 
   return {

--- a/libs/versioning/src/workspace/operations/batch-update.ts
+++ b/libs/versioning/src/workspace/operations/batch-update.ts
@@ -179,6 +179,14 @@ function extractVersionPrefix(versionRange: string): string {
 }
 
 /**
+ * Minimal slice of a `package.json` whose `version` field can be mutated.
+ */
+type PackageJsonVersion = {
+  /** Package version string */
+  version: string
+}
+
+/**
  * Updates a package.json file using a VFS Tree.
  *
  * @param tree - Virtual file system tree
@@ -197,10 +205,7 @@ function extractVersionPrefix(versionRange: string): string {
  * ```
  */
 export function updatePackageVersionInTree(tree: Tree, packageJsonPath: string, newVersion: string): void {
-  changeJsonFile<{
-    /** Package version string */
-    version: string
-  }>(tree, packageJsonPath, (pkg) => {
+  changeJsonFile<PackageJsonVersion>(tree, packageJsonPath, (pkg) => {
     pkg.version = newVersion
     return pkg
   })

--- a/libs/versioning/src/workspace/operations/validate.ts
+++ b/libs/versioning/src/workspace/operations/validate.ts
@@ -300,16 +300,22 @@ function validateDependencyVersions(workspace: Workspace, project: Project): Val
 }
 
 /**
+ * Result of {@link validatePackageNameFormat}: a single `valid` flag indicating
+ * whether the supplied package name conforms to npm's name rules.
+ */
+type PackageNameFormatValidation = {
+  /** Whether the package name format is valid. */
+  valid: boolean
+}
+
+/**
  * Validates npm package name format without using complex regex.
  * This avoids ReDoS vulnerabilities from backtracking regex patterns.
  *
  * @param name - Package name to validate
  * @returns Validation result
  */
-function validatePackageNameFormat(name: string): {
-  /** Whether the package name format is valid. */
-  valid: boolean
-} {
+function validatePackageNameFormat(name: string): PackageNameFormatValidation {
   const isValidChar = (char: string): boolean => {
     const code = char.charCodeAt(0)
     return (code >= 97 && code <= 122) || (code >= 48 && code <= 57) || code === 45 || code === 95 || code === 46

--- a/roadmap/phase-1-2-builder-implementation-plan.md
+++ b/roadmap/phase-1-2-builder-implementation-plan.md
@@ -1,0 +1,716 @@
+# `@hyperfrontend/builder` Implementation Plan
+
+**Status:** Approved (Grill Session Complete)
+**Date:** 2026-04-27
+**Parent:** [features-implementation-plan.md](./features-implementation-plan.md), Phase 1.2
+
+---
+
+## Context
+
+Create `@hyperfrontend/builder`, the publishable vendor-neutral spiritual successor of [tools/package/src/executors/build/](../tools/package/src/executors/build/). It exposes composable primitives plus a single `build()` facade for library bundling (ESM/CJS/IIFE/UMD), JS bin synthesis, and Node SEA cross-platform native binaries; the existing Nx executor in `tools/package` is reduced to a thin facade caller and lib-versioning's hand-rolled `scripts/build-bins.mjs` is deleted in the same migration.
+
+---
+
+## Decisions Locked
+
+| #   | Topic                       | Decision                                                                                                                                                                                                                    |
+| --- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Scope                       | Library + bin (JS) + Node SEA cross-platform native binaries + features-style shell packages — all in scope                                                                                                                 |
+| 2   | API model                   | No separate "library mode" vs "CLI mode" — bins are standard `package.json#bin`. Composable primitives + facades + CLI + native binary                                                                                      |
+| 3   | Shell packages              | Treated as libraries with extra inlining + pre-build code-gen seam (generator lives in `@hyperfrontend/features`, not builder)                                                                                              |
+| 4   | Opinionation principle      | Composable primitives + opt-in presets, single big-config `build()` runner, presets replaceable                                                                                                                             |
+| 5   | Sub-path layout             | Domain-grouped (~12 subpaths), lib-versioning style                                                                                                                                                                         |
+| 6   | Workspace dep awareness     | `isWorkspacePackage?: (name: string) => boolean` predicate canonical; `byPrefix(scope)` and `byNames(names[])` factories in `./presets`                                                                                     |
+| 7   | Logger source               | Primitives use `logger` from `@hyperfrontend/logging` directly; no DI                                                                                                                                                       |
+| 8   | Logger extensions           | `channel`/`timed`/`timedAsync` promoted upstream into `@hyperfrontend/logging` itself                                                                                                                                       |
+| 9   | I/O delegation              | Strict `@hyperfrontend/project-scope` delegation; raw `node:fs` only for genuine gaps. **No** `@nx/devkit`, **no** `glob`, **no** `minimatch`. Allowed externals: `rollup` + `@rollup/plugin-*` + `typescript` + `postject` |
+| 10  | Memory monitor              | Subpath `@hyperfrontend/builder/memory`, opt-in via config; `recover()` (event-loop yield) is always-on free utility independent of monitoring                                                                              |
+| 11  | Default assets              | Builder ships zero default-asset knowledge — generic `copyAssets({ from, to, files[], condition? })` primitive. Wrapper supplies its own asset spec lists                                                                   |
+| 12  | Field inheritance           | Configurable: `inheritFieldsFrom?: { from: string; fields: string[] }`. Wrapper passes `{ from: workspaceRoot/package.json, fields: ['repository','bugs','homepage','author'] }`                                            |
+| 13  | Output workspace-dep filter | Opt-in flag (`filterWorkspaceDepsFromOutput: boolean`), explicit                                                                                                                                                            |
+| 14  | Bin source convention       | Enforced: `src/bin/<name>.ts`. Config supplies `name` only                                                                                                                                                                  |
+| 15  | Bin runner export           | Default: `default` export. Override via `runner: 'name'` (preserves lib-versioning's `runCz`/`runCl`)                                                                                                                       |
+| 16  | Bin runner contract         | `(io: { argv: string[], cwd: string, stderr: NodeJS.WritableStream, stdout?: NodeJS.WritableStream }) => number \| Promise<number>`                                                                                         |
+| 17  | Bin format                  | Per-bin `format: 'cjs' \| 'esm' \| ('cjs' \| 'esm')[]` (required). Both supported per declaration                                                                                                                           |
+| 18  | Bin bootstrap footer        | Built-in default footer + per-bin string override (`bootstrap?: string`)                                                                                                                                                    |
+| 19  | Bin mechanics               | Always: chmod 0o755 + shebang `#!/usr/bin/env node`. Auto-wire JS bins to `package.json#bin`                                                                                                                                |
+| 20  | Node SEA injection          | `postject` is the third allowed external dep (alongside rollup + typescript). Builder calls postject's JS API directly                                                                                                      |
+| 21  | Node SEA platform model     | Current-platform-only build. Per-bin `sea?: { platforms: [...] }`. Builder skips with info log if `process.platform`/`arch` not in declared targets. CI matrix orchestrates per-platform runners                            |
+| 22  | Native binary wiring        | Native binaries do **not** auto-wire to `package.json#bin` — output to `dist/.../bin/<name>.<platform>-<arch>`; CI/release tooling distributes as separate artifacts                                                        |
+| 23  | Wrapper invocation          | Facade-only. ~50 lines. No primitive composition                                                                                                                                                                            |
+| 24  | Wrapper lib/                | Delete entire `tools/package/src/executors/build/lib/`. Tiny `wrapper-config.ts` for monorepo constants only                                                                                                                |
+| 25  | Wrapper schema              | Minimal/opinionated, mirrors builder's facade config. Monorepo opinions hardcoded                                                                                                                                           |
+| 26  | Migration timing            | Atomic in one PR: builder land + wrapper retrofit + lib-versioning migration                                                                                                                                                |
+| 27  | Bootstrap                   | Builder dogfoods via wrapper. Phased commits inside the PR                                                                                                                                                                  |
+| 28  | Self-build smoke test       | None. Regular CI is sufficient                                                                                                                                                                                              |
+| 29  | CI native platforms         | Full common set (per GitHub Actions runner availability): `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`                                                                                             |
+| 30  | CI native trigger           | Main branch only. PR pipeline validates JS bin builds only                                                                                                                                                                  |
+| 31  | Native artifact destination | GitHub Releases attached to the auto-tagged versions from the existing ci-main.yml publish flow                                                                                                                             |
+| 32  | CI workflow shape           | Reusable `_lib-native.yml` template + per-lib `ci-lib-<name>-native.yml` caller                                                                                                                                             |
+| 33  | Test depth                  | 100% coverage on every primitive                                                                                                                                                                                            |
+| 34  | Integration tests           | None at builder level. Wrapper's libs continuing to build successfully is the integration coverage                                                                                                                          |
+| 35  | Behavioral parity           | Manual diff during the migration PR. No permanent CI parity assertion                                                                                                                                                       |
+| 36  | Plan format                 | Per implementation-plans skill                                                                                                                                                                                              |
+| 37  | Doc deliverables            | README + JSDoc per skills up-front. ARCHITECTURE.md deferred to release-time on user request                                                                                                                                |
+
+### Minor scaffolding choices (proposed; revisit during PR review)
+
+- **Builder CLI bin name:** single bin `hf-build` declared at `src/bin/hf-build.ts`.
+- **Initial preset list:** `byPrefix(scope)`, `byNames(names[])` only. Future presets (`standardLibrary`, `shellPackage`) added when their consumers exist.
+- **Runtime config validation:** none. TypeScript types are the contract.
+
+---
+
+## Sub-path Layout
+
+```
+@hyperfrontend/builder
+├── .                       facade: build(config) runner + key types
+├── ./models                all type definitions
+├── ./bundle                facade for bundling subdomain
+├── ./bundle/entries        entry-point discovery primitives
+├── ./bundle/externals      externals resolution primitives
+├── ./bundle/rollup         rollup driver primitives + plugin factories
+├── ./bundle/declarations   tsc-driven .d.ts emission + flatten
+├── ./package               facade for package output subdomain
+├── ./package/json          package.json synthesis + exports field generation + inheritance + filter
+├── ./package/assets        generic copyAssets primitive
+├── ./package/licenses      third-party license collection (opt-in preset)
+├── ./bin                   facade for bin output subdomain
+├── ./bin/script            JS bin synthesis (shebang, bootstrap, chmod, cjs/esm)
+├── ./bin/native            Node SEA native binary per platform (postject)
+├── ./presets               byPrefix, byNames, future preset factories
+└── ./memory                opt-in memory monitor + thresholds
+```
+
+---
+
+## Dependency Surface
+
+Allowed runtime/dev dependencies (hard constraint):
+
+| Dependency                           | Role                                                 |
+| ------------------------------------ | ---------------------------------------------------- |
+| `@hyperfrontend/logging`             | Logging substrate (extended in Phase 1)              |
+| `@hyperfrontend/project-scope`       | File/path/glob/walk substrate                        |
+| `@hyperfrontend/immutable-api-utils` | Safe builtins per coding skill                       |
+| `@hyperfrontend/json-utils`          | (Optional, only if a future config-validation lands) |
+| `rollup`                             | Bundler                                              |
+| `@rollup/plugin-commonjs`            | CJS interop for rollup                               |
+| `@rollup/plugin-json`                | JSON imports for rollup                              |
+| `@rollup/plugin-node-resolve`        | Node resolution for rollup                           |
+| `@rollup/plugin-terser`              | Minification for IIFE/UMD                            |
+| `@rollup/plugin-typescript`          | TypeScript transpilation in rollup                   |
+| `typescript`                         | `tsc` invocation for declaration emission            |
+| `postject`                           | Node SEA blob injection (third allowed external)     |
+| `node:*` builtins                    | I/O ops not covered by project-scope                 |
+
+**Banned:** `@nx/devkit`, `glob`, `minimatch`, any other external runtime dep.
+
+---
+
+## Phase 1 — Foundation: extend `@hyperfrontend/logging`
+
+Promote `channel`, `timed`, `timedAsync` from the executor's local `BuildLogger` into lib-logging itself. Builder primitives (and any other consumer) get them natively.
+
+**Files to modify:**
+
+- `libs/logging/src/create-logger.ts` — extend `Logger` type with `channel`, `timed`, `timedAsync`; implement them in the factory
+- `libs/logging/src/create-logger.spec.ts` — add 100% coverage for the three new methods
+- `libs/logging/src/index.ts` — re-export updated types
+- `libs/logging/package.json` — bump version (minor: feature addition)
+- `libs/logging/README.md` — document new methods per readme-docs skill
+
+**Method signatures:**
+
+```typescript
+interface Logger {
+  // ... existing methods
+  /** Returns a sub-logger that prepends `[prefix]` to every message. */
+  channel(prefix: string): Logger
+  /** Wraps a sync call with timing. Logs completion or failure with elapsed ms. */
+  timed<T>(label: string, fn: () => T): T
+  /** Wraps a promise-returning call with timing. Dumps stack trace on error to debug log. */
+  timedAsync<T>(label: string, fn: () => Promise<T>): Promise<T>
+}
+```
+
+**Verification:**
+
+```bash
+npx nx test lib-logging
+npx nx lint lib-logging --fix
+npx nx typecheck lib-logging
+npx nx format:write --projects=lib-logging
+```
+
+---
+
+## Phase 2 — Scaffold `libs/builder`
+
+Generate the publishable library shell.
+
+**Generator command:**
+
+```bash
+nx generate @hyperfrontend/package:library \
+  --name=builder \
+  --type=util \
+  --description="Composable, vendor-neutral build toolkit for TypeScript libraries, JS bins, and Node SEA native binaries." \
+  --publishable
+```
+
+**Files to verify after generation:**
+
+- `libs/builder/package.json` — name `@hyperfrontend/builder`, version `0.0.0`, license MIT, sideEffects false, engines, keywords, exports map (placeholder)
+- `libs/builder/project.json` — name `lib-builder`, tags `['type:util','scope:public']`, build target uses `@hyperfrontend/package:build`, version + version-check + publish targets
+- `libs/builder/tsconfig.json`, `tsconfig.lib.json`, `tsconfig.spec.json` — standard
+- `libs/builder/eslint.config.cjs`, `jest.config.ts` — standard
+- `libs/builder/README.md` — standard sections per readme-docs skill
+- `libs/builder/src/index.ts` — `@module` JSDoc header, empty re-exports
+
+**Files to create:**
+
+- `libs/builder/CHANGELOG.md` — initial Keep-a-Changelog skeleton
+
+**Files to modify:**
+
+- `tsconfig.base.json` — add `"@hyperfrontend/builder": ["libs/builder/src/index.ts"]` path
+
+**Add deps to `libs/builder/package.json`:**
+
+```json
+{
+  "dependencies": {
+    "@hyperfrontend/logging": "<current>",
+    "@hyperfrontend/project-scope": "<current>",
+    "@hyperfrontend/immutable-api-utils": "<current>",
+    "rollup": "<current>",
+    "@rollup/plugin-commonjs": "<current>",
+    "@rollup/plugin-json": "<current>",
+    "@rollup/plugin-node-resolve": "<current>",
+    "@rollup/plugin-terser": "<current>",
+    "@rollup/plugin-typescript": "<current>",
+    "typescript": "<current>",
+    "postject": "<current>"
+  }
+}
+```
+
+**Verification:**
+
+```bash
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+npx nx format:write --projects=lib-builder
+```
+
+---
+
+## Phase 3 — Models and Memory
+
+Type definitions (no implementation logic) plus the opt-in memory monitor with always-on `recover()` utility.
+
+**Files to create:**
+
+- `libs/builder/src/models/index.ts` — `@module` header, re-exports
+- `libs/builder/src/models/build-config.ts` — `BuildConfig`, `EsmConfig`, `CjsConfig`, `IifeConfig`, `UmdConfig`, `BinConfig`, `SeaConfig`, `AssetSpec`, `InheritFromSpec`
+- `libs/builder/src/models/entry-point.ts` — `EntryPoint`, `EntryPointDiscovery`, `EntryPointCategory`
+- `libs/builder/src/models/format-output.ts` — `FormatOutputs`, `IifeOutput`, `UmdOutput`
+- `libs/builder/src/models/package-json.ts` — `PackageJson`, `ConditionalExport`, `ExportValue`, `RepositoryField`, `BugsField`, `AuthorField`, `FundingField`
+- `libs/builder/src/models/build-context.ts` — `BuildContext` (computed paths + resolved settings, no Nx context)
+- `libs/builder/src/models/build-result.ts` — `BuildResult` (success + per-format counts + timing)
+- `libs/builder/src/memory/index.ts` — `@module` header
+- `libs/builder/src/memory/recover.ts` — always-on `recover()` (yield to event loop, optional GC if `--expose-gc`)
+- `libs/builder/src/memory/recover.spec.ts` — 100% coverage
+- `libs/builder/src/memory/monitor.ts` — `createMemoryMonitor(opts?)` factory; `MemorySnapshot`, `MemoryMonitorOptions` (warningMB, criticalMB, growthMB)
+- `libs/builder/src/memory/monitor.spec.ts` — 100% coverage
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export models
+- `libs/builder/package.json` — add `./models` and `./memory` exports
+- `tsconfig.base.json` — add path mappings for both subpaths
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+```
+
+---
+
+## Phase 4 — Bundle subdomain
+
+Entry-point discovery, externals resolution (predicate-based), per-format Rollup configuration factories, and tsc-driven declaration generation. Replaces `minimatch` with `matchGlobPattern` from project-scope and `glob` with `walkDirectory`/`findFilesInTree`.
+
+**Files to create:**
+
+- `libs/builder/src/bundle/index.ts` — `@module` header; re-exports a `runBundlePhase(ctx, config)` orchestrator
+- `libs/builder/src/bundle/entries/index.ts` — `@module` header
+- `libs/builder/src/bundle/entries/discover-entries.ts` — `discoverEntries(projectRoot)` (current `discoverEntryPoints` ported, `node:fs` via project-scope where possible)
+- `libs/builder/src/bundle/entries/resolve-entries.ts` — `resolveEntries(config, discovered)` using `matchGlobPattern`
+- `libs/builder/src/bundle/entries/by-platform.ts` — `getEntriesByPlatform`, `getSharedEntries`
+- `libs/builder/src/bundle/entries/*.spec.ts` — 100% coverage
+- `libs/builder/src/bundle/externals/index.ts` — `@module` header
+- `libs/builder/src/bundle/externals/resolve-externals.ts` — `resolveExternals({ packageJsonPath, additional, isWorkspacePackage, bundleWorkspaceDeps })`. Returns `string[]`
+- `libs/builder/src/bundle/externals/external-fn.ts` — `createExternalFn(externals)`, `createBundleExternalFn(externals?)`
+- `libs/builder/src/bundle/externals/validate-globals.ts` — `validateExternalsConfig(externals, globals)` (throws on missing globals)
+- `libs/builder/src/bundle/externals/*.spec.ts` — 100% coverage
+- `libs/builder/src/bundle/rollup/index.ts` — `@module` header
+- `libs/builder/src/bundle/rollup/plugins.ts` — `createNodeResolvePlugin(opts)`, `createBrowserNodeResolvePlugin()`, `createCommonJsPlugin()`, `createTypescriptPlugin(opts)`, `createBundleTypescriptPlugin(opts)`, `createJsonPlugin()`, `createTerserPlugin()`
+- `libs/builder/src/bundle/rollup/config-esm.ts` — `createEsmEntryConfig(entry, config, ctx)` + `createEsmConfig(...)`
+- `libs/builder/src/bundle/rollup/config-cjs.ts` — same shape for CJS
+- `libs/builder/src/bundle/rollup/config-iife.ts` — same shape for IIFE
+- `libs/builder/src/bundle/rollup/config-umd.ts` — same shape for UMD
+- `libs/builder/src/bundle/rollup/execute.ts` — `executeRollup(config, label)` (creates bundle, writes outputs, closes, clears refs)
+- `libs/builder/src/bundle/rollup/*.spec.ts` — 100% coverage
+- `libs/builder/src/bundle/declarations/index.ts` — `@module` header
+- `libs/builder/src/bundle/declarations/generate-declarations.ts` — `generateDeclarations(ctx, discovery)` (spawns `tsc`)
+- `libs/builder/src/bundle/declarations/flatten-paths.ts` — `flattenDeclarationPaths(ctx, discovery)`
+- `libs/builder/src/bundle/declarations/*.spec.ts` — 100% coverage
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export bundle facade
+- `libs/builder/package.json` — add `./bundle`, `./bundle/entries`, `./bundle/externals`, `./bundle/rollup`, `./bundle/declarations` exports
+- `tsconfig.base.json` — add path mappings for each subpath
+
+**Project-scope usage notes:**
+
+- Pattern matching: `matchGlobPattern` for entry-pattern matching; verify behavior matches minimatch for the patterns we use (`./browser/*`, `./browser/v1`)
+- File walks: `walkDirectory` / `findFilesInTree` for asset glob (used by Phase 5)
+- Path ops: `join`, `joinPosix`, `relativePath`, `parsePath` everywhere — never `node:path` directly when project-scope has the equivalent
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+```
+
+---
+
+## Phase 5 — Package subdomain
+
+`package.json` synthesis (with configurable inheritance + opt-in workspace-dep filter), generic asset copy, and opt-in third-party license collection.
+
+**Files to create:**
+
+- `libs/builder/src/package/index.ts` — `@module` header; orchestrator `runPackagePhase(ctx, config, formatOutputs)`
+- `libs/builder/src/package/json/index.ts` — `@module` header
+- `libs/builder/src/package/json/read-package-json.ts` — `readProjectPackageJson(projectRoot)` via project-scope's `readJsonFile`
+- `libs/builder/src/package/json/inherit-fields.ts` — `inheritFields(target, { from, fields })` (no-op if `from` not provided)
+- `libs/builder/src/package/json/filter-deps.ts` — `filterWorkspaceDepsFromOutput(pkg, isWorkspacePackage)` (opt-in caller)
+- `libs/builder/src/package/json/generate-exports.ts` — `generateExportsFromFormats(discovery, formatOutputs, srcPkg)` (existing logic, source-exports-first strategy preserved)
+- `libs/builder/src/package/json/cdn-paths.ts` — `getCdnPaths(formatOutputs, opts)` (unpkg/jsdelivr resolution)
+- `libs/builder/src/package/json/synthesize.ts` — `synthesizePackageJson(srcPkg, ctx, formatOutputs, opts)` — main facade combining all of the above
+- `libs/builder/src/package/json/write.ts` — `writeOutputPackageJson(outputPath, packageJson)` via project-scope's `writeJsonFile`
+- `libs/builder/src/package/json/*.spec.ts` — 100% coverage
+- `libs/builder/src/package/assets/index.ts` — `@module` header
+- `libs/builder/src/package/assets/copy-assets.ts` — `copyAssets(specs)` accepting `AssetSpec[]` where `AssetSpec = { from: string, to: string, files?: string[], glob?: string, condition?: (pkg) => boolean }`. Uses project-scope's `walkDirectory`/`findFilesInTree` for glob, `copyFileSync` from `node:fs` for the actual copy
+- `libs/builder/src/package/assets/*.spec.ts` — 100% coverage
+- `libs/builder/src/package/licenses/index.ts` — `@module` header
+- `libs/builder/src/package/licenses/collect.ts` — `collectThirdPartyLicenses(projectRoot, workspaceRoot, externals)` returning `ThirdPartyLicenseEntry[]`. Uses `parseRepositoryUrl` from `@hyperfrontend/versioning/repository/parse` (existing dep, OK)
+- `libs/builder/src/package/licenses/generate-content.ts` — `generateThirdPartyLicensesContent(entries)` returning markdown string
+- `libs/builder/src/package/licenses/write.ts` — `writeThirdPartyLicensesFile(outputPath, content)`
+- `libs/builder/src/package/licenses/*.spec.ts` — 100% coverage
+
+**Note on `@hyperfrontend/versioning`:** the license collector imports `parseRepositoryUrl` from versioning. This becomes a new runtime dep of builder. Add to `libs/builder/package.json`. Versioning currently depends on logging + project-scope + immutable-api-utils + json-utils + questions — no circular import risk.
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export package facade
+- `libs/builder/package.json` — add subpath exports + new dep on `@hyperfrontend/versioning`
+- `tsconfig.base.json` — add path mappings
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+```
+
+---
+
+## Phase 6 — Bin subdomain (JS)
+
+JS bin synthesis: rollup-bundle the source, prepend shebang, append the bootstrap footer (default or per-bin override), chmod 0o755. Per-bin format `cjs`/`esm`/array supported.
+
+**Files to create:**
+
+- `libs/builder/src/bin/index.ts` — `@module` header; orchestrator `runBinPhase(ctx, bins)`
+- `libs/builder/src/bin/script/index.ts` — `@module` header
+- `libs/builder/src/bin/script/build-bin.ts` — `buildJsBin(bin, ctx)` — rollup-bundles `src/bin/<name>.ts`, applies shebang + bootstrap footer per format, chmods. Returns `{ name, format, outputPath }[]`
+- `libs/builder/src/bin/script/bootstrap-footer.ts` — `defaultBootstrap({ runner, format })` returning the standard footer string
+- `libs/builder/src/bin/script/wire-package-bin.ts` — `wireBinFieldInPackageJson(pkg, binOutputs)` mutates `pkg.bin` to map name → relative path
+- `libs/builder/src/bin/script/*.spec.ts` — 100% coverage
+
+**Bootstrap footer template (default):**
+
+```javascript
+__RUNNER__({ argv: process.argv.slice(2), cwd: process.cwd(), stderr: process.stderr, stdout: process.stdout }).then(
+  (code) => {
+    process.exit(code)
+  },
+  (error) => {
+    process.stderr.write((error instanceof Error ? error.message : String(error)) + '\n')
+    process.exit(1)
+  }
+)
+```
+
+`__RUNNER__` substituted with the runner export name (default: `(await import('...')).default`; if `runner: 'name'` provided, that name).
+
+**Output naming convention:**
+
+- CJS: `dist/.../bin/<name>.cjs.js` (or `<name>.js` if only CJS declared)
+- ESM: `dist/.../bin/<name>.mjs`
+- `package.json#bin` maps `<name>` → first available output (CJS preferred for compat)
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export bin facade
+- `libs/builder/package.json` — add `./bin`, `./bin/script` exports
+- `tsconfig.base.json` — add path mappings
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+```
+
+---
+
+## Phase 7 — Bin subdomain (Node SEA)
+
+Node SEA wrapping. Bundles to single CJS, generates SEA config, runs `node --experimental-sea-config`, copies the current-platform Node host binary, injects the blob via postject, signs as needed. Skips silently with info log if `process.platform`/`arch` doesn't match declared targets.
+
+**Files to create:**
+
+- `libs/builder/src/bin/native/index.ts` — `@module` header
+- `libs/builder/src/bin/native/build-native.ts` — `buildNativeBin(bin, ctx)` orchestrator
+- `libs/builder/src/bin/native/sea-config.ts` — `generateSeaConfig({ mainPath, outputPath })` returns the SEA config JSON
+- `libs/builder/src/bin/native/sea-blob.ts` — `generateSeaBlob(seaConfigPath)` — spawns `node --experimental-sea-config <path>`, returns blob path
+- `libs/builder/src/bin/native/host-binary.ts` — `resolveHostBinary(platform, arch)` returns path to a usable Node host (default: `process.execPath`; future: per-target downloads)
+- `libs/builder/src/bin/native/inject.ts` — `injectBlob(hostBinary, outputBinary, blobPath)` calls postject's JS API
+- `libs/builder/src/bin/native/codesign.ts` — `removeCodesign(binary)` (macOS) and `applyCodesign(binary, opts?)` (macOS/Windows). MVP: removes existing macOS signature; re-signing left to release tooling
+- `libs/builder/src/bin/native/platform-check.ts` — `currentPlatformMatches(declaredPlatforms)` — returns true if `<process.platform>-<process.arch>` is in the list
+- `libs/builder/src/bin/native/*.spec.ts` — 100% coverage. Tests stub postject and node-spawn — actual binary production validated through CI matrix in Phase 12
+
+**SEA config shape produced (per Node docs):**
+
+```json
+{
+  "main": "<path>/<bin>.cjs.js",
+  "output": "<path>/sea-prep.blob",
+  "disableExperimentalSEAWarning": true
+}
+```
+
+**Output naming convention:**
+
+- `dist/.../bin/<name>.<platform>-<arch>` (e.g., `hf-build.linux-x64`, `hf-build.darwin-arm64`)
+- Windows: `<name>.<platform>-<arch>.exe`
+
+**Constraint enforcement:**
+
+- If a bin declares `sea` but is not built in CJS, `buildNativeBin` errors with: "SEA requires a CJS bin output; declare format: ['cjs'] or format: 'cjs' on bin <name>".
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export native facade
+- `libs/builder/package.json` — add `./bin/native` export, add `postject` dep
+- `tsconfig.base.json` — add path mapping
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+```
+
+---
+
+## Phase 8 — Presets and the `build()` Facade
+
+Predicate factories (`byPrefix`, `byNames`) and the single `build(config)` runner that orchestrates bundle → package → bin phases.
+
+**Files to create:**
+
+- `libs/builder/src/presets/index.ts` — `@module` header
+- `libs/builder/src/presets/by-prefix.ts` — `byPrefix(scope: string): (name: string) => boolean`
+- `libs/builder/src/presets/by-names.ts` — `byNames(names: string[]): (name: string) => boolean`
+- `libs/builder/src/presets/*.spec.ts` — 100% coverage
+- `libs/builder/src/build.ts` — `build(config: BuildConfig): Promise<BuildResult>` — the facade. Resolves context, optionally creates memory monitor, runs bundle phase, runs package phase, runs bin phase, returns result
+- `libs/builder/src/build.spec.ts` — 100% coverage (mock subdomain orchestrators; verify call order, context propagation, error handling, monitor lifecycle)
+
+**Facade orchestration outline:**
+
+```typescript
+export async function build(config: BuildConfig): Promise<BuildResult> {
+  const ctx = createBuildContext(config)
+  const monitor = config.memoryMonitor
+    ? createMemoryMonitor(typeof config.memoryMonitor === 'object' ? config.memoryMonitor : undefined)
+    : undefined
+  monitor?.logDebug('build:start')
+  try {
+    const formatOutputs = await runBundlePhase(ctx, config, monitor)
+    await runPackagePhase(ctx, config, formatOutputs)
+    const binOutputs = await runBinPhase(ctx, config.bin ?? [], monitor)
+    monitor?.logSummary()
+    return { success: true, formatOutputs, binOutputs, durationMs: ctx.elapsed() }
+  } catch (error) {
+    monitor?.logSummary()
+    throw error
+  }
+}
+```
+
+**Files to modify:**
+
+- `libs/builder/src/index.ts` — re-export `build`, key types, and presets
+- `libs/builder/package.json` — add `./presets` export; ensure `.` exports `build`
+- `tsconfig.base.json` — add path mapping for `./presets`
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+npx nx build lib-builder    # first dogfood: lib-builder builds itself via the existing wrapper
+```
+
+The `nx build lib-builder` step exercises the facade via the wrapper. At this point the wrapper still uses its old inline pipeline; this just confirms `lib-builder`'s own source produces a valid dist. The wrapper retrofit happens in Phase 10.
+
+---
+
+## Phase 9 — Builder's own CLI bin
+
+The `hf-build` CLI: a runner that reads a config file (`builder.config.json` or similar) or accepts CLI flags, and calls `build()`.
+
+**Files to create:**
+
+- `libs/builder/src/bin/hf-build.ts` — exports `runHfBuild(io: { argv, cwd, stderr, stdout? }): Promise<number>`. Parses argv, loads config from `cwd/builder.config.json` (or `--config <path>`), calls `build(config)`, returns 0 on success / 1 on failure
+- `libs/builder/src/bin/hf-build.spec.ts` — 100% coverage (mock `build`, verify argv parsing, config loading, exit code mapping, error formatting)
+
+**Files to modify:**
+
+- `libs/builder/project.json` — add bin block to the build target options:
+
+  ```json
+  "bin": [
+    {
+      "name": "hf-build",
+      "format": ["cjs"],
+      "sea": {
+        "platforms": ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]
+      }
+    }
+  ]
+  ```
+
+  Builder source is the runner export; default-export the function from `src/bin/hf-build.ts`.
+
+- `libs/builder/package.json` — `bin` field will be auto-wired by builder during build to `{ "hf-build": "./bin/hf-build.cjs.js" }`. Source package.json can declare a placeholder; the build overwrites it for the published package.
+
+**Note:** at this point `nx build lib-builder` exercises both the library output and the bin pipeline. The `hf-build.cjs.js` artifact lands at `dist/libs/builder/bin/hf-build.cjs.js` with shebang + chmod. Native binaries only emit on the appropriate CI runner per Phase 12.
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+npx nx build lib-builder
+node dist/libs/builder/bin/hf-build.cjs.js --help    # smoke test
+```
+
+---
+
+## Phase 10 — Wrapper retrofit
+
+Replace `tools/package/src/executors/build/executor.ts` and supporting `lib/` with a thin facade caller. The schema mirrors builder's `BuildConfig` minus the monorepo-specific knobs (which are hardcoded in the wrapper).
+
+**Files to delete:**
+
+- `tools/package/src/executors/build/lib/` (entire directory: `assets.ts`, `config-cjs.ts`, `config-esm.ts`, `config-iife.ts`, `config-umd.ts`, `declarations.ts`, `entry-resolver.ts`, `externals.ts`, `index.ts`, `logger.ts`, `package-json.ts`, `paths.ts`, `rollup-plugins.ts`, `types.ts`)
+
+**Files to create:**
+
+- `tools/package/src/executors/build/wrapper-config.ts` — exports the monorepo constants:
+  - `WORKSPACE_SCOPE = '@hyperfrontend/'`
+  - `INHERITABLE_FIELDS = ['repository', 'bugs', 'homepage', 'author']`
+  - `DEFAULT_PROJECT_ASSETS = ['README.md', 'CHANGELOG.md', 'ARCHITECTURE.md']`
+  - `DEFAULT_WORKSPACE_ASSETS = ['LICENSE.md', 'SECURITY.md']`
+  - `FUNDING_ASSET = 'FUNDING.md'` (conditional on `pkg.funding`)
+  - `MEMORY_THRESHOLDS = { warningMB: 512, criticalMB: 768, growthMB: 50 }`
+
+**Files to modify:**
+
+- `tools/package/src/executors/build/executor.ts` — rewrite to ~50 lines:
+  1. Resolve `projectRoot`, `workspaceRoot` from Nx `ExecutorContext`
+  2. Build a `BuildConfig` object: spread the schema-validated executor options + inject:
+     - `isWorkspacePackage: byPrefix(WORKSPACE_SCOPE)`
+     - `bundleWorkspaceDeps: per-format from options`
+     - `filterWorkspaceDepsFromOutput: true`
+     - `inheritFieldsFrom: { from: <workspaceRoot>/package.json, fields: INHERITABLE_FIELDS }`
+     - `assets: [{ from: projectRoot, files: DEFAULT_PROJECT_ASSETS }, { from: workspaceRoot, files: DEFAULT_WORKSPACE_ASSETS }, { from: workspaceRoot, files: [FUNDING_ASSET], condition: pkg => Boolean(pkg.funding) }, ...options.assets]`
+     - `thirdPartyLicenses: true`
+     - `memoryMonitor: MEMORY_THRESHOLDS`
+  3. `await build(config)`, return `{ success: true }` or log + `{ success: false }`
+
+- `tools/package/src/executors/build/schema.json` — update to mirror builder's `BuildConfig` minus the monorepo knobs. Add `bin` property (array of bin descriptors per Q12).
+- `tools/package/package.json` — replace dev deps: drop `@nx/devkit`, `@hyperfrontend/logging` (still indirect), `@hyperfrontend/versioning` (still indirect), rollup family. Add runtime dep on `@hyperfrontend/builder`. Keep `@nx/devkit` only if Nx executor entry signature requires it (it does for `ExecutorContext` type — keep in devDependencies).
+- `tools/package/src/executors/build/README.md` — update to reflect new schema (additions: `bin`; removals: none — the format-centric API is preserved 1:1)
+
+**Behavioral parity check (manual, during PR):**
+
+For each currently-publishable lib (`lib-cryptography`, `lib-data-utils`, `lib-function-utils`, `lib-immutable-api-utils`, `lib-json-utils`, `lib-list-utils`, `lib-logging`, `lib-network-protocol`, `lib-nexus`, `lib-project-scope`, `lib-questions`, `lib-random-generator-utils`, `lib-state-machine`, `lib-string-utils`, `lib-time-utils`, `lib-ui-utils`, `lib-versioning`, `lib-web-worker`):
+
+1. On `main` (pre-PR) baseline: `nx build <project>` → snapshot `dist/libs/<lib>/` tree
+2. On the PR branch: `nx build <project>` → diff against snapshot
+3. Acceptable differences: ordering of keys in `package.json`, comment whitespace in generated files. Anything else investigated and either fixed or documented.
+
+**Verification:**
+
+```bash
+npx nx test tool-package
+npx nx lint tool-package --fix
+npx nx typecheck tool-package
+npx nx build lib-builder       # builder rebuilds via the new wrapper
+npx nx build lib-logging       # representative dependent lib still builds correctly
+```
+
+---
+
+## Phase 11 — lib-versioning bin migration
+
+Delete the hand-rolled rollup script; declare the cz/cl bins in `project.json` so the wrapper's bin pipeline produces them.
+
+**Files to delete:**
+
+- `libs/versioning/scripts/build-bins.mjs`
+- `libs/versioning/scripts/` (if now empty)
+
+**Files to modify:**
+
+- `libs/versioning/project.json` — under build target options:
+
+  ```json
+  "bin": [
+    { "name": "cz", "runner": "runCz", "format": "cjs" },
+    { "name": "cl", "runner": "runCl", "format": "cjs" }
+  ]
+  ```
+
+  Remove any post-step or chained target that invoked `build-bins.mjs`.
+
+- `libs/versioning/src/bin/cz.ts` — verify it exports `runCz` matching the `(io: { argv, cwd, stderr }) => Promise<number>` contract. (Already does per the existing bootstrap footer.)
+- `libs/versioning/src/bin/cl.ts` — same verification for `runCl`.
+- `libs/versioning/package.json` — leave `bin` field as is (`{ "cz": "./bin/cz.js", "cl": "./bin/cl.js" }`); builder's auto-wire will overwrite in dist with the same shape.
+
+**Verification:**
+
+```bash
+npx nx test lib-versioning
+npx nx lint lib-versioning --fix
+npx nx typecheck lib-versioning
+npx nx build lib-versioning
+node dist/libs/versioning/bin/cz.js --help
+node dist/libs/versioning/bin/cl.js --help
+```
+
+The bin smoke tests confirm the cz/cl behavior matches the prior hand-rolled output.
+
+---
+
+## Phase 12 — CI workflows
+
+Per-library CI workflow + new reusable native template + per-library native caller. Leverages existing patterns from `_lib-ci.yml`.
+
+**Files to create:**
+
+- `.github/workflows/_lib-native.yml` — reusable workflow callable by any lib that produces native bins. Inputs: `project-name`, `bin-name`, `platforms` (JSON array). Matrix runs the build per-platform on the matching runner; uploads each binary as a workflow artifact + (on a release-tag run) attaches to the GitHub Release.
+
+  Runner mapping:
+  | Declared platform | GitHub runner |
+  | ----------------- | ------------------------ |
+  | `linux-x64` | `ubuntu-latest` |
+  | `linux-arm64` | `ubuntu-24.04-arm` (or `ubuntu-latest` with QEMU if arm runner unavailable) |
+  | `darwin-x64` | `macos-13` |
+  | `darwin-arm64` | `macos-latest` |
+  | `win32-x64` | `windows-latest` |
+
+- `.github/workflows/ci-lib-builder.yml` — calls `_lib-ci.yml` (typecheck/build/test/coverage). Triggered on PR + main. Created/scaffolded by `make-publishable` generator if available; manual otherwise.
+- `.github/workflows/ci-lib-builder-native.yml` — calls `_lib-native.yml` with `project-name: lib-builder`, `bin-name: hf-build`, all five platforms. Triggered on push to `main` only. On a published version tag, the same job re-runs and attaches binaries to the matching GitHub Release.
+
+**Files to modify (per library-ci-workflows skill manual steps):**
+
+- `.github/workflows/ci-libraries.yml` — add path filter for `libs/builder/**` and matrix entry `add_if_changed "${{ steps.filter.outputs.builder }}" "lib-builder" "libs/builder" "builder"`
+- `.github/workflows/ci-main.yml` — add `"builder:libs/builder"` entry in the LIBS coverage array
+- `.github/workflows/ci-main.yml` — extend the publish/tag flow to also invoke `ci-lib-builder-native.yml` after a successful publish step (so a new version tag triggers the native artifact attach)
+
+**Verification:**
+
+```bash
+# Local lint of workflow YAML (if workflow linter is configured)
+npx nx lint tool-eslint-rules --fix
+
+# Confirm path filter wires up by pushing a no-op change to libs/builder/ and checking only ci-lib-builder runs
+```
+
+---
+
+## Phase 13 — Publishable scaffolding & docs
+
+Standard `make-publishable` follow-up: documentation deliverables (per readme-docs / jsdoc-examples), root README + docs-site entries, library compatibility table, E2E project.
+
+**Files to verify (auto-created or pre-existing):**
+
+- `libs/builder/README.md` — completed per readme-docs skill (title, badges, description, features, install, quickstart, sub-paths, examples, contributing, license sections)
+- All exported members in `libs/builder/src/**` carry `@param`, `@returns`, and at least one `@example` block per jsdoc-examples skill
+- `libs/builder-e2e/` — E2E project verifying ESM, CJS, IIFE, UMD outputs work (per library-e2e-setup skill); also verifies the JS bin (`hf-build`) is invokable post-install
+
+**Files to modify (per library-generators make-publishable manual steps):**
+
+- `README.md` (root) — add row for `@hyperfrontend/builder` in the Main Packages table
+- `apps/docs-site/scripts/generate-docs.ts` — add `'builder'` entry to the LIBRARIES array
+- `apps/docs-site/src/lib/content.ts` — add LIBRARIES entry:
+
+  ```typescript
+  {
+    name: 'Builder',
+    packageName: '@hyperfrontend/builder',
+    slug: 'builder',
+    readmePath: 'libs/builder/README.md',
+    entryPoints: ['libs/builder/src/index.ts'],
+    category: 'core',
+  },
+  ```
+
+- `apps/docs-site/src/app/docs/libraries/builder/page.tsx` — page route per the docs-site template
+- `LIBRARY_COMPATIBILITY.md` — add a row recording the cross-package dep compatibility (builder depends on logging, project-scope, immutable-api-utils, versioning)
+
+**ARCHITECTURE.md:** deferred to release-time per user request — to be written before the first published release of `@hyperfrontend/builder`, capturing data flow (config → discover → externals → rollup → dts → package.json → assets → bins → SEA), the subpath layout, and the predicate-based extension model.
+
+**Verification:**
+
+```bash
+npx nx test lib-builder
+npx nx lint lib-builder --fix
+npx nx typecheck lib-builder
+npx nx test lib-builder-e2e
+npx nx lint lib-builder-e2e --fix
+npx nx build docs-site
+npx nx lint docs-site --fix
+```

--- a/tools/app/src/executors/build/executor.ts
+++ b/tools/app/src/executors/build/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { BuildExecutorOptions } from './schema'
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
@@ -19,10 +19,7 @@ import { logger } from '../../lib/logger'
 export default async function buildExecutor(
   options: BuildExecutorOptions,
   context: ExecutorContext
-): Promise<{
-  /** Indicates whether the build succeeded. */
-  success: boolean
-}> {
+): ReturnType<PromiseExecutor> {
   const projectName = context.projectName
   if (!projectName) {
     logger.error('No project name provided')

--- a/tools/app/src/executors/install/executor.ts
+++ b/tools/app/src/executors/install/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { InstallExecutorOptions } from './schema'
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
@@ -16,13 +16,7 @@ import { logger } from '../../lib/logger'
  * @param context - Executor context providing project information
  * @returns An object indicating success or failure of the install
  */
-export default async function installExecutor(
-  options: InstallExecutorOptions,
-  context: ExecutorContext
-): Promise<{
-  /** Indicates whether the install succeeded. */
-  success: boolean
-}> {
+export default async function installExecutor(options: InstallExecutorOptions, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const projectName = context.projectName
   if (!projectName) {
     logger.error('No project name provided')

--- a/tools/app/src/executors/serve/executor.ts
+++ b/tools/app/src/executors/serve/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { ServeExecutorOptions } from './schema'
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
@@ -17,13 +17,7 @@ import { logger } from '../../lib/logger'
  * @param context - Executor context providing project information
  * @returns An object indicating success or failure of the serve command
  */
-export default async function serveExecutor(
-  options: ServeExecutorOptions,
-  context: ExecutorContext
-): Promise<{
-  /** Whether the serve operation completed successfully */
-  success: boolean
-}> {
+export default async function serveExecutor(options: ServeExecutorOptions, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const projectName = context.projectName
   if (!projectName) {
     logger.error('No project name provided')
@@ -54,10 +48,7 @@ export default async function serveExecutor(
   logger.info(`  Running: ${command}`)
   logger.info(`  In: ${cwd}`)
 
-  return createPromise<{
-    /** Whether the serve operation completed successfully */
-    success: boolean
-  }>((resolve) => {
+  return createPromise<Awaited<ReturnType<PromiseExecutor>>>((resolve) => {
     const child = spawn(command, {
       cwd,
       stdio: 'inherit',

--- a/tools/eslint-rules/docs/no-inline-type-literal.md
+++ b/tools/eslint-rules/docs/no-inline-type-literal.md
@@ -1,0 +1,105 @@
+# no-inline-type-literal
+
+Prohibit inline anonymous object type literals at use sites. Require a named `type` alias or `interface` so JSDoc can be attached and the shape can be reused.
+
+## Rule Details
+
+Object type literals (`{ a: number; b: string }`) declared at use sites cannot have JSDoc attached to them — they are not declarations. The repository's JSDoc-injecting rule cannot decorate them, so the convention is to extract every named-property shape into a `type` alias or `interface` and reference it by name.
+
+This rule flags any `TSTypeLiteral` with at least one `TSPropertySignature` or `TSMethodSignature` member, except when it is the immediate right-hand side of a `type` alias declaration. Nesting a literal inside a type alias is also flagged — every shape needs its own name.
+
+### Why?
+
+- **Documentability.** Only declarations can carry JSDoc. Inline shapes route around the JSDoc-coverage rules.
+- **Reusability.** Named types can be imported, extended, and combined. Inline shapes cannot.
+- **Discoverability.** A named type appears in editor symbol search; an inline shape does not.
+- **Refactor safety.** Shape changes localize to one declaration instead of many duplicated literals.
+
+### What is exempt
+
+- The immediate RHS of `type X = { ... }` (the canonical naming site).
+- The body of `interface X { ... }` (a different AST node, never matches).
+- Empty `{}` — semantically "any non-nullish," not a shape.
+- Index-signature-only literals like `{ [k: string]: T }` — no per-property names to document; use `Record<string, T>` if a name is desired.
+- Pure call-signature literals like `{ (): void }` — no named members.
+
+## Examples
+
+### ❌ Incorrect
+
+```typescript
+function a({ logger, other }: { logger: Logger; other: number }) {
+  /* ... */
+}
+
+function f(): { etc: boolean } {
+  /* ... */
+}
+
+const x: { a: number } = { a: 1 }
+
+class C {
+  x: { a: number } = { a: 1 }
+}
+
+const something = <{ etc: boolean }>getSomething()
+const other = getSomething() as { etc: boolean }
+
+const r = useState<{ a: number }>()
+const m: Map<string, { a: number }> = new Map()
+
+type U = string | { a: number }
+type I = Base & { a: number }
+
+const v = data satisfies { a: number }
+
+function gen<T extends { a: number }>(x: T): T {
+  return x
+}
+
+type Outer = { inner: { a: number } }
+```
+
+### ✅ Correct
+
+```typescript
+type LoggerProps = { logger: Logger; other: number }
+function a({ logger, other }: LoggerProps) {
+  /* ... */
+}
+
+type EtcResult = { etc: boolean }
+function f(): EtcResult {
+  /* ... */
+}
+
+interface Position {
+  a: number
+}
+const x: Position = { a: 1 }
+
+const something = <EtcResult>getSomething()
+
+const r = useState<Position>()
+const m: Map<string, Position> = new Map()
+
+type U = string | Position
+type I = Base & Position
+
+const v = data satisfies Position
+
+function gen<T extends Position>(x: T): T {
+  return x
+}
+
+type Inner = { a: number }
+type Outer = { inner: Inner }
+
+const empty: {} = {}
+const dict: { [k: string]: number } = {}
+```
+
+## Related Rules
+
+- [prefer-angle-bracket-assertion](./prefer-angle-bracket-assertion.md)
+- [no-mixed-type-import](./no-mixed-type-import.md)

--- a/tools/eslint-rules/src/index.ts
+++ b/tools/eslint-rules/src/index.ts
@@ -36,6 +36,7 @@ import noDecorativeHeaderComments, { RULE_NAME as NO_DECORATIVE_HEADER_COMMENTS 
 import noDeprecatedTag, { RULE_NAME as NO_DEPRECATED_TAG } from './rules/no-deprecated-tag'
 import noDirectConsole, { RULE_NAME as NO_DIRECT_CONSOLE } from './rules/no-direct-console'
 import noEnum, { RULE_NAME as NO_ENUM } from './rules/no-enum'
+import noInlineTypeLiteral, { RULE_NAME as NO_INLINE_TYPE_LITERAL } from './rules/no-inline-type-literal'
 import noMixedTypeExport, { RULE_NAME as NO_MIXED_TYPE_EXPORT } from './rules/no-mixed-type-export'
 import noMixedTypeImport, { RULE_NAME as NO_MIXED_TYPE_IMPORT } from './rules/no-mixed-type-import'
 import noNamespaceImport, { RULE_NAME as NO_NAMESPACE_IMPORT } from './rules/no-namespace-import'
@@ -97,6 +98,7 @@ export const rules: ESLint.Plugin['rules'] = {
   [NO_DEPRECATED_TAG]: noDeprecatedTag as unknown as Rule.RuleModule,
   [NO_DIRECT_CONSOLE]: noDirectConsole as unknown as Rule.RuleModule,
   [NO_ENUM]: noEnum as unknown as Rule.RuleModule,
+  [NO_INLINE_TYPE_LITERAL]: noInlineTypeLiteral as unknown as Rule.RuleModule,
   [NO_MIXED_TYPE_EXPORT]: noMixedTypeExport as unknown as Rule.RuleModule,
   [NO_MIXED_TYPE_IMPORT]: noMixedTypeImport as unknown as Rule.RuleModule,
   [NO_NAMESPACE_IMPORT]: noNamespaceImport as unknown as Rule.RuleModule,

--- a/tools/eslint-rules/src/rules/deepest-import-path.ts
+++ b/tools/eslint-rules/src/rules/deepest-import-path.ts
@@ -19,16 +19,41 @@ const createRule = ESLintUtils.RuleCreator(
 type MessageIds = 'useDeeperImport'
 
 /**
+ * Slice of `compilerOptions` we read for path-alias lookups.
+ */
+interface TsConfigCompilerOptions {
+  /** Base URL for module resolution */
+  baseUrl?: string
+  /** Path alias mappings */
+  paths?: Record<string, string[]>
+}
+
+/**
  * Represents a parsed tsconfig.json structure.
  */
 interface TsConfig {
   /** Compiler options from tsconfig.json */
-  compilerOptions?: {
-    /** Base URL for module resolution */
-    baseUrl?: string
-    /** Path alias mappings */
-    paths?: Record<string, string[]>
-  }
+  compilerOptions?: TsConfigCompilerOptions
+}
+
+/**
+ * Public-facing subpath entry for a package alias: the alias and the file path
+ * it ultimately points at.
+ */
+type PackageSubpath = {
+  /** The path alias (e.g., '@hyperfrontend/project-scope/cli') */
+  alias: string
+  /** The resolved source file path */
+  sourcePath: string
+}
+
+/**
+ * Internal subpath entry — adds segment depth so we can sort deepest-first
+ * before returning the public {@link PackageSubpath} shape.
+ */
+interface RankedPackageSubpath extends PackageSubpath {
+  /** Depth of the path (number of segments) */
+  depth: number
 }
 
 /**
@@ -212,23 +237,8 @@ function parseExports(filePath: string, visited: Set<string> = createSet()): Set
  * @param tsconfigPaths - Map of all available path aliases.
  * @returns Array of subpath entries sorted by depth (deepest first).
  */
-function getPackageSubpaths(
-  packageName: string,
-  tsconfigPaths: Map<string, string>
-): Array<{
-  /** The path alias (e.g., '@hyperfrontend/project-scope/cli') */
-  alias: string
-  /** The resolved source file path */
-  sourcePath: string
-}> {
-  const subpaths: Array<{
-    /** The path alias */
-    alias: string
-    /** The resolved source file path */
-    sourcePath: string
-    /** Depth of the path (number of segments) */
-    depth: number
-  }> = []
+function getPackageSubpaths(packageName: string, tsconfigPaths: Map<string, string>): Array<PackageSubpath> {
+  const subpaths: Array<RankedPackageSubpath> = []
 
   for (const [alias, sourcePath] of tsconfigPaths) {
     if (alias === packageName || alias.startsWith(`${packageName}/`)) {

--- a/tools/eslint-rules/src/rules/docs-site-libraries.ts
+++ b/tools/eslint-rules/src/rules/docs-site-libraries.ts
@@ -27,6 +27,23 @@ export interface PublishableLibrary {
 }
 
 /**
+ * Slice of `package.json` we read when extracting the published package name.
+ */
+type PackageJsonName = {
+  /** Package name field */
+  name?: string
+}
+
+/**
+ * Minimal AST helper exposing the optional `parent` reference attached to nodes
+ * by ESLint at traversal time.
+ */
+type NodeWithParent = {
+  /** Parent AST node */
+  parent?: Node
+}
+
+/**
  * Gets the package name from a library's package.json.
  *
  * @param projectDir - The absolute path to the project directory.
@@ -34,10 +51,7 @@ export interface PublishableLibrary {
  */
 function getPackageName(projectDir: string): string | null {
   const packageJsonPath = join(projectDir, 'package.json')
-  const packageJson = readJsonFileIfExists<{
-    /** Package name field */
-    name?: string
-  }>(packageJsonPath)
+  const packageJson = readJsonFileIfExists<PackageJsonName>(packageJsonPath)
   return packageJson?.name ?? null
 }
 
@@ -189,12 +203,7 @@ const rule: Rule.RuleModule = {
           return
         }
 
-        const parent = (<
-          {
-            /** Parent AST node */
-            parent?: Node
-          }
-        >node).parent
+        const parent = (<NodeWithParent>node).parent
         const isExported = parent?.type === 'ExportNamedDeclaration'
 
         if (isContentTs && !isExported) {

--- a/tools/eslint-rules/src/rules/docs-site-library-docs.ts
+++ b/tools/eslint-rules/src/rules/docs-site-library-docs.ts
@@ -51,6 +51,15 @@ export interface LibraryEntry {
 }
 
 /**
+ * Minimal AST helper exposing the optional `parent` reference attached to nodes
+ * by ESLint at traversal time.
+ */
+type NodeWithParent = {
+  /** Parent AST node, if present. */
+  parent?: Node
+}
+
+/**
  * Extracts the string value from a property value node.
  *
  * @param node - The AST node representing the property value.
@@ -335,12 +344,7 @@ const rule: Rule.RuleModule = {
           return
         }
 
-        const parent = (
-          node as {
-            /** Parent AST node, if present. */
-            parent?: Node
-          }
-        ).parent
+        const parent = (node as NodeWithParent).parent
         const isExported = parent?.type === 'ExportNamedDeclaration'
 
         if (!isExported) {

--- a/tools/eslint-rules/src/rules/docs-site-routes.ts
+++ b/tools/eslint-rules/src/rules/docs-site-routes.ts
@@ -25,6 +25,15 @@ export interface LibraryEntry {
 }
 
 /**
+ * Minimal AST helper exposing the optional `parent` reference attached to nodes
+ * by ESLint at traversal time.
+ */
+type NodeWithParent = {
+  /** Parent AST node, if present. */
+  parent?: Node
+}
+
+/**
  * Extracts the string value from a property value node.
  *
  * @param node - The AST node representing the property value.
@@ -185,12 +194,7 @@ const rule: Rule.RuleModule = {
           return
         }
 
-        const parent = (
-          node as {
-            /** Parent AST node, if present. */
-            parent?: Node
-          }
-        ).parent
+        const parent = (node as NodeWithParent).parent
         const isExported = parent?.type === 'ExportNamedDeclaration'
 
         if (!isExported) {

--- a/tools/eslint-rules/src/rules/docs-site-secondary-entries.ts
+++ b/tools/eslint-rules/src/rules/docs-site-secondary-entries.ts
@@ -39,6 +39,15 @@ interface PackageJson {
 }
 
 /**
+ * Minimal AST helper exposing the optional `parent` reference attached to nodes
+ * by ESLint at traversal time.
+ */
+type NodeWithParent = {
+  /** Parent AST node, if present. */
+  parent?: Node
+}
+
+/**
  * Extracts the string value from a property value node.
  *
  * @param node - The AST node representing the property value.
@@ -239,12 +248,7 @@ const rule: Rule.RuleModule = {
           return
         }
 
-        const parent = (
-          node as {
-            /** Parent AST node, if present. */
-            parent?: Node
-          }
-        ).parent
+        const parent = (node as NodeWithParent).parent
         const isExported = parent?.type === 'ExportNamedDeclaration'
 
         if (!isExported) {

--- a/tools/eslint-rules/src/rules/lib-ci-workflows.ts
+++ b/tools/eslint-rules/src/rules/lib-ci-workflows.ts
@@ -34,6 +34,16 @@ export interface PublishableLibrary {
 }
 
 /**
+ * Map of Nx target names this rule cares about within a project.json file.
+ */
+interface ProjectTargets {
+  /** Build target configuration */
+  build?: unknown
+  /** Publish target configuration */
+  publish?: unknown
+}
+
+/**
  * Interface for project.json structure.
  */
 interface ProjectJson {
@@ -42,12 +52,16 @@ interface ProjectJson {
   /** Type of project (library, application, etc.) */
   projectType?: string
   /** Build targets configuration */
-  targets?: {
-    /** Build target configuration */
-    build?: unknown
-    /** Publish target configuration */
-    publish?: unknown
-  }
+  targets?: ProjectTargets
+}
+
+/**
+ * Adds the optional `name` field that may appear on `project.json` even when
+ * the upstream interface omits it.
+ */
+type WithProjectName = {
+  /** Project name from project.json */
+  name?: string
 }
 
 /**
@@ -88,12 +102,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
   if (isPublishableLibraryDir(baseDir)) {
     const relativePath = baseDir.slice(workspaceRoot.length + 1)
     const projectJsonPath = join(baseDir, 'project.json')
-    const projectJson = readJsonFileIfExists<
-      ProjectJson & {
-        /** Project name from project.json */
-        name?: string
-      }
-    >(projectJsonPath)
+    const projectJson = readJsonFileIfExists<ProjectJson & WithProjectName>(projectJsonPath)
 
     results.push({
       name: projectJson?.name ?? `lib-${basename(baseDir)}`,

--- a/tools/eslint-rules/src/rules/lib-compatibility-docs.ts
+++ b/tools/eslint-rules/src/rules/lib-compatibility-docs.ts
@@ -29,35 +29,68 @@ export interface PublishableLibrary {
 }
 
 /**
+ * Configuration for a single browser bundle format (IIFE or UMD).
+ */
+interface BrowserBundleFormatConfig {
+  /** Entry point for the bundle */
+  entry?: string
+  /** Global variable name for the bundle */
+  globalName?: string
+}
+
+/**
+ * Build options block of project.json that this rule reads when deciding whether
+ * a library exposes browser bundles.
+ */
+interface BuildOptionsWithBrowserBundles {
+  /** IIFE bundle configuration */
+  iife?: BrowserBundleFormatConfig
+  /** UMD bundle configuration */
+  umd?: BrowserBundleFormatConfig
+  [key: string]: unknown
+}
+
+/**
+ * Build target shape inspected by this rule.
+ */
+interface BuildTargetWithBundles {
+  /** Build configuration options */
+  options?: BuildOptionsWithBrowserBundles
+  [key: string]: unknown
+}
+
+/**
+ * `targets` map of project.json restricted to the `build` entry this rule reads.
+ */
+interface BuildTargets {
+  /** Build target with bundle options */
+  build?: BuildTargetWithBundles
+  [key: string]: unknown
+}
+
+/**
  * Extended project.json structure with build options.
  */
 interface ProjectJsonWithBuildOptions extends ProjectJson {
   /** Build targets configuration */
-  targets?: {
-    /** Build target with bundle options */
-    build?: {
-      /** Build configuration options */
-      options?: {
-        /** IIFE bundle configuration */
-        iife?: {
-          /** Entry point for the bundle */
-          entry?: string
-          /** Global variable name for the bundle */
-          globalName?: string
-        }
-        /** UMD bundle configuration */
-        umd?: {
-          /** Entry point for the bundle */
-          entry?: string
-          /** Global variable name for the bundle */
-          globalName?: string
-        }
-        [key: string]: unknown
-      }
-      [key: string]: unknown
-    }
-    [key: string]: unknown
-  }
+  targets?: BuildTargets
+}
+
+/**
+ * Slice of `package.json` we read when extracting the published package name.
+ */
+type PackageJsonName = {
+  /** Package name from package.json */
+  name?: string
+}
+
+/**
+ * Adds the optional `name` field that can appear on `project.json` even when
+ * the upstream interface omits it.
+ */
+type WithProjectName = {
+  /** Project name from project.json */
+  name?: string
 }
 
 /**
@@ -86,10 +119,7 @@ function hasBrowserBundles(projectDir: string): boolean {
  */
 function getPackageName(projectDir: string): string | null {
   const packageJsonPath = join(projectDir, 'package.json')
-  const packageJson = readJsonFileIfExists<{
-    /** Package name from package.json */
-    name?: string
-  }>(packageJsonPath)
+  const packageJson = readJsonFileIfExists<PackageJsonName>(packageJsonPath)
   return packageJson?.name ?? null
 }
 
@@ -109,12 +139,7 @@ function findPublishableLibraries(baseDir: string, workspaceRoot: string, result
     const relativePath = baseDir.slice(workspaceRoot.length + 1)
     const projectJsonPath = join(baseDir, 'project.json')
     const packageName = getPackageName(baseDir)
-    const projectJson = readJsonFileIfExists<
-      ProjectJson & {
-        /** Project name from project.json */
-        name?: string
-      }
-    >(projectJsonPath)
+    const projectJson = readJsonFileIfExists<ProjectJson & WithProjectName>(projectJsonPath)
 
     if (packageName) {
       results.push({

--- a/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-bundle-entry.ts
@@ -10,30 +10,36 @@ import { isPublishableLibrary } from '../utils/nx-project'
  */
 export const RULE_NAME = 'lib-pkg-bundle-entry'
 
+/** Single bundle-format entry (IIFE or UMD) */
+interface BundleFormatEntry {
+  /** Entry point path for the bundle */
+  entry?: string
+}
+
 /** Build options for bundle configuration */
 interface BuildOptions {
   /** IIFE bundle entry configuration */
-  iife?: {
-    /** Entry point path for the bundle */
-    entry?: string
-  }
+  iife?: BundleFormatEntry
   /** UMD bundle entry configuration */
-  umd?: {
-    /** Entry point path for the bundle */
-    entry?: string
-  }
+  umd?: BundleFormatEntry
+}
+
+/** Build target configuration relevant to this rule */
+interface BuildTarget {
+  /** Build options including bundle entries */
+  options?: BuildOptions
+}
+
+/** Subset of `targets` we read from project.json */
+interface ProjectTargets {
+  /** Build target configuration */
+  build?: BuildTarget
 }
 
 /** Project.json structure for reading build targets */
 interface ProjectJson {
   /** Project targets configuration */
-  targets?: {
-    /** Build target configuration */
-    build?: {
-      /** Build options including bundle entries */
-      options?: BuildOptions
-    }
-  }
+  targets?: ProjectTargets
 }
 
 /**

--- a/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-exports-js-only.ts
@@ -16,6 +16,15 @@ export const RULE_NAME = 'lib-pkg-exports-js-only'
 const VALID_EXTENSIONS = createSet<string>(['.js', '.mjs', '.cjs', '.json'])
 
 /**
+ * JSONC AST nodes carry a verbatim source slice on `raw` that includes quotes;
+ * this helper exposes that field without committing to the broader node type.
+ */
+type JSONNodeWithRaw = {
+  /** Raw string representation of the node value. */
+  raw?: string
+}
+
+/**
  * Checks if a path represents a package.json self-reference export.
  *
  * @param exportPath - The export path to check.
@@ -103,12 +112,7 @@ const rule: Rule.RuleModule = {
           },
           fix(fixer) {
             if (/\.(ts|tsx|mts|cts)$/.test(exportPath)) {
-              const raw = (
-                valueNode as unknown as {
-                  /** Raw string representation of the node value. */
-                  raw?: string
-                }
-              ).raw
+              const raw = (valueNode as unknown as JSONNodeWithRaw).raw
               if (raw) {
                 const quote = raw[0]
                 return fixer.replaceText(valueNode as unknown as Rule.Node, `${quote}${suggested}${quote}`)

--- a/tools/eslint-rules/src/rules/lib-pkg-no-main.ts
+++ b/tools/eslint-rules/src/rules/lib-pkg-no-main.ts
@@ -8,6 +8,22 @@ import { isPublishableLibrary } from '../utils/nx-project'
  */
 export const RULE_NAME = 'lib-pkg-no-main'
 
+/**
+ * Minimal token shape exposing the optional `value` string ESLint attaches to tokens.
+ */
+type TokenWithValue = {
+  /** Token string value */
+  value?: string
+}
+
+/**
+ * Minimal node shape exposing the `[start, end]` source range used by ESLint fixers.
+ */
+type NodeWithRange = {
+  /** Source range as [start, end] positions */
+  range: [number, number]
+}
+
 const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
@@ -82,12 +98,7 @@ const rule: Rule.RuleModule = {
               const text = sourceCode.getText()
               const range = <[number, number]>mainNodeCast.range
 
-              if (tokenAfter && (<
-                  {
-                    /** Token string value */
-                    value?: string
-                  }
-                >tokenAfter).value === ',') {
+              if (tokenAfter && (<TokenWithValue>tokenAfter).value === ',') {
                 let startPos = range[0]
                 while (startPos > 0 && text[startPos - 1] !== '\n') {
                   startPos--
@@ -98,12 +109,7 @@ const rule: Rule.RuleModule = {
                 return fixer.removeRange([startPos, tokenAfter.range[1]])
               }
 
-              if (tokenBefore && (<
-                  {
-                    /** Token string value */
-                    value?: string
-                  }
-                >tokenBefore).value === ',') {
+              if (tokenBefore && (<TokenWithValue>tokenBefore).value === ',') {
                 return fixer.removeRange([tokenBefore.range[0], range[1]])
               }
 
@@ -116,12 +122,7 @@ const rule: Rule.RuleModule = {
             messageId: 'noMainField',
             fix(fixer) {
               if (mainValue) {
-                const mainNodeTyped = <
-                  {
-                    /** Source range as [start, end] positions */
-                    range: [number, number]
-                  }
-                >(<unknown>mainNode)
+                const mainNodeTyped = <NodeWithRange>(<unknown>mainNode)
                 const replacement = `"exports": {\n    ".": "${mainValue}"\n  }`
                 return fixer.replaceTextRange(mainNodeTyped.range, replacement)
               }

--- a/tools/eslint-rules/src/rules/lib-project-metadata.ts
+++ b/tools/eslint-rules/src/rules/lib-project-metadata.ts
@@ -8,6 +8,31 @@ import { isPublishableLibrary } from '../utils/nx-project'
  */
 export const RULE_NAME = 'lib-project-metadata'
 
+/**
+ * Recorded metadata field: the parsed value plus the AST node it came from
+ * so the rule can attach reports/fixes to the original source location.
+ *
+ * @template TValue - Concrete value type for the field
+ */
+type MetadataFieldRecord<TValue> = {
+  /** Field value or null if not set */
+  value: TValue | null
+  /** AST node reference */
+  node: JSONProperty
+}
+
+/**
+ * Bag of project.json metadata fields the rule tracks while traversing the AST.
+ */
+type ProjectMetadataFields = {
+  /** Project name field data */
+  name?: MetadataFieldRecord<string>
+  /** Project tags field data */
+  tags?: MetadataFieldRecord<unknown[]>
+  /** Project description field data */
+  description?: MetadataFieldRecord<string>
+}
+
 const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
@@ -36,29 +61,7 @@ const rule: Rule.RuleModule = {
     }
 
     // istanbul ignore next -- fields initialization
-    const fields: {
-      /** Project name field data */
-      name?: {
-        /** Field value or null if not set */
-        value: string | null
-        /** AST node reference */
-        node: JSONProperty
-      }
-      /** Project tags field data */
-      tags?: {
-        /** Field value or null if not set */
-        value: unknown[] | null
-        /** AST node reference */
-        node: JSONProperty
-      }
-      /** Project description field data */
-      description?: {
-        /** Field value or null if not set */
-        value: string | null
-        /** AST node reference */
-        node: JSONProperty
-      }
-    } = {}
+    const fields: ProjectMetadataFields = {}
 
     return {
       JSONProperty(node: JSONNode) {

--- a/tools/eslint-rules/src/rules/lib-require-jsdoc-example-label.ts
+++ b/tools/eslint-rules/src/rules/lib-require-jsdoc-example-label.ts
@@ -24,20 +24,22 @@ type MessageIds = 'missingLabel'
 const EXAMPLE_TAG = '@example'
 
 /**
+ * Result of inspecting a single `@example` tag in a JSDoc comment.
+ */
+type ExampleLabelInfo = {
+  /** Whether the `@example` tag has a descriptive label. */
+  hasLabel: boolean
+}
+
+/**
  * Extracts all `@example` occurrences from a JSDoc comment and checks if they have labels.
  * A label is non-whitespace text on the same line as `@example`.
  *
  * @param comment - The JSDoc comment text to analyze.
  * @returns Array of objects indicating whether each `@example` has a label.
  */
-function analyzeExampleLabels(comment: string): Array<{
-  /** Whether the `@example` tag has a descriptive label. */
-  hasLabel: boolean
-}> {
-  const results: Array<{
-    /** Whether the `@example` tag has a descriptive label. */
-    hasLabel: boolean
-  }> = []
+function analyzeExampleLabels(comment: string): Array<ExampleLabelInfo> {
+  const results: Array<ExampleLabelInfo> = []
   const lines = comment.split('\n')
 
   for (let i = 0; i < lines.length; i++) {

--- a/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
+++ b/tools/eslint-rules/src/rules/lib-tsconfig-paths.ts
@@ -28,12 +28,17 @@ interface EntryPointMapping {
 }
 
 /**
- * Extended JSONNode with optional parent reference.
+ * Adds the optional `parent` reference attached by the JSONC parser to a {@link JSONNode}.
  */
-type JSONNodeWithParent = JSONNode & {
+type ParentRef = {
   /** Reference to parent node in AST */
   parent?: JSONNode
 }
+
+/**
+ * Extended JSONNode with optional parent reference.
+ */
+type JSONNodeWithParent = JSONNode & ParentRef
 
 /**
  * Information about an orphan path that should be removed.

--- a/tools/eslint-rules/src/rules/no-direct-console.ts
+++ b/tools/eslint-rules/src/rules/no-direct-console.ts
@@ -62,6 +62,17 @@ const LOGGING_LIBRARY = '@hyperfrontend/logging'
 type MessageIds = 'noGlobalConsole' | 'noNxDevkitLogger' | 'noImmutableConsole' | 'noDisallowedLoggerUsage'
 
 /**
+ * Pending Nx devkit import discovered during traversal — paired with the local
+ * binding name that aliases it in the source file.
+ */
+type PendingNxDevkitImport = {
+  /** The import specifier node */
+  specifier: TSESTree.ImportSpecifier
+  /** The local binding name */
+  bindingName: string
+}
+
+/**
  * Checks if an import source is the approved logging library or its subpaths.
  *
  * @param source - The import source string.
@@ -114,12 +125,7 @@ export default createRule<[], MessageIds>({
     const nxDevkitLoggerBindings = createSet<string>()
     const immutableConsoleBindings = createSet<string>()
     const loggingLibraryBindings = createSet<string>()
-    const pendingNxDevkitImports: {
-      /** The import specifier node */
-      specifier: TSESTree.ImportSpecifier
-      /** The local binding name */
-      bindingName: string
-    }[] = []
+    const pendingNxDevkitImports: PendingNxDevkitImport[] = []
     const nxDevkitBindingsWithDisallowedUsage = createSet<string>()
     let importsCreateLogger = false
 

--- a/tools/eslint-rules/src/rules/no-inline-type-literal.spec.ts
+++ b/tools/eslint-rules/src/rules/no-inline-type-literal.spec.ts
@@ -1,0 +1,122 @@
+import type { InvalidTestCase, ValidTestCase } from '@typescript-eslint/rule-tester'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './no-inline-type-literal'
+
+type TestOptions = readonly []
+type MessageIds = 'noInlineTypeLiteral'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: false,
+    },
+  },
+})
+
+/**
+ * Valid test cases - code that does not use inline type literals at use sites.
+ */
+const validCases: ValidTestCase<TestOptions>[] = [
+  { code: `type Logger = { log: (msg: string) => void }` },
+  { code: `type Empty = {}` },
+  { code: `type WithMethod = { greet(): void }` },
+  { code: `type IndexOnly = { [k: string]: number }` },
+
+  { code: `interface Logger { log(msg: string): void }` },
+  { code: `interface Empty {}` },
+  { code: `interface WithIndex { [k: string]: number }` },
+
+  { code: `function f({ a }: Props) { return a }` },
+  { code: `function g(): Result { return getResult() }` },
+  { code: `const x: User = getUser()` },
+  { code: `class C { x: User = getUser() }` },
+  { code: `const u = <User>data` },
+  { code: `const r = useState<Config>()` },
+  { code: `const m: Map<string, User> = new Map()` },
+  { code: `type U = string | User` },
+  { code: `type I = Base & Mixin` },
+  { code: `const v = data satisfies User` },
+  { code: `function gen<T extends User>(x: T): T { return x }` },
+
+  { code: `function f(x: {}) { return x }` },
+  { code: `function f(x: { [k: string]: number }) { return x }` },
+  { code: `const x: {} = {}` },
+  { code: `const r = <{}>data` },
+
+  { code: `type CallableTag = { (): void }` },
+]
+
+/**
+ * Invalid test cases - inline type literals at use sites.
+ */
+const invalidCases: InvalidTestCase<MessageIds, TestOptions>[] = [
+  {
+    code: `function a({ logger, other }: { logger: Logger; other: number }) { return logger }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `function f(): { etc: boolean } { return { etc: true } }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const x: { a: number } = { a: 1 }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `class C { x: { a: number } = { a: 1 } }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const something = <{ etc: boolean }>getSomething()`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const something = getSomething() as { etc: boolean }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const r = useState<{ a: number }>()`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const m: Map<string, { a: number }> = new Map()`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `type U = string | { a: number }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `type I = Base & { a: number }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `const v = data satisfies { a: number }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `function gen<T extends { a: number }>(x: T): T { return x }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `function f(x: { greet(): void }) { return x }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `type Foo = { inner: { a: number } }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `interface Foo { inner: { a: number } }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+  {
+    code: `function tup(x: [{ a: number }, string]) { return x }`,
+    errors: [{ messageId: 'noInlineTypeLiteral' }],
+  },
+]
+
+ruleTester.run('no-inline-type-literal', rule, {
+  valid: validCases,
+  invalid: invalidCases,
+})

--- a/tools/eslint-rules/src/rules/no-inline-type-literal.ts
+++ b/tools/eslint-rules/src/rules/no-inline-type-literal.ts
@@ -1,0 +1,55 @@
+import type { TSESTree } from '@typescript-eslint/utils'
+import { ESLintUtils } from '@typescript-eslint/utils'
+
+/**
+ * Rule identifier for the no-inline-type-literal rule.
+ */
+export const RULE_NAME = 'no-inline-type-literal'
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/AndrewRedican/hyperfrontend/blob/main/tools/eslint-rules/docs/${name}.md`
+)
+
+/**
+ * Message identifiers for the no-inline-type-literal rule.
+ */
+type MessageIds = 'noInlineTypeLiteral'
+
+/**
+ * Determines whether a TSTypeLiteral has at least one property or method
+ * signature member. Empty `{}` and index-signature-only literals
+ * (e.g., `{ [k: string]: T }`) are intentionally exempt because they have
+ * no per-property names for JSDoc to attach to.
+ *
+ * @param node - The TSTypeLiteral node to inspect.
+ * @returns True if the literal has at least one named-property member.
+ */
+function hasNamedMember(node: TSESTree.TSTypeLiteral): boolean {
+  return node.members.some((member) => member.type === 'TSPropertySignature' || member.type === 'TSMethodSignature')
+}
+
+export default createRule<[], MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prohibit inline anonymous object type literals at use sites; require a named `type` alias or `interface`',
+    },
+    schema: [],
+    messages: {
+      noInlineTypeLiteral:
+        'Anonymous inline type literal is not allowed. Extract it into a named `type` alias or `interface` so it can be documented and reused. JSDoc cannot be attached to inline shapes.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSTypeLiteral(node) {
+        if (node.parent.type === 'TSTypeAliasDeclaration') return
+        if (!hasNamedMember(node)) return
+
+        context.report({ node, messageId: 'noInlineTypeLiteral' })
+      },
+    }
+  },
+})

--- a/tools/eslint-rules/src/rules/no-todo-comments.ts
+++ b/tools/eslint-rules/src/rules/no-todo-comments.ts
@@ -18,6 +18,16 @@ type MessageIds = 'noTodoComment'
 const TODO_PATTERNS = ['todo', 'to-do', 'to do']
 
 /**
+ * Location of a single task-reminder marker matched in a piece of text.
+ */
+type TodoMatch = {
+  /** Starting index of the match */
+  index: number
+  /** Length of the matched pattern */
+  length: number
+}
+
+/**
  * Checks if a character is a word character (letter, digit, or underscore).
  *
  * @param ch - The character to check.
@@ -38,19 +48,9 @@ function isWordChar(ch: string | undefined): boolean {
  * @param text - The text to search.
  * @returns Array of index and length for each match.
  */
-function findTodoOccurrences(text: string): Array<{
-  /** Starting index of the match */
-  index: number
-  /** Length of the matched pattern */
-  length: number
-}> {
+function findTodoOccurrences(text: string): Array<TodoMatch> {
   const lower = text.toLowerCase()
-  const results: Array<{
-    /** Starting index of the match */
-    index: number
-    /** Length of the matched pattern */
-    length: number
-  }> = []
+  const results: Array<TodoMatch> = []
 
   for (const pattern of TODO_PATTERNS) {
     let searchStart = 0

--- a/tools/eslint-rules/src/rules/no-unsafe-regex.ts
+++ b/tools/eslint-rules/src/rules/no-unsafe-regex.ts
@@ -64,6 +64,17 @@ const DEFAULT_OPTIONS: Required<NoUnsafeRegexOptions> = {
 }
 
 /**
+ * Result of {@link hasExponentialBounds}: whether an exponential quantifier was
+ * found and, if so, the offending bound string.
+ */
+type ExponentialBoundResult = {
+  /** Whether exponential bounds were detected in the pattern. */
+  found: boolean
+  /** The bound string if found (e.g., "{1,100000}"). */
+  bound?: string
+}
+
+/**
  * Checks if a regex pattern contains exponential bounded quantifiers.
  * Matches patterns like {1,100000} where the upper bound exceeds the threshold.
  *
@@ -71,15 +82,7 @@ const DEFAULT_OPTIONS: Required<NoUnsafeRegexOptions> = {
  * @param maxBound - The maximum allowed quantifier bound.
  * @returns An object indicating whether exponential bounds were found and the bound string if found.
  */
-function hasExponentialBounds(
-  pattern: string,
-  maxBound: number
-): {
-  /** Whether exponential bounds were detected in the pattern. */
-  found: boolean
-  /** The bound string if found (e.g., "{1,100000}"). */
-  bound?: string
-} {
+function hasExponentialBounds(pattern: string, maxBound: number): ExponentialBoundResult {
   // eslint-disable-next-line workspace/no-unsafe-regex -- This regex is safe and used for static analysis
   const quantifierRegex = /\{(\d+),(\d+)?\}/g
   let match: RegExpExecArray | null

--- a/tools/eslint-rules/src/rules/root-readme-packages.ts
+++ b/tools/eslint-rules/src/rules/root-readme-packages.ts
@@ -28,12 +28,18 @@ export interface PublishableLibrary {
 }
 
 /**
- * Extended project JSON with optional name field.
+ * Adds the optional `name` field that is occasionally written into project.json
+ * but isn't typed on Nx's `ProjectJson`.
  */
-type ProjectJsonWithName = ProjectJson & {
+type WithProjectName = {
   /** Project name */
   name?: string
 }
+
+/**
+ * Extended project JSON with optional name field.
+ */
+type ProjectJsonWithName = ProjectJson & WithProjectName
 
 /**
  * Package JSON subset with name field.

--- a/tools/eslint-rules/src/utils/nx-project.ts
+++ b/tools/eslint-rules/src/utils/nx-project.ts
@@ -5,20 +5,25 @@ import { createRuleLogger } from './logger'
 const logger = createRuleLogger('nx-project')
 
 /**
+ * Map of Nx target names to their configurations within a project.json file.
+ */
+export interface ProjectTargets {
+  /** Build target configuration */
+  build?: unknown
+  /** Publish target configuration */
+  publish?: unknown
+  /** Additional target configurations */
+  [key: string]: unknown
+}
+
+/**
  * Represents the structure of a project.json file.
  */
 export interface ProjectJson {
   /** The type of project - library or application */
   projectType?: 'library' | 'application'
   /** Build targets configuration */
-  targets?: {
-    /** Build target configuration */
-    build?: unknown
-    /** Publish target configuration */
-    publish?: unknown
-    /** Additional target configurations */
-    [key: string]: unknown
-  }
+  targets?: ProjectTargets
   /** Tags associated with the project */
   tags?: string[]
   [key: string]: unknown

--- a/tools/package/src/executors/build/executor.ts
+++ b/tools/package/src/executors/build/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { RollupOptions } from 'rollup'
 import type { BuildExecutorOptions, BuildContext, FormatOutputs, EntryPoint, ESMConfig, CJSConfig } from './lib'
 import { existsSync, mkdirSync, rmSync } from 'node:fs'
@@ -293,10 +293,7 @@ async function buildSingleEntry(
 export default async function runExecutor(
   options: BuildExecutorOptions,
   context: ExecutorContext
-): Promise<{
-  /** Whether the build succeeded */
-  success: boolean
-}> {
+): ReturnType<PromiseExecutor> {
   const { projectName, root: workspaceRoot } = context
   const logger = getLogger()
   logger.setLogLevel(options.verbose ?? false)

--- a/tools/package/src/executors/build/lib/assets.ts
+++ b/tools/package/src/executors/build/lib/assets.ts
@@ -7,6 +7,26 @@ import {keys} from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 import { parseRepositoryUrl } from '@hyperfrontend/versioning/repository/parse'
 import { logger } from '../../../lib/logger'
 
+/**
+ * Object form of `package.json` `repository` (the alternative to a plain URL string).
+ */
+type RepositoryDescriptor = {
+  /** Repository provider type */
+  type: string
+  /** Repository URL */
+  url: string
+}
+
+/**
+ * Pattern entry used to detect known SPDX licenses inside LICENSE file text.
+ */
+type LicensePattern = {
+  /** Regular expression to match license text */
+  pattern: RegExp
+  /** SPDX license type identifier */
+  type: string
+}
+
 /** License information for a third-party dependency */
 export interface ThirdPartyLicenseEntry {
   /** Package name */
@@ -173,12 +193,7 @@ function findLicenseFile(packageDir: string): string | null {
  * @param licenseFileName - Name of the license file (e.g., 'LICENSE', 'LICENSE.md')
  * @returns URL to the license file or null if URL cannot be constructed
  */
-function constructLicenseUrl(repositoryUrl: string | {
-    /** Repository provider type */
-    type: string
-    /** Repository URL */
-    url: string
-  } | undefined, licenseFileName: string): string | null {
+function constructLicenseUrl(repositoryUrl: string | RepositoryDescriptor | undefined, licenseFileName: string): string | null {
   if (!repositoryUrl) {
     return null
   }
@@ -210,12 +225,7 @@ function constructLicenseUrl(repositoryUrl: string | {
  * @returns Detected license type or 'Unknown'
  */
 function detectLicenseFromContent(licenseContent: string): string | null {
-  const patterns: Array<{
-    /** Regular expression to match license text */
-    pattern: RegExp
-    /** SPDX license type identifier */
-    type: string
-  }> = [
+  const patterns: Array<LicensePattern> = [
     { pattern: /MIT License/i, type: 'MIT' },
     { pattern: /The MIT License/i, type: 'MIT' },
     { pattern: /Apache License.*Version 2\.0/i, type: 'Apache-2.0' },

--- a/tools/package/src/executors/e2e/executor.ts
+++ b/tools/package/src/executors/e2e/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { E2eExecutorOptions } from './schema'
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, unlinkSync, mkdirSync, renameSync } from 'node:fs'
@@ -8,17 +8,22 @@ import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 import { logger } from '../../lib/logger'
 
 /**
+ * Slice of `package.json` we need when locating a built artifact's tarball.
+ */
+type PackageInfo = {
+  /** The package name from package.json */
+  name: string
+  /** The package version from package.json */
+  version: string
+}
+
+/**
  * Reads package info from dist package.json.
  *
  * @param distPath - The path to the dist directory containing package.json
  * @returns An object containing the package name and version
  */
-function getPackageInfo(distPath: string): {
-  /** The package name from package.json */
-  name: string
-  /** The package version from package.json */
-  version: string
-} {
+function getPackageInfo(distPath: string): PackageInfo {
   const pkgPath = join(distPath, 'package.json')
   if (!existsSync(pkgPath)) {
     throw createError(`Package.json not found at ${pkgPath}. Has the library been built?`)
@@ -124,13 +129,7 @@ function runJestTests(testDir: string, format: string, workspaceRoot: string): b
  * @param context - The Nx executor context
  * @returns A promise resolving to an object indicating success or failure
  */
-export default async function e2eExecutor(
-  options: E2eExecutorOptions,
-  context: ExecutorContext
-): Promise<{
-  /** Whether the E2E tests passed */
-  success: boolean
-}> {
+export default async function e2eExecutor(options: E2eExecutorOptions, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const { projectName, root: workspaceRoot, projectGraph } = context
 
   if (!projectName) {

--- a/tools/package/src/executors/publish/executor.ts
+++ b/tools/package/src/executors/publish/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { PublishExecutorOptions } from './schema'
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
@@ -7,16 +7,31 @@ import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
 import { logger } from '../../lib/logger'
 
 /**
+ * Slice of an Nx project configuration relevant to {@link isLibraryProject}.
+ */
+type LibraryProjectConfig = {
+  /** Type of the project (e.g., 'library', 'application') */
+  projectType?: string
+}
+
+/**
+ * Errors thrown by `child_process` may carry a `stderr` field beyond the
+ * standard `Error` shape; this captures it without committing to the full
+ * Node.js error type.
+ */
+type ErrorWithStderr = {
+  /** Standard error output */
+  stderr: unknown
+}
+
+/**
  * Verifies the project is a publishable library.
  *
  * @param projectConfig - Project configuration from Nx
  * @param projectConfig.projectType - Type of the project (e.g., 'library', 'application')
  * @returns True if the project is a library
  */
-function isLibraryProject(projectConfig: {
-  /** Type of the project (e.g., 'library', 'application') */
-  projectType?: string
-}): boolean {
+function isLibraryProject(projectConfig: LibraryProjectConfig): boolean {
   return projectConfig.projectType === 'library'
 }
 
@@ -101,13 +116,7 @@ function buildPublishArgs(options: PublishExecutorOptions): string[] {
  * @param context - Nx executor context
  * @returns Success status
  */
-export default async function publishExecutor(
-  options: PublishExecutorOptions,
-  context: ExecutorContext
-): Promise<{
-  /** Whether the publish operation succeeded */
-  success: boolean
-}> {
+export default async function publishExecutor(options: PublishExecutorOptions, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const { projectName, root: workspaceRoot } = context
 
   if (!projectName) {
@@ -200,16 +209,7 @@ export default async function publishExecutor(
     if (error instanceof Error) {
       logger.error(error.message)
       if ('stderr' in error) {
-        logger.error(
-          String(
-            (<
-              {
-                /** Standard error output */
-                stderr: unknown
-              }
-            >error).stderr
-          )
-        )
+        logger.error(String((<ErrorWithStderr>error).stderr))
       }
     }
     return { success: false }

--- a/tools/package/src/executors/typecheck/executor.ts
+++ b/tools/package/src/executors/typecheck/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { TypecheckExecutorOptions } from './schema'
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
@@ -16,13 +16,7 @@ import { logger } from '../../lib/logger'
  * @param context - Executor context providing project information
  * @returns An object indicating success or failure of the type check
  */
-export default async function typecheckExecutor(
-  options: TypecheckExecutorOptions,
-  context: ExecutorContext
-): Promise<{
-  /** Whether the type check completed successfully. */
-  success: boolean
-}> {
+export default async function typecheckExecutor(options: TypecheckExecutorOptions, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const projectName = context.projectName
   if (!projectName) {
     logger.error('No project name provided')

--- a/tools/package/src/executors/version-batch/executor.ts
+++ b/tools/package/src/executors/version-batch/executor.ts
@@ -40,10 +40,7 @@ export interface VersionBatchResult {
 export default async function versionBatchExecutor(
   options: VersionBatchExecutorSchema,
   context: ExecutorContext
-): Promise<{
-  /** Whether the batch versioning operation succeeded */
-  success: boolean
-}> {
+): Promise<Pick<VersionBatchResult, 'success'>> {
   const workspaceRoot = context.root
   const { base = 'origin/main', head = 'HEAD', dryRun = false, verbose = false } = options
 

--- a/tools/package/src/executors/version-check/executor.ts
+++ b/tools/package/src/executors/version-check/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import type { VersionCheckExecutorSchema } from './schema'
 import { isInUnstableGitState } from '../version/lib/is-in-unstable-git-state'
 import { isVersionCommit } from '../version/lib/is-version-commit'
@@ -28,10 +28,7 @@ import { validateVersionState, formatValidationResult } from '../version/lib/val
 export default async function versionCheckExecutor(
   options: VersionCheckExecutorSchema,
   context: ExecutorContext
-): Promise<{
-  /** Whether the version check completed successfully. */
-  success: boolean
-}> {
+): ReturnType<PromiseExecutor> {
   const { projectName, root: workspaceRoot, projectGraph } = context
   const logger = getLogger()
   logger.setLogLevel(options)

--- a/tools/package/src/executors/version/executor.ts
+++ b/tools/package/src/executors/version/executor.ts
@@ -1,4 +1,4 @@
-import type { ExecutorContext } from '@nx/devkit'
+import type { ExecutorContext, PromiseExecutor } from '@nx/devkit'
 import { getLogger } from './lib/logger'
 import { runVersionForProject } from './lib/run-version-for-project'
 import { VersionExecutorSchema } from './schema'
@@ -19,13 +19,7 @@ import { VersionExecutorSchema } from './schema'
  * @param context - Nx executor context
  * @returns Success status
  */
-export default async function versionExecutor(
-  options: VersionExecutorSchema,
-  context: ExecutorContext
-): Promise<{
-  /** Whether the version operation completed successfully. */
-  success: boolean
-}> {
+export default async function versionExecutor(options: VersionExecutorSchema, context: ExecutorContext): ReturnType<PromiseExecutor> {
   const { projectName, root: workspaceRoot, projectGraph } = context
   const logger = getLogger()
   logger.setLogLevel(options)

--- a/tools/package/src/lib/project-references.ts
+++ b/tools/package/src/lib/project-references.ts
@@ -4,6 +4,22 @@ import { isArray } from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
 import { values } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
 
 /**
+ * Slice of an Nx target config we mutate while updating project references.
+ */
+type TargetWithDependsOn = {
+  /** Target dependencies */
+  dependsOn?: unknown[]
+}
+
+/**
+ * Object form of an entry in `dependsOn` (the alternative to a plain target name).
+ */
+type DependsOnObject = {
+  /** Projects this target depends on */
+  projects?: string | string[]
+}
+
+/**
  * Options for updating project references.
  */
 export interface UpdateReferencesOptions {
@@ -62,24 +78,14 @@ export function updateProjectReferences(tree: Tree, options: UpdateReferencesOpt
 
       if (json.targets) {
         for (const target of values(json.targets)) {
-          const targetConfig = <
-            {
-              /** Target dependencies */
-              dependsOn?: unknown[]
-            }
-          >target
+          const targetConfig = <TargetWithDependsOn>target
           if (isArray(targetConfig.dependsOn)) {
             targetConfig.dependsOn = targetConfig.dependsOn.map((dep) => {
               if (typeof dep === 'string' && dep === options.currentProjectName) {
                 return options.newProjectName
               }
               if (typeof dep === 'object' && dep !== null) {
-                const depObj = <
-                  {
-                    /** Projects this target depends on */
-                    projects?: string | string[]
-                  }
-                >dep
+                const depObj = <DependsOnObject>dep
                 if (depObj.projects === options.currentProjectName) {
                   depObj.projects = options.newProjectName
                 } else if (isArray(depObj.projects)) {


### PR DESCRIPTION
## Description

Introduces a new `workspace/no-inline-type-literal` ESLint rule that prohibits inline anonymous object type literals at use sites and requires every named-property shape to live as a `type` alias or `interface`. The rule is enabled across the workspace, and every pre-existing inline literal has been extracted into a declared type so JSDoc-coverage rules can decorate it. Also lands the Phase 1–2 builder package implementation plan under `roadmap/`.

## Type of Change

✨ Feature | ♻️ Refactor | 📝 Docs

## Changes Made

- Add `workspace/no-inline-type-literal` rule in `tools/eslint-rules/src/rules/no-inline-type-literal.ts` with accompanying spec and a documentation page at `tools/eslint-rules/docs/no-inline-type-literal.md`.
- Wire the rule into `eslint.base.config.cjs` for `**/*.ts` and `**/*.tsx`, with Jest config and spec files exempted.
- Refactor inline type literals into declared `type` aliases or `interface`s across `libs/network-protocol`, `libs/nexus`, `libs/project-scope`, `libs/versioning`, `libs/utils/data`, `libs/utils/json`, `libs/utils/string`, `apps/docs-site`, `tools/app`, `tools/package`, and `tools/eslint-rules`.
- Add `roadmap/phase-1-2-builder-implementation-plan.md` documenting the planned builder package work.

## Testing

- New unit tests for the rule in `tools/eslint-rules/src/rules/no-inline-type-literal.spec.ts` cover positional, return-type, cast, generic, union/intersection, satisfies, generic-constraint, and nested-literal cases, plus exempt forms (RHS of `type`, `interface` bodies, empty `{}`, index-signature-only, call-signature-only).
- Repository lint run confirms the rule passes across the touched libraries, apps, and tools after the refactors.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests as needed
- [x] I have updated relevant documentation
- [x] I have used `npm run commit` for conventional commit messages

## AI Assistance

GitHub Copilot was used to generate this PR description.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
