### PR TITLE
Package-Filterable Guides Destination and Hidden-Frame Liveness Fix

### DIFF
--- a/.claude/skills/how-to-guides/SKILL.md
+++ b/.claude/skills/how-to-guides/SKILL.md
@@ -17,6 +17,8 @@ Understanding why → `explanation`
 
 A how-to ships as a guide unit: `apps/docs-site/content/guides/<slug>/` holding `guide.md` and `meta.json`. Guides are docs-site editorial artifacts. A guide may describe a package, use its APIs, and link to its reference pages, but it never lives inside that package: nothing goes under `libs/<lib>/docs/`, because a file inside a publishable project makes Nx, CI, versioning, and publishing treat the package itself as changed. Read `meta.json` before writing and confirm `type` is `how-to`, `troubleshooting`, or `recipe`. A mismatch is a decision to make, not a formality: change the type or move the content, never leave the two disagreeing.
 
+`troubleshooting` is narrower than the word suggests: it means diagnosing HyperFrontend itself, when one of its APIs, its runtime, or a configuration is not behaving as documented. Teaching a reader to use a HyperFrontend package against a problem their own application or the platform handed them is a `how-to`, no matter how error-shaped the title is. "How to fix `Converting circular structure to JSON`" is a how-to: the error is `JSON.stringify`'s, and the guide teaches `@hyperfrontend/data-utils` as the way through it.
+
 What the body must corroborate:
 
 | Field           | Must agree with                                                                        |

--- a/.claude/skills/readme-docs/SKILL.md
+++ b/.claude/skills/readme-docs/SKILL.md
@@ -64,8 +64,14 @@ The sub-module page renders this README plus an auto-generated scoped API refere
 
 ```markdown
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/<name>/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2F<name>)
 • 👉 See [**roadmap**](https://github.com/AndrewRedican/hyperfrontend/blob/main/roadmap/<name>/)
 ```
+
+The guides link is checked by `lib-readme-structure` against `package.json`'s
+`name`, URL-encoded the way the site's own filter encodes it. It points at a
+filter rather than at guide slugs, so it is correct before any guide exists and
+starts surfacing guides the moment they are written.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/guide_request.yml
+++ b/.github/ISSUE_TEMPLATE/guide_request.yml
@@ -1,0 +1,32 @@
+name: 📘 Guide Request
+description: Ask for a how-to guide or tutorial covering something you are trying to do
+title: '[GUIDE] '
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Guides are written from real problems. Tell us the one you have and we will know what to write.
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: The `@hyperfrontend/…` package the guide should cover. Prefilled when you arrive from a package's guides page.
+      placeholder: '@hyperfrontend/nexus'
+    validations:
+      required: false
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to accomplish?
+      description: The task or problem in your own words. A concrete situation beats a topic name.
+      placeholder: I need to keep an idle timeout running across a dialog that pauses it, and every version I write drifts.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything you already tried or read?
+      description: Optional. Docs pages that got close, approaches that did not work, or the error you keep hitting.
+    validations:
+      required: false

--- a/apps/docs-site/README.md
+++ b/apps/docs-site/README.md
@@ -213,6 +213,16 @@ the static build. Articles are served as an Atom feed at `/feed.xml`
 (`src/lib/feed.ts` + `src/app/feed.xml/route.ts`), advertised via the layout's
 `alternates.types`.
 
+### Sharing
+
+One share implementation serves every reader-facing page: `src/lib/share.ts` composes the
+canonical URL and share text, `src/components/share/share-menu.tsx` renders the control, and
+`src/components/share/share-icons.tsx` holds the destination brand marks as inline SVG so a
+handful of icons costs no dependency and no extra request. Articles, how-to guides, and
+tutorials mount the same component with their own title and page line, so the experience does
+not depend on which kind of page the reader is on. Every mark is decorative and paired with a
+visible label.
+
 ---
 
 ## Libraries Documented

--- a/apps/docs-site/README.md
+++ b/apps/docs-site/README.md
@@ -138,6 +138,10 @@ Slugs are global and flat: the directory name is the URL. Grouping folders are
 deliberately absent, because `meta.json` already carries the taxonomy the site filters
 and sorts on.
 
+`prerequisites.knowledge` entries are authored sentences, so they render through
+`markdownToInlineHtml`: an entry may carry a link or a code span, and nothing else. The
+rest of `meta.json` stays plain text.
+
 The compiler
 (`scripts/generate-guides.ts`) validates metadata, resolves every
 `<!-- snippet: region -->` placeholder from `// ref: [guide:<slug>/<region>] start|end`

--- a/apps/docs-site/README.md
+++ b/apps/docs-site/README.md
@@ -163,6 +163,29 @@ Outputs: `.generated/guides/<slug>/guide.md` (rendered at `/docs/guides/<slug>`)
 `/guides/index.json`. Library pages surface their guides from that index; there is no
 hand-maintained guide registry.
 
+#### One filtered destination, many entry points
+
+`/docs/guides/` is the only guides destination, and both of its facets live in the query
+string: `?package=<npm package name>` and `?type=<tutorial|how-to|troubleshooting|recipe>`.
+The semantics are defined once in [src/lib/guide-filters.ts](src/lib/guide-filters.ts) and
+every consumer goes through it: the index page's own controls, the landing page's learning
+cards, each library page's guides link, and `getGuidesForPackage`, which library pages use
+to list a package's guides. There is no second filtering implementation and no
+package-to-guide table: association comes from each unit's `meta.json` `packages`, and the
+selectable package list comes from the documentation manifest, so a package with no guides
+yet is still a valid, shareable filter.
+
+Published package READMEs link the same URL
+(`https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2F<name>`), enforced
+by the `lib-readme-structure` ESLint rule against `package.json`'s `name`. Because the link
+addresses a filter rather than guide slugs, it is correct before a package has any guides
+and begins surfacing them the moment they ship, with no README change.
+
+A filtered view with no results is a deliberate empty state, not an error: it names the
+package and offers a prefilled guide request against the `guide_request.yml` issue form
+(`src/lib/guide-request.ts`), using GitHub's own field-prefill query parameters. A populated
+view carries the same request as a quieter secondary action.
+
 Fast authoring loop (skips TypeDoc):
 
 ```bash
@@ -311,6 +334,8 @@ asset links resolve against `public/` as well as `src/app` routes.
 | `/docs/quick-start`             | Quick Start guide             |
 | `/docs/core-concepts`           | Core Concepts                 |
 | `/docs/guides`                  | Guides index (problem-first)  |
+| `/docs/guides/?package={pkg}`   | Guides filtered to a package  |
+| `/docs/guides/?type={type}`     | Guides filtered to a type     |
 | `/docs/guides/{slug}`           | One compiled guide            |
 | `/docs/libraries/{slug}`        | Library documentation         |
 | `/docs/libraries/utils/{slug}`  | Utils package documentation   |

--- a/apps/docs-site/content/guides/build-a-setup-wizard-for-your-cli/guide.md
+++ b/apps/docs-site/content/guides/build-a-setup-wizard-for-your-cli/guide.md
@@ -1,0 +1,170 @@
+# Build a setup wizard for your CLI
+
+You will build a `create-service` command that asks four questions, refuses answers it cannot use, lets the reader back out at any point, and writes a project from what it collected.
+
+Everything comes from [`@hyperfrontend/questions`](/docs/libraries/questions). In an empty directory:
+
+```bash
+npm install @hyperfrontend/questions
+```
+
+## Ask the first question
+
+Create `create-service.mjs`:
+
+```js
+import { text } from '@hyperfrontend/questions'
+
+const outcome = await text({ message: 'Service name:' })
+
+console.log(outcome)
+```
+
+Run it with `node create-service.mjs`, type a name, press Enter:
+
+```text
+{ result: 'submitted', value: 'billing' }
+```
+
+Now run it again and press `Ctrl+C`:
+
+```text
+{ result: 'cancelled', value: undefined }
+```
+
+Every prompt resolves to that same [`PromptOutcome`](/docs/libraries/questions#api-PromptOutcome) union. Nothing throws, nothing leaves the terminal in raw mode, and there is no signal handler to install: an interrupted question is a value you read like any other.
+
+## Refuse an answer you cannot use
+
+The name becomes a directory and a package name, so most of what someone could type is unusable. Give [`text`](/docs/libraries/questions#api-text) a [`validate`](/docs/libraries/questions#api-TextConfig-prop-validate) function returning a message to reject and `undefined` to accept:
+
+```js
+const outcome = await text({
+  message: 'Service name:',
+  validate: (value) => (/^[a-z][a-z0-9-]*$/.test(value) ? undefined : 'Lowercase letters, digits and dashes, starting with a letter'),
+})
+```
+
+Type `Billing` and press Enter: the message appears under the prompt and the cursor stays where it was, with what you typed still editable. The prompt only resolves once the value passes.
+
+## Handle a cancelled session once
+
+Three more questions are coming, and checking `result` after each one puts the same four lines in four places. Because the union is the same shape everywhere, one helper covers all of them:
+
+```js
+import { text, PromptResult } from '@hyperfrontend/questions'
+
+async function ask(prompt) {
+  const outcome = await prompt
+  if (outcome.result === PromptResult.Cancelled) {
+    console.log('\nNothing was written.')
+    process.exit(130)
+  }
+  return outcome.value
+}
+
+const name = await ask(text({ message: 'Service name:', validate: /* … */ }))
+```
+
+`ask` takes the promise a prompt already returned, so it composes with every prompt in the package without knowing which one it holds, and [`PromptResult`](/docs/libraries/questions#api-PromptResult) is the pair of constants the union discriminates on. Exiting `130` is the conventional code for a run stopped by `SIGINT`, which is what a shell script wrapping your CLI looks for.
+
+From here every answer reads as a plain value.
+
+## Offer a closed set
+
+A runtime is one of two things, so typing it is only an opportunity for typos. [`select`](/docs/libraries/questions#api-select) takes [`Choice`](/docs/libraries/questions#api-Choice) objects, where `label` is what the reader sees, `value` is what you get back, and `hint` is the consequence they need in order to choose:
+
+```js
+import { select } from '@hyperfrontend/questions'
+
+const runtime = await ask(
+  select({
+    message: 'Runtime:',
+    choices: [
+      { label: 'node', value: 'node', hint: 'long-running process' },
+      { label: 'edge', value: 'edge', hint: 'no filesystem, no native modules' },
+    ],
+  })
+)
+```
+
+```text
+? Runtime: (use arrows, enter to select)
+❯ node — long-running process
+  edge — no filesystem, no native modules
+```
+
+## Take several answers at once
+
+Optional extras are not exclusive, so they need [`multiselect`](/docs/libraries/questions#api-multiselect): space toggles, Enter submits, and the answer is an array of the `value`s. Turning on [`searchable`](/docs/libraries/questions#api-MultiselectConfig-prop-searchable) lets typing narrow the list, which is what keeps this prompt usable when the list grows past a screen:
+
+```js
+import { multiselect } from '@hyperfrontend/questions'
+
+const extras = await ask(
+  multiselect({
+    message: 'Include:',
+    choices: [
+      { label: 'Dockerfile', value: 'docker' },
+      { label: 'GitHub Actions workflow', value: 'ci' },
+      { label: 'OpenTelemetry tracing', value: 'otel' },
+      { label: 'Health check endpoint', value: 'health' },
+    ],
+    searchable: true,
+  })
+)
+```
+
+```text
+? Include: (type to filter, space to toggle, enter to submit)
+  2 selected
+  ☑ Dockerfile
+❯ ☑ GitHub Actions workflow
+  ☐ OpenTelemetry tracing
+  ☐ Health check endpoint
+```
+
+Selecting none is a valid answer here. Pass `min: 1` when it is not.
+
+## Confirm, then write
+
+Show what you collected before you touch the disk, and make the last question a [`confirm`](/docs/libraries/questions#api-confirm). Its `initial` decides which answer a bare Enter gives, so the prompt reads `(Y/n)`:
+
+```js
+import { confirm } from '@hyperfrontend/questions'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+console.log(`\n  ${name} (${runtime})`)
+console.log(`  extras: ${extras.length ? extras.join(', ') : 'none'}\n`)
+
+if (!(await ask(confirm({ message: `Create ./${name}?`, initial: true })))) {
+  console.log('Nothing was written.')
+  process.exit(0)
+}
+
+await mkdir(name, { recursive: true })
+await writeFile(`${name}/service.json`, JSON.stringify({ name, runtime, extras }, null, 2) + '\n')
+console.log(`Created ./${name}/service.json`)
+```
+
+A declined confirm is not a cancellation: it is a `false` the reader deliberately gave, so it exits `0`.
+
+## What you have
+
+```bash
+node create-service.mjs
+```
+
+```text
+? Service name: billing
+? Runtime: node
+? Include: Dockerfile, GitHub Actions workflow
+
+  billing (node)
+  extras: docker, ci
+
+? Create ./billing? Yes
+Created ./billing/service.json
+```
+
+Four prompts, one `ask` helper, and no terminal handling anywhere in your code. The shape that made that possible is the outcome union: because submission and cancellation are values of one type rather than a value and an exception, the interesting path stays a straight line of `await`s, and the boring path is handled once at the top.

--- a/apps/docs-site/content/guides/build-a-setup-wizard-for-your-cli/meta.json
+++ b/apps/docs-site/content/guides/build-a-setup-wizard-for-your-cli/meta.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "type": "tutorial",
+  "title": "Build a setup wizard for your CLI",
+  "problem": "My CLI takes its setup from a wall of flags nobody remembers, and every attempt at an interactive version turns into raw-mode handling, signal handlers, and a validation branch after every question.",
+  "outcome": "A working create-service command that asks four questions, rejects a name it cannot use while the reader is still typing, backs out cleanly on Ctrl+C from any step, and writes a project from the answers.",
+  "priority": "P0",
+  "packages": ["@hyperfrontend/questions"],
+  "verification": {
+    "kind": "authored",
+    "verifiedAgainst": "@hyperfrontend/questions@0.3.0",
+    "verifiedOn": "2026-08-19"
+  },
+  "complexity": "beginner",
+  "estMinutes": 20,
+  "apis": [
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "text"
+    },
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "select"
+    },
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "multiselect"
+    },
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "confirm"
+    },
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "PromptResult"
+    },
+    {
+      "package": "@hyperfrontend/questions",
+      "symbol": "PromptOutcome"
+    }
+  ],
+  "prerequisites": {
+    "knowledge": ["Node.js 18 or newer", "An empty directory to build the command in"]
+  },
+  "related": {
+    "guides": ["instrument-a-cli-with-logging"],
+    "reference": ["/docs/libraries/questions"]
+  },
+  "keywords": [
+    "prompt",
+    "wizard",
+    "interactive CLI",
+    "scaffolding",
+    "select",
+    "multiselect",
+    "confirm",
+    "text input",
+    "validation",
+    "Ctrl+C",
+    "cancellation",
+    "searchable",
+    "terminal"
+  ]
+}

--- a/apps/docs-site/content/guides/fix-converting-circular-structure-to-json/meta.json
+++ b/apps/docs-site/content/guides/fix-converting-circular-structure-to-json/meta.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "type": "troubleshooting",
+  "type": "how-to",
   "title": "How to fix \"Converting circular structure to JSON\"",
   "problem": "JSON.stringify throws on an object graph with back references, the engine names only one of them, and every edge I remove reveals another.",
   "outcome": "A list of every loop in the value, a copy that serialises with those edges replaced by path pointers, and the original graph untouched.",

--- a/apps/docs-site/content/guides/fix-converting-circular-structure-to-json/meta.json
+++ b/apps/docs-site/content/guides/fix-converting-circular-structure-to-json/meta.json
@@ -28,7 +28,9 @@
     }
   ],
   "prerequisites": {
-    "knowledge": ["A value that already throws on JSON.stringify"]
+    "knowledge": [
+      "A value that already throws on [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)"
+    ]
   },
   "related": {
     "reference": ["/docs/libraries/utils/data"]

--- a/apps/docs-site/content/guides/harden-code-against-prototype-pollution/guide.md
+++ b/apps/docs-site/content/guides/harden-code-against-prototype-pollution/guide.md
@@ -1,0 +1,85 @@
+# How to harden your code against prototype pollution
+
+You will make the checks that matter (an authorisation test, a serialiser, a dispatch table) keep telling the truth after something else on the page has moved the ground under them.
+
+Any script sharing your realm can write `Object.prototype.isAdmin = true` or reassign `Array.isArray`, and every later reader inherits the lie without an error anywhere. A tag manager, a chat widget, a plugin, or a dependency five levels down is enough. [`@hyperfrontend/immutable-api-utils`](/docs/libraries/utils/immutable-api) gives you references captured before that happens, plus the two access patterns that a polluted prototype cannot reach through.
+
+## 1. Capture the built-ins first
+
+```bash
+npm install @hyperfrontend/immutable-api-utils
+```
+
+Put the imports above every other import in your entry module. Each one reads its built-in a single time, when the module is evaluated, so the reference you get is whatever was true at that moment:
+
+```ts
+import { hasOwn, keys, create } from '@hyperfrontend/immutable-api-utils/built-in-copy/object'
+import { isArray } from '@hyperfrontend/immutable-api-utils/built-in-copy/array'
+import { stringify } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+
+import './analytics'
+import './app'
+```
+
+Order decides the outcome, because [ES modules evaluate in source order](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#importing_features_into_your_script). Above `./analytics` the copies are the originals; below it they would be whatever that module left behind. Everything else in your build can import them at any point afterwards.
+
+There is one entry point per built-in ([`object`](/docs/libraries/utils/immutable-api/built-in-copy/object), [`array`](/docs/libraries/utils/immutable-api/built-in-copy/array), [`json`](/docs/libraries/utils/immutable-api/built-in-copy/json), [`console`](/docs/libraries/utils/immutable-api/built-in-copy/console), [`timers`](/docs/libraries/utils/immutable-api/built-in-copy/timers), and the rest), so you take only what you depend on.
+
+## 2. Call the copies where a lie would matter
+
+Say another script has run this:
+
+```ts
+Object.prototype.isAdmin = true
+Array.isArray = () => true
+JSON.stringify = () => '{"amount":0}'
+```
+
+The globals now agree with the attacker. Your captured references do not:
+
+```ts
+Array.isArray({}) // true
+isArray({}) // false
+
+JSON.stringify({ amount: 4200 }) // '{"amount":0}'
+stringify({ amount: 4200 }) // '{"amount":4200}'
+```
+
+Use them on the paths where a wrong answer is a security or correctness event: type gates before a privileged branch, the serialiser that produces a signed payload, the [`console`](/docs/libraries/utils/immutable-api/built-in-copy/console) call your incident report depends on, the [`setTimeout`](/docs/libraries/utils/immutable-api/built-in-copy/timers) that arms a session expiry. Ordinary application code can keep using the globals.
+
+## 3. Ask about own properties, not inherited ones
+
+A polluted prototype answers for every object you did not explicitly check. [`hasOwn`](/docs/libraries/utils/immutable-api/built-in-copy/object#api-hasOwn) asks the object itself:
+
+```ts
+const session = { user: 'ada' }
+
+'isAdmin' in session // true
+session.isAdmin // true
+hasOwn(session, 'isAdmin') // false
+```
+
+The same split runs through enumeration. [`for...in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) walks the prototype chain and picks the injected key up; [`keys`](/docs/libraries/utils/immutable-api/built-in-copy/object#api-keys) stays on the object:
+
+```ts
+for (const key in session) console.log(key) // 'user', then 'isAdmin'
+
+keys(session) // ['user']
+```
+
+## 4. Give lookup objects no prototype at all
+
+An object keyed by data you did not author (a message type, a route name, a feature flag) answers to `toString`, `constructor`, and `__proto__` before anyone attacks it. [`create(null)`](/docs/libraries/utils/immutable-api/built-in-copy/object#api-create) removes the chain, so a miss is a miss:
+
+```ts
+const handlers = create(null)
+handlers.refund = onRefund
+
+handlers['toString'] // undefined
+```
+
+Built with `{}` instead, `handlers['toString']` is a function, and `if (handlers[type])` dispatches on a key nobody registered.
+
+## Check it worked
+
+Write a scratch module that pollutes `Object.prototype` and reassigns `Array.isArray`, and import it after your captured copies. The copied `isArray` still rejects `{}`, `hasOwn` still reports `false` for the injected key, and your dispatch table still misses on `toString`. Then move the polluting import above the copies and run it again: every one of those flips, which is the whole reason the import sits where it does.

--- a/apps/docs-site/content/guides/harden-code-against-prototype-pollution/meta.json
+++ b/apps/docs-site/content/guides/harden-code-against-prototype-pollution/meta.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "type": "how-to",
+  "title": "How to harden your code against prototype pollution",
+  "problem": "Anything else running on the page can add to Object.prototype or reassign a built-in like Array.isArray, and my authorisation checks, serialisers, and dispatch tables inherit the lie without an error anywhere.",
+  "outcome": "Built-in references captured before untrusted code runs, own-property checks that a polluted prototype cannot answer for, and lookup objects with no prototype chain to inherit from.",
+  "priority": "P0",
+  "packages": ["@hyperfrontend/immutable-api-utils"],
+  "verification": {
+    "kind": "authored",
+    "verifiedAgainst": "@hyperfrontend/immutable-api-utils@0.1.4",
+    "verifiedOn": "2026-08-19"
+  },
+  "complexity": "intermediate",
+  "estMinutes": 10,
+  "apis": [
+    {
+      "package": "@hyperfrontend/immutable-api-utils",
+      "symbol": "hasOwn"
+    },
+    {
+      "package": "@hyperfrontend/immutable-api-utils",
+      "symbol": "keys"
+    },
+    {
+      "package": "@hyperfrontend/immutable-api-utils",
+      "symbol": "create"
+    },
+    {
+      "package": "@hyperfrontend/immutable-api-utils",
+      "symbol": "isArray"
+    },
+    {
+      "package": "@hyperfrontend/immutable-api-utils",
+      "symbol": "stringify"
+    }
+  ],
+  "prerequisites": {
+    "knowledge": ["A JavaScript or TypeScript project with an entry module you control"]
+  },
+  "related": {
+    "reference": [
+      "/docs/libraries/utils/immutable-api",
+      "/docs/libraries/utils/immutable-api/built-in-copy/object",
+      "/docs/libraries/utils/immutable-api/built-in-copy/array",
+      "/docs/libraries/utils/immutable-api/built-in-copy/json"
+    ],
+    "explanation": ["/docs/core-concepts/security"]
+  },
+  "keywords": [
+    "prototype pollution",
+    "__proto__",
+    "Object.prototype",
+    "monkey patching",
+    "built-in copy",
+    "hasOwn",
+    "hasOwnProperty",
+    "create(null)",
+    "null prototype",
+    "supply chain",
+    "third-party script",
+    "tamper"
+  ]
+}

--- a/apps/docs-site/content/guides/replace-commitizen-and-commitlint/guide.md
+++ b/apps/docs-site/content/guides/replace-commitizen-and-commitlint/guide.md
@@ -1,0 +1,96 @@
+# How to replace commitizen and commitlint with one package
+
+You will drop four packages and both of their configs, and keep the same workflow: a guided prompt for writing conventional commits, and a hook that refuses the ones that do not conform.
+
+`commitizen`, `cz-conventional-changelog`, `@commitlint/cli`, and `@commitlint/config-conventional` split one concern across two toolchains that have to be kept agreeing with each other. [`@hyperfrontend/versioning`](/docs/libraries/versioning) ships both halves as the [`cz` and `cl` bins](/docs/libraries/versioning/bin), reading one config file, with no runtime dependencies of its own.
+
+## 1. Swap the packages
+
+```bash
+npm uninstall commitizen cz-conventional-changelog @commitlint/cli @commitlint/config-conventional
+npm install --save-dev @hyperfrontend/versioning
+```
+
+Delete `commitlint.config.js`, and the `.czrc` or `config.commitizen` block that pointed commitizen at its adapter. The `"commit": "cz"` script can go too, because `npx cz` runs on its own.
+
+## 2. Put both configs in one file
+
+`commit.config.js` at the repo root feeds the prompt and the validator from a single source, so a type you offer is always a type you accept:
+
+```js
+/** @type {import('@hyperfrontend/versioning/commits/author').PartialSessionConfig} */
+module.exports = {
+  types: [
+    { name: 'feat', description: 'A new feature' },
+    { name: 'fix', description: 'A bug fix' },
+    { name: 'docs', description: 'Documentation only' },
+    { name: 'chore', description: 'Tooling and housekeeping' },
+  ],
+  scopeOptional: true,
+  headerMaxLength: 72,
+  validateRuleset: {
+    'type-enum': ['error', { types: ['feat', 'fix', 'docs', 'chore'] }],
+    'subject-empty': ['error'],
+    'header-max-length': ['error', { maxLength: 72 }],
+    'imperative-mood': ['warn'],
+  },
+}
+```
+
+[`validateRuleset`](/docs/libraries/versioning/commits/validate#api-Ruleset) maps a rule name to a [`[level]` or `[level, options]` tuple](/docs/libraries/versioning/commits/validate#api-RuleConfig), where the level is `error`, `warn`, or `off` and anything unlisted is off. The rules are `type-enum`, `scope-enum`, `subject-empty`, `subject-case`, `header-max-length`, and `imperative-mood`. `.mjs` and `.cjs` work the same way, and `--config <path>` overrides discovery.
+
+The rest of [`PartialSessionConfig`](/docs/libraries/versioning/commits/author#api-PartialSessionConfig) shapes the session: `scopeMulti` to collect several scopes, and `scopeFilter` to drop candidates by `{ path, name }`.
+
+## 3. Author commits with `cz`
+
+```bash
+git add .
+npx cz
+```
+
+The session walks type, scope, subject, body, breaking change, issue references, then a preview you confirm before it runs `git commit`. The subject step counts down the characters left in the header budget as you type, and the same ruleset warns inline, so a message that would fail the hook is visible before you reach it.
+
+Scope choices come from what you staged: each staged path resolves to its nearest project, and those project names become the list. Stage inside one package and that package is the only offer; stage nothing and the session stops and tells you to stage first. Cancelling with `Ctrl+C` exits `130` and writes nothing.
+
+## 4. Enforce it in the `commit-msg` hook
+
+`cl` takes the path git hands the hook and exits non-zero on any error-level violation, which is exactly the contract [husky](https://typicode.github.io/husky/) and [lefthook](https://lefthook.dev/) already expect.
+
+`.husky/commit-msg`:
+
+```bash
+npx cl "$1"
+```
+
+Or in `lefthook.yml`:
+
+```yaml
+commit-msg:
+  commands:
+    validate:
+      run: npx cl {1}
+```
+
+Warnings print and let the commit through; errors print and stop it:
+
+```text
+✖ type-enum: type must be one of [feat, fix, docs, chore] but was "added"
+```
+
+## 5. Run the same check on a pull request
+
+A hook only protects the machines that installed it. Validate every commit on the branch in CI, using the same config file:
+
+```yaml
+- run: |
+    status=0
+    for sha in $(git rev-list ${{ github.event.pull_request.base.sha }}..HEAD); do
+      git log -1 --format=%B "$sha" > "$RUNNER_TEMP/commit-msg"
+      npx cl "$RUNNER_TEMP/commit-msg" || status=1
+    done
+    exit $status
+```
+
+## Check it worked
+
+Commit a message that breaks a rule you set to `error` and watch the hook reject it by name. Commit a conforming one and watch it land. Then run `npx cz` on a staged change: the type list is the one from your config, the scope offered matches the package you staged in, and the header countdown starts at your `headerMaxLength`.

--- a/apps/docs-site/content/guides/replace-commitizen-and-commitlint/meta.json
+++ b/apps/docs-site/content/guides/replace-commitizen-and-commitlint/meta.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "type": "how-to",
+  "title": "How to replace commitizen and commitlint with one package",
+  "problem": "Guided commit authoring and commit-message linting take four packages and two config files that have to be kept agreeing with each other, and the prompt still offers types the linter rejects.",
+  "outcome": "One dev dependency and one config file driving both halves: a guided cz session whose choices come from your staged files, and a cl check running in the commit-msg hook and again on every pull request.",
+  "priority": "P1",
+  "packages": ["@hyperfrontend/versioning"],
+  "verification": {
+    "kind": "authored",
+    "verifiedAgainst": "@hyperfrontend/versioning@0.6.2",
+    "verifiedOn": "2026-08-19"
+  },
+  "complexity": "beginner",
+  "estMinutes": 15,
+  "apis": [
+    {
+      "package": "@hyperfrontend/versioning",
+      "symbol": "PartialSessionConfig"
+    },
+    {
+      "package": "@hyperfrontend/versioning",
+      "symbol": "Ruleset"
+    },
+    {
+      "package": "@hyperfrontend/versioning",
+      "symbol": "RuleConfig"
+    }
+  ],
+  "prerequisites": {
+    "knowledge": [
+      "A git repository using [Conventional Commits](https://www.conventionalcommits.org/)",
+      "A git hook manager such as husky or lefthook, or the willingness to add one"
+    ]
+  },
+  "related": {
+    "reference": ["/docs/libraries/versioning", "/docs/libraries/versioning/bin", "/docs/libraries/versioning/commits/validate"]
+  },
+  "keywords": [
+    "commitizen",
+    "commitlint",
+    "conventional commits",
+    "cz",
+    "cl",
+    "commit-msg",
+    "husky",
+    "lefthook",
+    "git hook",
+    "commit.config.js",
+    "scope",
+    "ruleset",
+    "migration"
+  ]
+}

--- a/apps/docs-site/content/guides/track-an-async-task-without-loading-flags/guide.md
+++ b/apps/docs-site/content/guides/track-an-async-task-without-loading-flags/guide.md
@@ -1,0 +1,75 @@
+# How to track an async task without loading flags
+
+You will render a first load, a background refresh, a failure, and a retry as four different screens, from one object, without threading `isLoading` and `error` through your components.
+
+`isLoading` plus `error` is two booleans and four combinations, and none of them remember what happened last time. A refresh looks exactly like a first load, so the spinner covers rows you could have kept on screen; a retry looks exactly like a failure clearing, so the error banner disappears the moment someone clicks it. [`AsyncOperation`](/docs/libraries/state-machine/async-operation#api-AsyncOperation) from [`@hyperfrontend/state-machine`](/docs/libraries/state-machine) derives those distinctions from the dispatches it is already making.
+
+## 1. Install it
+
+```bash
+npm install @hyperfrontend/state-machine
+```
+
+## 2. Wrap the work
+
+An [`AsyncProcess`](/docs/libraries/state-machine/async-operation#api-AsyncProcess) is a function returning a promise. Throw to report failure:
+
+```ts
+import { AsyncOperation } from '@hyperfrontend/state-machine/async-operation'
+
+const operation = new AsyncOperation(loadOrders)
+```
+
+Call [`start`](/docs/libraries/state-machine/async-operation#api-AsyncOperation) whenever the work should run: on mount, on a refresh button, on a retry. The same call covers all three, and the state tells them apart. `start` resolves either way, because a failure arrives as state rather than as a rejection.
+
+## 3. Keep the result and the error where you can render them
+
+The process returns nothing, so whatever it produces stays in scope beside it. Hold the error there too, and rethrow so the operation records the failure:
+
+```ts
+let orders: Order[] = []
+let failure: Error | null = null
+
+const loadOrders = async () => {
+  try {
+    const response = await fetch('/api/orders')
+    if (!response.ok) throw new Error(`orders request failed: ${response.status}`)
+    orders = await response.json()
+    failure = null
+  } catch (cause) {
+    failure = <Error>cause
+    throw cause
+  }
+}
+```
+
+Assigning `orders` only on success is what makes a refresh non-destructive: while the next attempt runs, the previous rows are still there to show.
+
+## 4. Render from the state you are handed
+
+[`on`](/docs/libraries/state-machine/async-operation#api-AsyncOperation) passes your handler the [`DerivedState`](/docs/libraries/state-machine/models#api-DerivedState) as of that transition. Test the specific states before the general ones, because [`retrying`](/docs/libraries/state-machine/models#api-DerivedState-prop-retrying) and [`restarting`](/docs/libraries/state-machine/models#api-DerivedState-prop-restarting) are both also [`inProgress`](/docs/libraries/state-machine/models#api-DerivedState-prop-inProgress):
+
+```ts
+import type { DerivedState } from '@hyperfrontend/state-machine'
+
+const render = (state: DerivedState) => {
+  if (state.notStarted) return emptyScreen()
+  if (state.retrying) return errorBanner(failure, { spinner: true })
+  if (state.restarting) return table(orders, { refreshing: true })
+  if (state.inProgress) return skeleton()
+  if (state.failed) return errorBanner(failure)
+  return table(orders)
+}
+
+for (const event of ['inProgress', 'successful', 'failed'] as const) {
+  operation.on(event, (_event, current) => paint(render(current)))
+}
+```
+
+Those three events cover every screen, because the second start after a success arrives as `inProgress` with `restarting` already true, and the second start after a failure arrives as `inProgress` with `retrying` already true. Subscribe to [`restarting`](/docs/libraries/state-machine/models#api-Event) or `retrying` directly when something other than the view needs to know, for example an analytics call that should fire on retries only.
+
+`operation` is a plain value with nothing to mount, so it holds the same way in a React effect, a Svelte store, a worker, or a module; over work `AsyncOperation` does not own, [`Store`](/docs/libraries/state-machine/store#api-Store) takes the same dispatches directly.
+
+## Check it worked
+
+Load the screen once and watch the skeleton give way to rows. Refresh, and the rows stay up with a refreshing marker instead of collapsing. Make the request fail, and the banner names it. Click retry, and the banner stays up with a spinner on it rather than blinking away. That last one is the difference the two booleans could not express.

--- a/apps/docs-site/content/guides/track-an-async-task-without-loading-flags/meta.json
+++ b/apps/docs-site/content/guides/track-an-async-task-without-loading-flags/meta.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "type": "how-to",
+  "title": "How to track an async task without loading flags",
+  "problem": "isLoading and error cannot tell a background refresh from a first load or a retry from a fresh failure, so my spinner hides rows I already had and my error banner vanishes the moment someone clicks retry.",
+  "outcome": "One operation driving four distinct screens: an empty state, a first-load skeleton, a refresh that keeps the previous rows up, and a retry that keeps the error visible while it runs.",
+  "priority": "P0",
+  "packages": ["@hyperfrontend/state-machine"],
+  "verification": {
+    "kind": "authored",
+    "verifiedAgainst": "@hyperfrontend/state-machine@0.2.0",
+    "verifiedOn": "2026-08-19"
+  },
+  "complexity": "beginner",
+  "estMinutes": 12,
+  "apis": [
+    {
+      "package": "@hyperfrontend/state-machine",
+      "symbol": "AsyncOperation"
+    },
+    {
+      "package": "@hyperfrontend/state-machine",
+      "symbol": "AsyncProcess"
+    },
+    {
+      "package": "@hyperfrontend/state-machine",
+      "symbol": "DerivedState"
+    },
+    {
+      "package": "@hyperfrontend/state-machine",
+      "symbol": "Store"
+    }
+  ],
+  "prerequisites": {
+    "knowledge": ["A view that loads data and can be refreshed or retried"]
+  },
+  "related": {
+    "reference": ["/docs/libraries/state-machine", "/docs/libraries/state-machine/async-operation", "/docs/libraries/state-machine/models"],
+    "explanation": ["/docs/libraries/state-machine/architecture"]
+  },
+  "keywords": [
+    "isLoading",
+    "loading state",
+    "async",
+    "AsyncOperation",
+    "retry",
+    "refresh",
+    "stale while revalidate",
+    "skeleton",
+    "spinner",
+    "error banner",
+    "state machine",
+    "derived state"
+  ]
+}

--- a/apps/docs-site/content/guides/validate-a-config-file-at-startup/guide.md
+++ b/apps/docs-site/content/guides/validate-a-config-file-at-startup/guide.md
@@ -1,0 +1,112 @@
+# How to validate a config file at startup
+
+You will turn a config file into something your process refuses to boot without, and get every problem in it named at once instead of one crash at a time.
+
+A bad value in a config file surfaces wherever it is finally read: a pool size of `0` becomes a hung request an hour later, a mistyped log level becomes silence. [`@hyperfrontend/json-utils`](/docs/libraries/utils/json) checks the whole file against a schema before any of it is used, and reports every failure with the path it came from.
+
+## 1. Install it
+
+```bash
+npm install @hyperfrontend/json-utils
+```
+
+## 2. Start the schema from a config you already trust
+
+Writing a schema by hand for an existing file is transcription. Hand [`toJsonSchema`](/docs/libraries/utils/json#api-toJsonSchema) a config you know is good and it infers the shape, marking every key it sees as required:
+
+```ts
+import { toJsonSchema } from '@hyperfrontend/json-utils'
+
+toJsonSchema({
+  port: 8080,
+  host: '0.0.0.0',
+  logLevel: 'info',
+  database: { url: 'postgres://localhost/app', poolSize: 10 },
+})
+// { type: 'object', properties: { port: { type: 'integer' }, … }, required: ['port', 'host', 'logLevel', 'database'] }
+```
+
+Print it once, paste it into your source, and edit from there.
+
+## 3. Tighten it into the contract you actually want
+
+The generated shape only knows types. Add the constraints that carry your real rules: ranges, the closed set of allowed values, which keys are optional, and whether unknown keys are a typo or a feature.
+
+```ts
+import type { Schema } from '@hyperfrontend/json-utils'
+
+const configSchema: Schema = {
+  type: 'object',
+  properties: {
+    port: { type: 'integer', minimum: 1, maximum: 65535 },
+    host: { type: 'string', minLength: 1 },
+    logLevel: { enum: ['error', 'warn', 'info', 'debug'] },
+    database: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', format: 'uri' },
+        poolSize: { type: 'integer', minimum: 1, maximum: 100 },
+      },
+      required: ['url'],
+    },
+  },
+  required: ['port', 'database'],
+  additionalProperties: false,
+}
+```
+
+The keyword vocabulary is [JSON Schema Draft v4](https://json-schema.org/specification-links#draft-4), including `allOf`/`anyOf`/`oneOf`, shared shapes through `definitions` and `$ref`, and the string formats listed on the [package page](/docs/libraries/utils/json). `additionalProperties: false` is what turns a silently ignored `databse` key into an error.
+
+## 4. Fail the boot, and say everything that is wrong
+
+[`validate`](/docs/libraries/utils/json#api-validate) collects every violation rather than stopping at the first, so one run fixes one round of edits:
+
+```ts
+import { validate } from '@hyperfrontend/json-utils'
+import { readFileSync } from 'node:fs'
+
+const config = JSON.parse(readFileSync('config.json', 'utf8'))
+const result = validate(config, configSchema)
+
+if (!result.valid) {
+  for (const error of result.errors) {
+    console.error(`config${error.path === '/' ? '' : error.path}: ${error.message}`)
+  }
+  process.exit(1)
+}
+```
+
+Each [`ValidationError`](/docs/libraries/utils/json#api-ValidationError) carries a `path` as a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the value, a human `message`, and a `code` naming the keyword that rejected it. Branch on `code`, never on message text:
+
+```text
+config/port: Number must be at most 65535, got 99999
+config/logLevel: Value must be one of: "error", "warn", "info", "debug"
+config/database/poolSize: Number must be at least 1, got 0
+config/database: Missing required property: url
+config: Additional property not allowed: cache
+```
+
+## 5. Reuse the check for values that arrive later
+
+Config is validated once; a webhook body or a job payload is validated thousands of times. [`createValidator`](/docs/libraries/utils/json#api-createValidator) binds the schema once and hands back a function:
+
+```ts
+import { createValidator } from '@hyperfrontend/json-utils'
+
+const validateWebhook = createValidator({
+  type: 'object',
+  properties: {
+    event: { enum: ['order.paid', 'order.refunded'] },
+    amount: { type: 'integer', minimum: 1 },
+  },
+  required: ['event', 'amount'],
+})
+
+validateWebhook(body) // { valid: true, errors: [] }
+```
+
+When the schema itself comes from a user rather than from you, pass [`safePatterns: true`](/docs/libraries/utils/json#api-ValidateOptions) so a hostile `pattern` is rejected instead of run.
+
+## Check it worked
+
+Break one value in each direction and boot the process: a port above 65535, a log level that is not in the enum, a missing `database.url`, and a key spelled wrong. One run should name all four, each with the path you would use to find it in the file. Fix them and the process starts.

--- a/apps/docs-site/content/guides/validate-a-config-file-at-startup/meta.json
+++ b/apps/docs-site/content/guides/validate-a-config-file-at-startup/meta.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "type": "how-to",
+  "title": "How to validate a config file at startup",
+  "problem": "A wrong value in a config file does not fail where it is written, it fails hours later somewhere unrelated, and fixing one mistake only reveals the next one.",
+  "outcome": "A schema derived from a config you already trust and tightened by hand, a boot that refuses a bad file and names every problem in it at once with the path to each, and the same check reusable for payloads that arrive later.",
+  "priority": "P0",
+  "packages": ["@hyperfrontend/json-utils"],
+  "verification": {
+    "kind": "authored",
+    "verifiedAgainst": "@hyperfrontend/json-utils@0.1.1",
+    "verifiedOn": "2026-08-19"
+  },
+  "complexity": "beginner",
+  "estMinutes": 12,
+  "apis": [
+    {
+      "package": "@hyperfrontend/json-utils",
+      "symbol": "validate"
+    },
+    {
+      "package": "@hyperfrontend/json-utils",
+      "symbol": "createValidator"
+    },
+    {
+      "package": "@hyperfrontend/json-utils",
+      "symbol": "toJsonSchema"
+    },
+    {
+      "package": "@hyperfrontend/json-utils",
+      "symbol": "Schema"
+    },
+    {
+      "package": "@hyperfrontend/json-utils",
+      "symbol": "ValidationError"
+    }
+  ],
+  "prerequisites": {
+    "knowledge": ["A Node.js service or CLI that reads a JSON config file"]
+  },
+  "related": {
+    "reference": ["/docs/libraries/utils/json"]
+  },
+  "keywords": [
+    "JSON Schema",
+    "config",
+    "configuration",
+    "validation",
+    "validate",
+    "Draft v4",
+    "startup",
+    "fail fast",
+    "schema generation",
+    "webhook payload",
+    "additionalProperties",
+    "ReDoS"
+  ]
+}

--- a/apps/docs-site/scripts/generate-guides.types.ts
+++ b/apps/docs-site/scripts/generate-guides.types.ts
@@ -69,7 +69,18 @@ export interface GuideRelated {
 export interface GuideMeta {
   /** Schema version; currently always 1 */
   schemaVersion: number
-  /** Diátaxis-aligned document type */
+  /**
+   * Diátaxis-aligned document type.
+   *
+   * `tutorial` teaches through a progressive lesson that leaves the reader
+   * with something built. `how-to` takes a reader who already has a task from
+   * their problem to a working outcome. `troubleshooting` is narrower than it
+   * sounds here: it means diagnosing HyperFrontend itself, when an API,
+   * runtime, or configuration is not behaving as documented. Teaching someone
+   * to use a HyperFrontend package against a problem their own application
+   * has is a `how-to`, however error-shaped the title. `recipe` is a short,
+   * copyable answer to a narrow question.
+   */
   type: 'tutorial' | 'how-to' | 'troubleshooting' | 'recipe'
   /** Guide title, matching the guide.md H1 */
   title: string

--- a/apps/docs-site/src/app/docs/guides/[slug]/page.tsx
+++ b/apps/docs-site/src/app/docs/guides/[slug]/page.tsx
@@ -4,11 +4,12 @@ import { GuideTypeBadge, VerificationBadge } from '@/components/guides/guide-bad
 import { ReadmeContent } from '@/components/readme-content'
 import { ShareMenu } from '@/components/share/share-menu'
 import { getAllGuideSlugs, getGuide, getGuideIndex } from '@/lib/guides'
-import { markdownToHtml } from '@/lib/markdown'
+import { markdownToHtml, markdownToInlineHtml } from '@/lib/markdown'
 import { extractMermaidBlocks } from '@/lib/mermaid-utils'
 import { getGuideMetadata } from '@/lib/metadata'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { promiseAll } from '@hyperfrontend/immutable-api-utils/built-in-copy/promise'
 
 /**
  * Route parameters for a guide page.
@@ -51,6 +52,8 @@ export default async function GuidePage({ params }: GuidePageProps) {
   const index = getGuideIndex()
   const prerequisiteGuides = (guide.prerequisites?.guides ?? []).flatMap((ref) => index.filter((entry) => entry.slug === ref))
   const relatedGuides = (guide.related?.guides ?? []).flatMap((ref) => index.filter((entry) => entry.slug === ref))
+  // why: Prerequisites are authored sentences, so an API they name can carry its own reference link instead of going bare
+  const prerequisiteKnowledge: string[] = await promiseAll((guide.prerequisites?.knowledge ?? []).map(markdownToInlineHtml))
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -83,7 +86,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
         ))}
       </div>
 
-      {prerequisiteGuides.length > 0 || (guide.prerequisites?.knowledge?.length ?? 0) > 0 ? (
+      {prerequisiteGuides.length > 0 || prerequisiteKnowledge.length > 0 ? (
         <aside className="mb-8 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/50">
           <p className="font-semibold text-slate-900 dark:text-white">Before you start</p>
           <ul className="mt-2 space-y-1 text-slate-600 dark:text-slate-400">
@@ -94,8 +97,12 @@ export default async function GuidePage({ params }: GuidePageProps) {
                 </Link>
               </li>
             ))}
-            {(guide.prerequisites?.knowledge ?? []).map((item) => (
-              <li key={item}>{item}</li>
+            {prerequisiteKnowledge.map((item) => (
+              <li
+                key={item}
+                className="[&_a:hover]:underline [&_a]:text-primary-600 dark:[&_a]:text-primary-400 [&_code]:rounded [&_code]:bg-slate-200/70 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs dark:[&_code]:bg-slate-700/70"
+                dangerouslySetInnerHTML={{ __html: item }}
+              />
             ))}
           </ul>
         </aside>

--- a/apps/docs-site/src/app/docs/guides/page.tsx
+++ b/apps/docs-site/src/app/docs/guides/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next'
 import { Breadcrumb } from '@/components/breadcrumb'
 import { GuidesIndexList } from '@/components/guides/guides-index-list'
-import { getGuideIndex } from '@/lib/guides'
+import { getGuideIndex, getGuidePackageOptions } from '@/lib/guides'
+import { Suspense } from 'react'
 
 export const metadata: Metadata = {
-  title: 'Guides',
+  title: 'Guides & Tutorials',
   description:
     'Task-focused tutorials and how-to guides for the HyperFrontend packages. Every code example is either extracted from source that ships and runs, or was executed against a named package version.',
   alternates: {
@@ -14,22 +15,22 @@ export const metadata: Metadata = {
 
 export default function GuidesPage() {
   const guides = getGuideIndex()
+  const packageOptions = getGuidePackageOptions()
 
   return (
     <div className="mx-auto max-w-4xl">
       <Breadcrumb />
-      <h1 className="font-display text-4xl font-bold tracking-tight text-slate-900 dark:text-white">Guides</h1>
+      <h1 className="font-display text-4xl font-bold tracking-tight text-slate-900 dark:text-white">Guides &amp; Tutorials</h1>
       <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">
         Start from the problem you are trying to solve. Tutorials teach by building something real; how-to guides get a specific job done.
         Code you see here either comes from source that ships and runs, or was executed against a named package version on a named date. The
         badge on each guide says which.
       </p>
       <div className="mt-8">
-        {guides.length === 0 ? (
-          <p className="text-slate-600 dark:text-slate-400">No guides published yet. Check back soon.</p>
-        ) : (
-          <GuidesIndexList guides={guides} />
-        )}
+        {/* why: The package and type facets live in the query string, and useSearchParams needs a boundary to stream past during the static build */}
+        <Suspense fallback={<p className="text-slate-600 dark:text-slate-400">Loading guides…</p>}>
+          <GuidesIndexList guides={guides} packageOptions={packageOptions} />
+        </Suspense>
       </div>
     </div>
   )

--- a/apps/docs-site/src/app/page.tsx
+++ b/apps/docs-site/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Footer } from '@/components/footer'
 import { Header } from '@/components/header'
 import { LandingHero } from '@/components/landing-hero'
+import { LandingLearnSection } from '@/components/landing-learn-section'
 
 /**
  * Featured package tile shown on the landing page: display name, link target,
@@ -36,6 +37,9 @@ export default function HomePage() {
       <main id="main-content" className="flex-1">
         {/* Hero Section - 50/50 Split Layout */}
         <LandingHero />
+
+        {/* Guides, tutorials, demos, and articles as four distinct destinations */}
+        <LandingLearnSection />
 
         {/* Secondary Content - Collapsed for Landing */}
         <section id="how-it-works" className="border-t border-slate-200 bg-white py-16 dark:border-slate-800 dark:bg-slate-900 lg:py-24">

--- a/apps/docs-site/src/components/breadcrumb.tsx
+++ b/apps/docs-site/src/components/breadcrumb.tsx
@@ -12,6 +12,7 @@ const pathLabels: Record<string, string> = {
   contributing: 'Contributing',
   'quick-start': 'Quick Start',
   'core-concepts': 'Core Concepts',
+  guides: 'Guides & Tutorials',
   architecture: 'Architecture',
   nexus: '@hyperfrontend/nexus',
   'network-protocol': '@hyperfrontend/network-protocol',

--- a/apps/docs-site/src/components/guides/guides-index-list.tsx
+++ b/apps/docs-site/src/components/guides/guides-index-list.tsx
@@ -1,103 +1,184 @@
 'use client'
 
-import type { GuideIndexEntry } from '@/lib/guides'
+import type { GuideFilter } from '@/lib/guide-filters'
+import type { GuideIndexEntry, GuidePackageOption } from '@/lib/guides'
 import { GuideTypeBadge, VerificationBadge } from '@/components/guides/guide-badges'
+import { SuggestGuideLink } from '@/components/guides/suggest-guide-link'
+import { buildGuidesHref, filterGuides, GUIDE_FILTER_ALL, readGuideFilter } from '@/lib/guide-filters'
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useMemo } from 'react'
 import { createSet } from '@hyperfrontend/immutable-api-utils/built-in-copy/set'
 
-const TYPE_FILTERS = [
-  { value: 'all', label: 'All' },
-  { value: 'tutorial', label: 'Tutorials' },
-  { value: 'how-to', label: 'How-to' },
-  { value: 'troubleshooting', label: 'Troubleshooting' },
-  { value: 'recipe', label: 'Recipes' },
+/**
+ * The document types the corpus can hold, in reading order, each with the
+ * chip label and the group heading it earns. Tutorials and how-to guides are
+ * different promises to the reader, so they never merge into one list.
+ */
+const TYPE_GROUPS = [
+  { value: 'tutorial', chip: 'Tutorials', heading: 'Tutorials', description: 'Learning-oriented: build something real, step by step.' },
+  {
+    value: 'how-to',
+    chip: 'How-to',
+    heading: 'How-to guides',
+    description: 'Goal-oriented: solve a specific problem with a working result.',
+  },
+  {
+    value: 'troubleshooting',
+    chip: 'Troubleshooting',
+    heading: 'Troubleshooting',
+    description: 'Diagnosis-oriented: work out why HyperFrontend is not behaving as documented.',
+  },
+  { value: 'recipe', chip: 'Recipes', heading: 'Recipes', description: 'Short, copyable answers to a narrow question.' },
 ] as const
 
 interface GuidesIndexListProps {
   /** Every compiled guide's index entry */
   guides: GuideIndexEntry[]
+  /** Every documented package, including those without guides yet */
+  packageOptions: GuidePackageOption[]
 }
 
 /**
- * Problem-first guide browser: tutorials and how-to guides grouped and
- * filterable by involved package and document type.
+ * Problem-first guide browser: tutorials, how-to guides, and the rest of the
+ * corpus filterable by involved package and document type.
+ *
+ * Both facets live in the URL rather than in component state, so a narrowed
+ * view can be shared, bookmarked, linked from a package README, and walked
+ * back through with the browser's own history.
  * @param props - Component props
  * @param props.guides - Every compiled guide's index entry
+ * @param props.packageOptions - Every documented package, including those without guides yet
  * @returns The rendered filterable guide list
  */
-export function GuidesIndexList({ guides }: GuidesIndexListProps) {
-  const [typeFilter, setTypeFilter] = useState('all')
-  const [packageFilter, setPackageFilter] = useState('all')
+export function GuidesIndexList({ guides, packageOptions }: GuidesIndexListProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { package: packageFilter, type: typeFilter } = readGuideFilter(searchParams)
 
-  const packages = useMemo(() => [...createSet(guides.flatMap((guide) => guide.packages))].sort(), [guides])
+  const presentTypes = useMemo(() => createSet(guides.map((guide) => guide.type)), [guides])
+  const visible = useMemo(() => filterGuides(guides, { package: packageFilter, type: typeFilter }), [guides, packageFilter, typeFilter])
 
-  const visible = useMemo(
-    () =>
-      guides.filter(
-        (guide) =>
-          (typeFilter === 'all' || guide.type === typeFilter) && (packageFilter === 'all' || guide.packages.includes(packageFilter))
-      ),
-    [guides, typeFilter, packageFilter]
-  )
+  const activePackage = packageFilter === GUIDE_FILTER_ALL ? undefined : packageFilter
 
-  const tutorials = visible.filter((guide) => guide.type === 'tutorial')
-  const howTos = visible.filter((guide) => guide.type !== 'tutorial')
+  const applyFilter = (next: Partial<GuideFilter>) => {
+    router.push(buildGuidesHref({ package: packageFilter, type: typeFilter, ...next }), { scroll: false })
+  }
 
   return (
     <div>
       <div className="mb-8 flex flex-wrap items-center gap-3">
         <div className="flex flex-wrap gap-1.5" role="group" aria-label="Filter guides by type">
-          {TYPE_FILTERS.map((filter) => (
-            <button
-              key={filter.value}
-              type="button"
-              onClick={() => setTypeFilter(filter.value)}
-              aria-pressed={typeFilter === filter.value}
-              className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
-                typeFilter === filter.value
-                  ? 'bg-primary-600 text-white dark:bg-primary-500'
-                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
-              }`}
-            >
-              {filter.label}
-            </button>
+          <FilterChip label="All" active={typeFilter === GUIDE_FILTER_ALL} onClick={() => applyFilter({ type: GUIDE_FILTER_ALL })} />
+          {TYPE_GROUPS.filter((group) => presentTypes.has(group.value) || typeFilter === group.value).map((group) => (
+            <FilterChip
+              key={group.value}
+              label={group.chip}
+              active={typeFilter === group.value}
+              onClick={() => applyFilter({ type: group.value })}
+            />
           ))}
         </div>
         <label className="ml-auto flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
           Package
           <select
             value={packageFilter}
-            onChange={(event) => setPackageFilter(event.target.value)}
+            onChange={(event) => applyFilter({ package: event.target.value })}
             className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-white"
           >
-            <option value="all">All packages</option>
-            {packages.map((packageName) => (
-              <option key={packageName} value={packageName}>
-                {packageName}
+            <option value={GUIDE_FILTER_ALL}>All packages</option>
+            {packageOptions.map((option) => (
+              <option key={option.packageName} value={option.packageName}>
+                {option.packageName}
+                {option.guideCount === 0 ? ' (none yet)' : ` (${option.guideCount})`}
               </option>
             ))}
+            {/* why: An unknown package in a shared URL must stay selected, or the control would silently contradict the results below */}
+            {activePackage && !packageOptions.some((option) => option.packageName === activePackage) ? (
+              <option value={activePackage}>{activePackage}</option>
+            ) : null}
           </select>
         </label>
       </div>
 
       {visible.length === 0 ? (
-        <p className="text-slate-600 dark:text-slate-400">No guides match this filter yet.</p>
+        <EmptyGuides packageName={activePackage} />
       ) : (
         <>
-          {tutorials.length > 0 && (
-            <GuideGroup title="Tutorials" description="Learning-oriented: build something real, step by step." guides={tutorials} />
-          )}
-          {howTos.length > 0 && (
-            <GuideGroup
-              title="How-to guides"
-              description="Goal-oriented: solve a specific problem with a working result."
-              guides={howTos}
-            />
-          )}
+          {TYPE_GROUPS.map((group) => {
+            const inGroup = visible.filter((guide) => guide.type === group.value)
+            return inGroup.length > 0 ? (
+              <GuideGroup key={group.value} title={group.heading} description={group.description} guides={inGroup} />
+            ) : null
+          })}
+          <p className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-slate-200 pt-6 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-400">
+            Not what you were looking for?
+            <SuggestGuideLink packageName={activePackage} />
+          </p>
         </>
       )}
     </div>
+  )
+}
+
+interface EmptyGuidesProps {
+  /** npm package the view is narrowed to, when it is narrowed to one */
+  packageName?: string
+}
+
+function EmptyGuides({ packageName }: EmptyGuidesProps) {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center dark:border-slate-700 dark:bg-slate-800/40">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+        {packageName ? (
+          <>
+            There are no guides for <code className="font-mono text-base">{packageName}</code> yet
+          </>
+        ) : (
+          'No guides match this view yet'
+        )}
+      </h2>
+      <p className="mx-auto mt-2 max-w-md text-sm text-slate-600 dark:text-slate-400">
+        {packageName
+          ? 'Guides are written from problems people actually hit. Tell us what you are trying to do and it becomes the next one.'
+          : 'Try a different type or package, or tell us what you were hoping to find.'}
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <SuggestGuideLink packageName={packageName} variant="button" label="Request a guide" />
+        <Link
+          href={buildGuidesHref()}
+          className="inline-flex min-h-[44px] items-center text-sm font-medium text-slate-600 hover:underline dark:text-slate-400"
+        >
+          Browse every guide
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+interface FilterChipProps {
+  /** Chip label */
+  label: string
+  /** Whether this chip is the active filter */
+  active: boolean
+  /** Click handler */
+  onClick: () => void
+}
+
+function FilterChip({ label, active, onClick }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? 'bg-primary-600 text-white dark:bg-primary-500'
+          : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+      }`}
+    >
+      {label}
+    </button>
   )
 }
 

--- a/apps/docs-site/src/components/guides/suggest-guide-link.tsx
+++ b/apps/docs-site/src/components/guides/suggest-guide-link.tsx
@@ -1,0 +1,48 @@
+import { buildGuideRequestUrl } from '@/lib/guide-request'
+
+interface SuggestGuideLinkProps {
+  /** npm package the reader is looking at, when the view is package-scoped */
+  packageName?: string
+  /** Visual weight: a quiet inline link, or a bordered button for an empty view */
+  variant?: 'inline' | 'button'
+  /** Link text; defaults to the wording used across the site */
+  label?: string
+}
+
+/**
+ * The way a reader asks for a guide that does not exist yet: a link opening a
+ * prefilled GitHub issue in a new tab, carrying the package they were looking
+ * at so triage does not have to guess. They review and submit it on GitHub.
+ * @param props - Component props
+ * @param props.packageName - npm package the reader is looking at, when the view is package-scoped
+ * @param props.variant - Quiet inline link, or bordered button for an empty view
+ * @param props.label - Link text
+ * @returns The rendered request action
+ */
+export function SuggestGuideLink({ packageName, variant = 'inline', label = 'Suggest a guide' }: SuggestGuideLinkProps) {
+  const className =
+    variant === 'button'
+      ? 'inline-flex min-h-[44px] items-center gap-2 rounded-lg border border-primary-300 bg-primary-50 px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:bg-primary-100 dark:border-primary-700 dark:bg-primary-950/40 dark:text-primary-300 dark:hover:bg-primary-900/40'
+      : 'inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:underline dark:text-primary-400'
+
+  return (
+    <a href={buildGuideRequestUrl(packageName)} target="_blank" rel="noopener noreferrer" className={className}>
+      <GitHubIcon className="h-4 w-4 shrink-0" />
+      {label}
+    </a>
+  )
+}
+
+type IconProps = { className?: string }
+
+function GitHubIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}

--- a/apps/docs-site/src/components/header.tsx
+++ b/apps/docs-site/src/components/header.tsx
@@ -1,6 +1,7 @@
 import { TrackedLink } from '@/components/analytics/tracked-link'
 import { SearchControl } from '@/components/search/search-dialog'
 import Link from 'next/link'
+import { mainNavLinks } from '../lib/navigation'
 import { MobileMenu } from './mobile-menu'
 import { ThemeToggle } from './theme-toggle'
 
@@ -16,11 +17,13 @@ export function Header() {
           </Link>
         </div>
 
-        <nav className="hidden items-center gap-8 md:flex">
-          <NavLink href="/docs">Docs</NavLink>
-          <NavLink href="/demos">Demos</NavLink>
-          <NavLink href="/articles">Articles</NavLink>
-          <NavLink href="/architecture">Architecture</NavLink>
+        {/* why: One nav list feeds the header, the mobile menu, and the sitemap, so a new destination cannot reach one and miss the others */}
+        <nav className="hidden items-center gap-6 md:flex lg:gap-8">
+          {mainNavLinks.map((link) => (
+            <NavLink key={link.href} href={link.href}>
+              {link.slug}
+            </NavLink>
+          ))}
         </nav>
 
         <div className="flex items-center gap-3 sm:gap-4">

--- a/apps/docs-site/src/components/landing-learn-section.tsx
+++ b/apps/docs-site/src/components/landing-learn-section.tsx
@@ -1,0 +1,178 @@
+import type { GuideIndexEntry } from '@/lib/guides'
+import { GuideTypeBadge } from '@/components/guides/guide-badges'
+import { buildGuidesHref } from '@/lib/guide-filters'
+import { getGuideIndex } from '@/lib/guides'
+import Link from 'next/link'
+
+/** How many guides the landing page features before sending readers to the index. */
+const FEATURED_COUNT = 4
+
+/** Editorial priority order used to pick which guides the landing page features. */
+const PRIORITY_ORDER: Record<GuideIndexEntry['priority'], number> = { P0: 0, P1: 1, P2: 2 }
+
+/**
+ * The four ways into the documentation, kept distinct on purpose: a tutorial
+ * and a how-to guide are different promises, and neither is a demo or an
+ * essay. Each destination is the canonical URL for that kind of content.
+ */
+const LEARNING_PATHS = [
+  {
+    title: 'Tutorials',
+    description: 'Learn by building something real, one step at a time, ending with a working result.',
+    href: buildGuidesHref({ type: 'tutorial' }),
+    icon: <TutorialIcon />,
+  },
+  {
+    title: 'How-to guides',
+    description: 'Have a job to do? Follow a direct route from the problem you have to the outcome you want.',
+    href: buildGuidesHref({ type: 'how-to' }),
+    icon: <HowToIcon />,
+  },
+  {
+    title: 'Live demos',
+    description: 'Real feature apps on their own origins, composed here and running in your browser right now.',
+    href: '/demos',
+    icon: <DemoIcon />,
+  },
+  {
+    title: 'Articles',
+    description: 'Long-form writing on the architecture: the pressures that produce it and the reasoning behind it.',
+    href: '/articles',
+    icon: <ArticleIcon />,
+  },
+]
+
+/**
+ * The landing page's learning band: the four kinds of documentation as
+ * distinct destinations, followed by the guides and tutorials themselves so a
+ * first-time reader can start one without knowing the site's shape.
+ * @returns The rendered section.
+ */
+export function LandingLearnSection() {
+  const guides = getGuideIndex()
+  const featured = [...guides]
+    .sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority] || a.title.localeCompare(b.title))
+    .slice(0, FEATURED_COUNT)
+
+  return (
+    <section id="learn" className="border-t border-slate-200 bg-slate-50 py-16 dark:border-slate-800 dark:bg-slate-900/50 lg:py-24">
+      <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-3xl">Start from what you want to do</h2>
+          <p className="mt-4 text-base text-slate-600 dark:text-slate-400">
+            Every code example in a guide is either extracted from source that ships and runs, or was executed against a named package
+            version on a named date. The badge on each one tells you which.
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {LEARNING_PATHS.map((path) => (
+            <Link
+              key={path.title}
+              href={path.href}
+              className="block rounded-xl border border-slate-200 bg-white p-6 transition-colors hover:border-primary-300 hover:bg-primary-50 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:border-primary-600 dark:hover:bg-slate-800"
+            >
+              <div className="mb-4 inline-flex rounded-lg bg-primary-50 p-2.5 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400">
+                {path.icon}
+              </div>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{path.title}</h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{path.description}</p>
+            </Link>
+          ))}
+        </div>
+
+        {featured.length > 0 ? (
+          <div className="mt-12">
+            <div className="flex flex-wrap items-baseline justify-between gap-3">
+              <h3 className="text-lg font-bold text-slate-900 dark:text-white">Where people usually start</h3>
+              <Link
+                href={buildGuidesHref()}
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300"
+              >
+                All {guides.length} guides and tutorials
+                <ArrowRightIcon className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {featured.map((guide) => (
+                <Link
+                  key={guide.slug}
+                  href={guide.route}
+                  className="group rounded-lg border border-slate-200 bg-white p-4 transition-colors hover:border-primary-300 hover:bg-primary-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-primary-700 dark:hover:bg-primary-950/30"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <GuideTypeBadge type={guide.type} />
+                    {guide.estMinutes ? <span className="text-xs text-slate-500 dark:text-slate-400">~{guide.estMinutes} min</span> : null}
+                  </div>
+                  <h4 className="mt-2 font-semibold text-slate-900 group-hover:text-primary-600 dark:text-white dark:group-hover:text-primary-400">
+                    {guide.title}
+                  </h4>
+                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{guide.problem}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+/** Common props for landing-section icons */
+type IconProps = { className?: string }
+
+function TutorialIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  )
+}
+
+function HowToIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+      />
+    </svg>
+  )
+}
+
+function DemoIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 7.5V18M15 7.5V18M3 16.811V8.69c0-.864.933-1.406 1.683-.977l7.108 4.061a1.125 1.125 0 010 1.954l-7.108 4.061A1.125 1.125 0 013 16.811z"
+      />
+    </svg>
+  )
+}
+
+function ArticleIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+      />
+    </svg>
+  )
+}
+
+function ArrowRightIcon({ className }: IconProps) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+    </svg>
+  )
+}

--- a/apps/docs-site/src/components/library-doc-page.tsx
+++ b/apps/docs-site/src/components/library-doc-page.tsx
@@ -3,9 +3,11 @@ import { TrackedLink } from '@/components/analytics/tracked-link'
 import { ApiLinkProvider, ApiReference } from '@/components/api-reference'
 import { Breadcrumb } from '@/components/breadcrumb'
 import { CodeBlock } from '@/components/code-block'
+import { SuggestGuideLink } from '@/components/guides/suggest-guide-link'
 import { H2 } from '@/components/heading-with-anchor'
 import { removeBadges, transformLinks } from '@/lib/content'
 import { getLibraryReadme, getLibraryArchitecture, getLibraryApi, getApiLinkIndex } from '@/lib/docs-loader'
+import { buildGuidesHref } from '@/lib/guide-filters'
 import { getGuidesForPackage } from '@/lib/guides'
 import { markdownToHtml } from '@/lib/markdown'
 import { extractMermaidBlocks } from '@/lib/mermaid-utils'
@@ -26,6 +28,8 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
   const hasArchitecture = !!getLibraryArchitecture(slug)
   const apiData = getLibraryApi(slug) as TypeDocOutput | null
   const guides = getGuidesForPackage(packageName)
+  // why: The same canonical destination the package README points at, so both entry points land on one filtered view
+  const guidesHref = buildGuidesHref({ package: packageName })
 
   if (readme) {
     let processed = removeBadges(readme)
@@ -56,11 +60,9 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
               Architecture →
             </Link>
           )}
-          {guides.length > 0 && (
-            <Link href="/docs/guides" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
-              Guides →
-            </Link>
-          )}
+          <Link href={guidesHref} className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+            Guides &amp; tutorials →
+          </Link>
           {apiData && (
             <a href="#api-reference" className="text-sm text-primary-600 hover:underline dark:text-primary-400">
               API Reference →
@@ -71,25 +73,38 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
         <ReadmeContent html={html} mermaidDiagrams={diagrams} />
 
         {/* Guides */}
-        {guides.length > 0 && (
-          <section className="mt-12 border-t border-slate-200 pt-8 dark:border-slate-700">
-            <h2 className="text-lg font-bold text-slate-900 dark:text-white">Guides using {packageName}</h2>
-            <div className="mt-4 grid gap-4 sm:grid-cols-2">
-              {guides.map((guide) => (
-                <Link
-                  key={guide.slug}
-                  href={guide.route}
-                  className="group rounded-lg border border-slate-200 bg-white p-4 transition-colors hover:border-primary-300 hover:bg-primary-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-primary-700 dark:hover:bg-primary-950/30"
-                >
-                  <h3 className="font-semibold text-slate-900 group-hover:text-primary-600 dark:text-white dark:group-hover:text-primary-400">
-                    {guide.title}
-                  </h3>
-                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{guide.problem}</p>
+        <section className="mt-12 border-t border-slate-200 pt-8 dark:border-slate-700">
+          <h2 className="text-lg font-bold text-slate-900 dark:text-white">Guides &amp; tutorials for {packageName}</h2>
+          {guides.length > 0 ? (
+            <>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                {guides.map((guide) => (
+                  <Link
+                    key={guide.slug}
+                    href={guide.route}
+                    className="group rounded-lg border border-slate-200 bg-white p-4 transition-colors hover:border-primary-300 hover:bg-primary-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-primary-700 dark:hover:bg-primary-950/30"
+                  >
+                    <h3 className="font-semibold text-slate-900 group-hover:text-primary-600 dark:text-white dark:group-hover:text-primary-400">
+                      {guide.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{guide.problem}</p>
+                  </Link>
+                ))}
+              </div>
+              <p className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600 dark:text-slate-400">
+                <Link href={guidesHref} className="font-medium text-primary-600 hover:underline dark:text-primary-400">
+                  Browse them filtered to this package
                 </Link>
-              ))}
-            </div>
-          </section>
-        )}
+                <SuggestGuideLink packageName={packageName} />
+              </p>
+            </>
+          ) : (
+            <p className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600 dark:text-slate-400">
+              There are none for {packageName} yet.
+              <SuggestGuideLink packageName={packageName} label="Request one" />
+            </p>
+          )}
+        </section>
 
         {/* API Reference */}
         {apiData && (
@@ -142,7 +157,7 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
 
       <h1 className="font-display text-4xl font-bold tracking-tight text-slate-900 dark:text-white">{title}</h1>
 
-      <div className="mt-4 flex items-center gap-3">
+      <div className="mt-4 flex flex-wrap items-center gap-3">
         <code className="rounded-lg bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
           {packageName}
         </code>
@@ -154,6 +169,9 @@ export async function LibraryDocPage({ title, packageName, slug, fallbackDescrip
         >
           View on npm →
         </TrackedLink>
+        <Link href={guidesHref} className="text-sm text-primary-600 hover:underline dark:text-primary-400">
+          Guides &amp; tutorials →
+        </Link>
       </div>
 
       {fallbackDescription && <p className="mt-6 text-lg text-slate-600 dark:text-slate-400">{fallbackDescription}</p>}

--- a/apps/docs-site/src/components/share/share-icons.tsx
+++ b/apps/docs-site/src/components/share/share-icons.tsx
@@ -1,0 +1,41 @@
+import type { ShareTarget } from '@/lib/share'
+
+/**
+ * Brand marks for the share destinations, as inline SVG so a handful of icons
+ * costs no extra request and no icon dependency. Paths are the public brand
+ * marks published by each service and mirrored in the CC0-licensed Simple
+ * Icons set; they inherit `currentColor` so one copy serves both themes.
+ *
+ * These are decorative: every caller pairs the mark with a visible text label,
+ * so the icons carry `aria-hidden` and never become the only name a control
+ * has.
+ */
+const BRAND_PATHS: Record<ShareTarget['id'], string> = {
+  linkedin:
+    'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
+  x: 'M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z',
+  whatsapp:
+    'M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51a12.8 12.8 0 00-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884a9.82 9.82 0 016.988 2.896 9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.885-9.885 9.885m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z',
+}
+
+interface ShareTargetIconProps {
+  /** Which share destination the mark stands for */
+  id: ShareTarget['id']
+  /** Sizing classes; defaults to the menu's 4×4 */
+  className?: string
+}
+
+/**
+ * The brand mark for one share destination.
+ * @param props - Component props
+ * @param props.id - Which share destination the mark stands for
+ * @param props.className - Sizing classes
+ * @returns The rendered mark, hidden from assistive technology
+ */
+export function ShareTargetIcon({ id, className = 'h-4 w-4' }: ShareTargetIconProps) {
+  return (
+    <svg className={`${className} shrink-0`} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+      <path d={BRAND_PATHS[id]} />
+    </svg>
+  )
+}

--- a/apps/docs-site/src/components/share/share-menu.tsx
+++ b/apps/docs-site/src/components/share/share-menu.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ShareTargetIcon } from '@/components/share/share-icons'
 import { trackShare } from '@/lib/analytics-events'
 import { buildShareDescriptor, buildShareTargets } from '@/lib/share'
 import { useEffect, useRef, useState } from 'react'
@@ -111,11 +112,12 @@ export function ShareMenu({ path, title, pageLine }: ShareMenuProps) {
         Share
       </button>
 
+      {/* why: The trigger sits at the right edge of its row on every page that mounts it, so anchoring the panel right keeps it on screen at 320px */}
       {open ? (
         <div
           id="share-menu-panel"
           aria-label="Share this page"
-          className="absolute left-0 z-[80] mt-2 w-60 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-xl sm:left-auto sm:right-0 dark:border-slate-700 dark:bg-slate-900"
+          className="absolute right-0 z-[80] mt-2 w-60 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-xl dark:border-slate-700 dark:bg-slate-900"
         >
           {canNativeShare ? (
             <button
@@ -149,9 +151,8 @@ export function ShareMenu({ path, title, pageLine }: ShareMenuProps) {
               }}
               className={itemClasses}
             >
-              <span aria-hidden="true" className="w-4 text-center text-xs font-bold text-slate-400">
-                {target.label.charAt(0)}
-              </span>
+              {/* why: The mark is decorative — the visible label beside it is what names the destination to every reader */}
+              <ShareTargetIcon id={target.id} className="h-4 w-4 text-slate-400" />
               {target.label}
             </a>
           ))}

--- a/apps/docs-site/src/components/value-proposition.tsx
+++ b/apps/docs-site/src/components/value-proposition.tsx
@@ -429,6 +429,9 @@ export function ValueProposition() {
           <GitHubIcon className="mr-2 h-4 w-4" />
           GitHub
         </TrackedLink>
+        <Link href="/docs/guides" className="btn-ghost">
+          Guides
+        </Link>
         <Link href="/demos" className="btn-ghost">
           Demos
         </Link>

--- a/apps/docs-site/src/lib/__tests__/guide-filters.spec.ts
+++ b/apps/docs-site/src/lib/__tests__/guide-filters.spec.ts
@@ -1,0 +1,92 @@
+import type { GuideIndexEntry } from '../../../scripts/generate-guides.types'
+import { describe, expect, it } from 'vitest'
+import { createURLSearchParams } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
+import { buildGuidesHref, filterGuides, GUIDE_FILTER_ALL, GUIDES_ROUTE, readGuideFilter } from '../guide-filters'
+
+/**
+ * Build a guide index entry with only the fields the filters read.
+ *
+ * @param slug - Global identifier, also the route segment and the sort key
+ * @param type - Which Diátaxis quadrant the guide sits in
+ * @param packages - Every npm package the guide involves, the one it is primarily about first
+ * @returns An index entry carrying just enough shape for the filters
+ */
+function guide(slug: string, type: GuideIndexEntry['type'], packages: string[]): GuideIndexEntry {
+  return <GuideIndexEntry>{ slug, type, packages, route: `/docs/guides/${slug}` }
+}
+
+const CORPUS = [
+  guide('a-nexus-tutorial', 'tutorial', ['@hyperfrontend/nexus']),
+  guide('b-crosses-into-nexus', 'how-to', ['@hyperfrontend/features', '@hyperfrontend/nexus']),
+  guide('c-nexus-how-to', 'how-to', ['@hyperfrontend/nexus']),
+]
+
+describe('buildGuidesHref', () => {
+  it('addresses the unfiltered index with no query string', () => {
+    expect(buildGuidesHref()).toBe(GUIDES_ROUTE)
+  })
+
+  it('drops facets left at the all-value rather than serializing them', () => {
+    expect(buildGuidesHref({ package: GUIDE_FILTER_ALL, type: GUIDE_FILTER_ALL })).toBe(GUIDES_ROUTE)
+  })
+
+  it('encodes the package name the way the README links spell it', () => {
+    expect(buildGuidesHref({ package: '@hyperfrontend/nexus' })).toBe('/docs/guides/?package=%40hyperfrontend%2Fnexus')
+  })
+
+  it('carries the type facet alone', () => {
+    expect(buildGuidesHref({ type: 'tutorial' })).toBe('/docs/guides/?type=tutorial')
+  })
+
+  it('carries both facets in a stable order', () => {
+    expect(buildGuidesHref({ package: '@hyperfrontend/nexus', type: 'how-to' })).toBe(
+      '/docs/guides/?package=%40hyperfrontend%2Fnexus&type=how-to'
+    )
+  })
+})
+
+describe('readGuideFilter', () => {
+  it('falls back to the all-value for both facets on a bare URL', () => {
+    expect(readGuideFilter(createURLSearchParams())).toEqual({ package: GUIDE_FILTER_ALL, type: GUIDE_FILTER_ALL })
+  })
+
+  it('round-trips a href built for a package and type', () => {
+    const query = buildGuidesHref({ package: '@hyperfrontend/nexus', type: 'tutorial' }).split('?')[1] ?? ''
+    expect(readGuideFilter(createURLSearchParams(query))).toEqual({ package: '@hyperfrontend/nexus', type: 'tutorial' })
+  })
+})
+
+describe('filterGuides', () => {
+  it('returns the corpus untouched when neither facet narrows', () => {
+    expect(filterGuides(CORPUS)).toEqual(CORPUS)
+  })
+
+  it('includes a cross-cutting guide under every package it involves', () => {
+    expect(filterGuides(CORPUS, { package: '@hyperfrontend/nexus' }).map((entry) => entry.slug)).toEqual([
+      'a-nexus-tutorial',
+      'c-nexus-how-to',
+      'b-crosses-into-nexus',
+    ])
+  })
+
+  it('narrows to one document type', () => {
+    expect(filterGuides(CORPUS, { type: 'tutorial' })).toEqual([CORPUS[0]])
+  })
+
+  it('applies both facets together', () => {
+    expect(filterGuides(CORPUS, { package: '@hyperfrontend/nexus', type: 'how-to' }).map((entry) => entry.slug)).toEqual([
+      'c-nexus-how-to',
+      'b-crosses-into-nexus',
+    ])
+  })
+
+  it('returns nothing for a package no guide involves', () => {
+    expect(filterGuides(CORPUS, { package: '@hyperfrontend/questions' })).toEqual([])
+  })
+
+  it('leaves the source array unsorted when narrowing by package', () => {
+    const source = [...CORPUS]
+    filterGuides(source, { package: '@hyperfrontend/nexus' })
+    expect(source).toEqual(CORPUS)
+  })
+})

--- a/apps/docs-site/src/lib/__tests__/guide-request.spec.ts
+++ b/apps/docs-site/src/lib/__tests__/guide-request.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { createURL } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
+import { buildGuideRequestUrl } from '../guide-request'
+
+describe('buildGuideRequestUrl', () => {
+  it("opens GitHub's own new-issue page rather than any custom integration", () => {
+    expect(createURL(buildGuideRequestUrl()).pathname).toBe('/AndrewRedican/hyperfrontend/issues/new')
+  })
+
+  it('selects the guide request template', () => {
+    expect(createURL(buildGuideRequestUrl()).searchParams.get('template')).toBe('guide_request.yml')
+  })
+
+  it('prefills the form package field when the reader came from a package view', () => {
+    expect(createURL(buildGuideRequestUrl('@hyperfrontend/nexus')).searchParams.get('package')).toBe('@hyperfrontend/nexus')
+  })
+
+  it('names the package in the issue title so triage reads it from the list', () => {
+    expect(createURL(buildGuideRequestUrl('@hyperfrontend/nexus')).searchParams.get('title')).toBe('[GUIDE] @hyperfrontend/nexus: ')
+  })
+
+  it('claims no package when the request comes from the unfiltered index', () => {
+    expect(createURL(buildGuideRequestUrl()).searchParams.get('package')).toBeNull()
+  })
+})

--- a/apps/docs-site/src/lib/guide-filters.ts
+++ b/apps/docs-site/src/lib/guide-filters.ts
@@ -1,0 +1,120 @@
+import type { GuideIndexEntry } from '../../scripts/generate-guides.types'
+import { createURLSearchParams } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
+
+/**
+ * The canonical route serving the guide and tutorial corpus. Every entry point
+ * into filtered guides, on the site and in published package READMEs, resolves
+ * here; there is no second guides destination.
+ */
+export const GUIDES_ROUTE = '/docs/guides/'
+
+/** Query parameter naming the npm package a guides view is narrowed to. */
+export const GUIDE_PACKAGE_PARAM = 'package'
+
+/** Query parameter naming the document type a guides view is narrowed to. */
+export const GUIDE_TYPE_PARAM = 'type'
+
+/** The facet value meaning "do not narrow on this axis"; never serialized into a URL. */
+export const GUIDE_FILTER_ALL = 'all'
+
+/**
+ * A guides view's two facets, as they appear in the URL.
+ */
+export interface GuideFilter {
+  /** npm package name, or {@link GUIDE_FILTER_ALL} */
+  package: string
+  /** Diátaxis-aligned document type, or {@link GUIDE_FILTER_ALL} */
+  type: string
+}
+
+/**
+ * The unfiltered view: every guide, every type.
+ */
+export const NO_GUIDE_FILTER: GuideFilter = { package: GUIDE_FILTER_ALL, type: GUIDE_FILTER_ALL }
+
+/**
+ * Anything that can answer `get(name)` for a query parameter: the DOM
+ * `URLSearchParams` and the App Router's `ReadonlyURLSearchParams` both do.
+ */
+export interface QueryParamSource {
+  /**
+   * Read one query parameter.
+   *
+   * @param name - Parameter name
+   * @returns The value, or null when absent
+   */
+  get(name: string): string | null
+}
+
+/**
+ * Build the canonical URL for a guides view.
+ *
+ * Facets left at {@link GUIDE_FILTER_ALL} (or omitted) are dropped rather than
+ * serialized, so one view always has exactly one URL: the unfiltered index is
+ * `/docs/guides/` and never `/docs/guides/?package=all`.
+ *
+ * @param filter - The facets to narrow to; omit for the unfiltered index
+ * @returns Site-relative URL, with a query string only when a facet is active
+ *
+ * @example Link a package's README or docs page at its guides
+ * ```ts
+ * buildGuidesHref({ package: '@hyperfrontend/nexus' })
+ * // '/docs/guides/?package=%40hyperfrontend%2Fnexus'
+ * ```
+ */
+export function buildGuidesHref(filter: Partial<GuideFilter> = {}): string {
+  const params = createURLSearchParams()
+  if (filter.package && filter.package !== GUIDE_FILTER_ALL) {
+    params.set(GUIDE_PACKAGE_PARAM, filter.package)
+  }
+  if (filter.type && filter.type !== GUIDE_FILTER_ALL) {
+    params.set(GUIDE_TYPE_PARAM, filter.type)
+  }
+  const query = params.toString()
+  return query ? `${GUIDES_ROUTE}?${query}` : GUIDES_ROUTE
+}
+
+/**
+ * Read a guides view's facets out of a URL's query string.
+ *
+ * @param params - The query parameters of the current URL
+ * @returns The facets, each falling back to {@link GUIDE_FILTER_ALL}
+ */
+export function readGuideFilter(params: QueryParamSource): GuideFilter {
+  return {
+    package: params.get(GUIDE_PACKAGE_PARAM) ?? GUIDE_FILTER_ALL,
+    type: params.get(GUIDE_TYPE_PARAM) ?? GUIDE_FILTER_ALL,
+  }
+}
+
+/**
+ * Narrow a guide corpus to one view.
+ *
+ * A guide matches a package filter when it names that package anywhere in its
+ * `packages` list, so a cross-cutting guide surfaces for every package it
+ * involves. When a package is named, the guides primarily about it sort ahead
+ * of the ones that merely involve it; otherwise the corpus keeps the index's
+ * slug order.
+ *
+ * @param guides - The compiled guide corpus, or any subset of it
+ * @param filter - The facets to narrow to
+ * @returns The matching guides, ownership-first when a package is named
+ */
+export function filterGuides(guides: GuideIndexEntry[], filter: Partial<GuideFilter> = {}): GuideIndexEntry[] {
+  const packageName = filter.package && filter.package !== GUIDE_FILTER_ALL ? filter.package : null
+  const type = filter.type && filter.type !== GUIDE_FILTER_ALL ? filter.type : null
+
+  const matching = guides.filter(
+    (guide) => (packageName === null || guide.packages.includes(packageName)) && (type === null || guide.type === type)
+  )
+
+  if (packageName === null) {
+    return matching
+  }
+
+  return [...matching].sort((a, b) => {
+    const aOwns = a.packages[0] === packageName ? 0 : 1
+    const bOwns = b.packages[0] === packageName ? 0 : 1
+    return aOwns - bOwns || a.slug.localeCompare(b.slug)
+  })
+}

--- a/apps/docs-site/src/lib/guide-request.ts
+++ b/apps/docs-site/src/lib/guide-request.ts
@@ -1,0 +1,35 @@
+import { createURLSearchParams } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
+import { REPO_URL } from './site'
+
+/**
+ * The repository issue form that collects guide requests. Prefilling works by
+ * field id, which is GitHub's own mechanism, so no credentials, API calls, or
+ * client-side integration are involved: the reader lands on a normal new-issue
+ * page with the context already typed in, and reviews and submits it there.
+ */
+const GUIDE_REQUEST_TEMPLATE = 'guide_request.yml'
+
+/**
+ * Build the URL that opens a prefilled guide request on GitHub.
+ *
+ * The package is prefilled only when the reader arrived from a package-scoped
+ * view, so a request made from the unfiltered index does not claim a package
+ * the reader never named.
+ *
+ * @param packageName - npm package the reader was looking at, when there was one
+ * @returns Absolute GitHub new-issue URL targeting the guide request form
+ *
+ * @example Offer a request from a package's empty guides view
+ * ```ts
+ * buildGuideRequestUrl('@hyperfrontend/nexus')
+ * // 'https://github.com/…/issues/new?template=guide_request.yml&title=%5BGUIDE%5D+%40hyperfrontend%2Fnexus%3A+&package=%40hyperfrontend%2Fnexus'
+ * ```
+ */
+export function buildGuideRequestUrl(packageName?: string): string {
+  const params = createURLSearchParams({ template: GUIDE_REQUEST_TEMPLATE })
+  params.set('title', packageName ? `[GUIDE] ${packageName}: ` : '[GUIDE] ')
+  if (packageName) {
+    params.set('package', packageName)
+  }
+  return `${REPO_URL}/issues/new?${params.toString()}`
+}

--- a/apps/docs-site/src/lib/guides.ts
+++ b/apps/docs-site/src/lib/guides.ts
@@ -2,6 +2,8 @@ import type { GuideIndex, GuideIndexEntry } from '../../scripts/generate-guides.
 import { existsSync, readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { parse } from '@hyperfrontend/immutable-api-utils/built-in-copy/json'
+import { getManifest } from './docs-loader'
+import { filterGuides } from './guide-filters'
 
 const GUIDES_DIR = resolve(process.cwd(), '.generated/guides')
 
@@ -63,10 +65,40 @@ export function getGuide(slug: string): Guide | null {
  * @returns Index entries of every guide whose packages list includes the package
  */
 export function getGuidesForPackage(packageName: string): GuideIndexEntry[] {
-  const involved = getGuideIndex().filter((guide) => guide.packages.includes(packageName))
-  return involved.sort((a, b) => {
-    const aOwns = a.packages[0] === packageName ? 0 : 1
-    const bOwns = b.packages[0] === packageName ? 0 : 1
-    return aOwns - bOwns || a.slug.localeCompare(b.slug)
-  })
+  return filterGuides(getGuideIndex(), { package: packageName })
+}
+
+/**
+ * One selectable package in the guides index's package filter.
+ */
+export interface GuidePackageOption {
+  /** npm package name, the filter's URL value */
+  packageName: string
+  /** Library display name */
+  name: string
+  /** How many compiled guides involve the package */
+  guideCount: number
+}
+
+/**
+ * List every documented package as a guides-filter option, with how many
+ * guides each one has.
+ *
+ * The options come from the documentation manifest rather than from the guide
+ * corpus, so a package nobody has written a guide for yet is still selectable
+ * and its shared URL still resolves to a deliberate empty state instead of a
+ * filter the reader cannot see.
+ *
+ * @returns Options for every documented package, display-name sorted
+ */
+export function getGuidePackageOptions(): GuidePackageOption[] {
+  const guides = getGuideIndex()
+  const libraries = getManifest()?.libraries ?? []
+  return libraries
+    .map((library) => ({
+      packageName: library.packageName,
+      name: library.name,
+      guideCount: guides.filter((guide) => guide.packages.includes(library.packageName)).length,
+    }))
+    .sort((a, b) => a.packageName.localeCompare(b.packageName))
 }

--- a/apps/docs-site/src/lib/markdown.ts
+++ b/apps/docs-site/src/lib/markdown.ts
@@ -39,6 +39,34 @@ export async function markdownToHtml(markdown: string): Promise<string> {
 }
 
 /**
+ * Convert a single line of markdown to inline HTML, without the wrapping
+ * paragraph.
+ *
+ * For short authored strings that live in metadata rather than in a document
+ * body: a guide's prerequisites, for example, which are sentences an author
+ * writes and should be able to punctuate with a link or a code span. Raw HTML
+ * and syntax highlighting are deliberately absent; a metadata line is a
+ * sentence, not a document.
+ *
+ * @param markdown - One line of markdown
+ * @returns A promise resolving to HTML with no block wrapper
+ *
+ * @example Link and code-format a prerequisite
+ * ```ts
+ * await markdownToInlineHtml('A value that throws on [`JSON.stringify`](https://example.com)')
+ * // 'A value that throws on <a href="https://example.com"><code>JSON.stringify</code></a>'
+ * ```
+ */
+export async function markdownToInlineHtml(markdown: string): Promise<string> {
+  const result = await remark().use(remarkGfm).use(remarkRehype).use(rehypeStringify).process(markdown)
+  return result
+    .toString()
+    .trim()
+    .replace(/^<p>/, '')
+    .replace(/<\/p>$/, '')
+}
+
+/**
  * The subset of a hast node the comment pass needs: its type, and its children
  * when it is a container.
  */

--- a/apps/docs-site/src/lib/navigation.ts
+++ b/apps/docs-site/src/lib/navigation.ts
@@ -440,6 +440,7 @@ const gettingStarted: NavItem[] = [
  */
 export const mainNavLinks = [
   { slug: 'Docs', href: '/docs' },
+  { slug: 'Guides', href: '/docs/guides' },
   { slug: 'Demos', href: '/demos' },
   { slug: 'Articles', href: '/articles' },
   { slug: 'Architecture', href: '/architecture' },
@@ -457,7 +458,7 @@ export const docsNavigation: NavItem[] = [
     children: gettingStarted,
   },
   {
-    slug: 'Guides',
+    slug: 'Guides & Tutorials',
     href: '/docs/guides',
   },
   {

--- a/apps/docs-site/src/lib/site.ts
+++ b/apps/docs-site/src/lib/site.ts
@@ -11,3 +11,9 @@
  * compiles to `undefined` in the browser.
  */
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.hyperfrontend.dev'
+
+/**
+ * Canonical GitHub repository URL, without a trailing slash. Issue, discussion,
+ * and source links compose onto it so the coordinates live in one place.
+ */
+export const REPO_URL = 'https://github.com/AndrewRedican/hyperfrontend'

--- a/apps/package-e2e/features/package.json
+++ b/apps/package-e2e/features/package.json
@@ -7,7 +7,7 @@
     "pack-install": "cd ../../../dist/libs/features && npm pack && cd - && npm install ../../../dist/libs/features/*.tgz"
   },
   "dependencies": {
-    "@hyperfrontend/features": "file:../../../tmp/e2e-packs/hyperfrontend-features-0.7.0.tgz"
+    "@hyperfrontend/features": "file:../../../tmp/e2e-packs/hyperfrontend-features-0.7.1.tgz"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/libs/builder/README.md
+++ b/libs/builder/README.md
@@ -36,6 +36,7 @@
 Composable, vendor-neutral build toolkit for TypeScript libraries, JS bins, and Node SEA native binaries.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/builder/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fbuilder)
 
 ## What is @hyperfrontend/builder?
 

--- a/libs/cryptography/README.md
+++ b/libs/cryptography/README.md
@@ -36,6 +36,7 @@
 Production-grade cryptographic primitives with isomorphic APIs for browser and Node.js environments.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/cryptography/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fcryptography)
 
 ## What is @hyperfrontend/cryptography?
 

--- a/libs/features/CHANGELOG.md
+++ b/libs/features/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1](https://github.com/AndrewRedican/hyperfrontend/compare/ee192ea7bb541593e6590243a08a29b68d69a1ac...4943d02ebe5bc10fc471f4d6a96c6b87812d0b76) - 2026-08-19
+
+### Bug Fixes
+
+- detect a frame killed while the page was hidden
+
 ## [0.7.0](https://github.com/AndrewRedican/hyperfrontend/compare/725db1b4556be686fd460b69424229a7d5ac5a63...711cd92957261be5b531486c08f51daab2f60cec) - 2026-08-15
 
 ### Features
@@ -60,25 +66,25 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changes
 
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** coordinate presentation host-side with contract-declared display modes
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** throw when registering v2 security without a shared key
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** is Open stays false after open() until the handshake completes; ready() rejects when no host answers
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** coordinate presentation host-side with contract-declared display modes
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** throw when registering v2 security without a shared key
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** is Open stays false after open() until the handshake completes; ready() rejects when no host answers
 
 ### Features
 
 - adopt a reloaded feature on its existing mount
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: coordinate presentation host-side with contract-declared display modes
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: coordinate presentation host-side with contract-declared display modes
 - delegate frame permissions and add host-only sandbox containment
 - add four-state liveness, closing flush window, and dirty state
 - validate action payloads on send and receive
 - announce contract versions and gate compatibility
 - add hostee security options and shared registration
 - add allow-open option to the nx build executor
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: adopt asynchronous wire-gated open with origin pinning and timeout errors
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: adopt asynchronous wire-gated open with origin pinning and timeout errors
 
 ### Bug Fixes
 
-- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: throw when registering v2 security without a shared key
+- **BREAKING** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** **BREAKING:** ⚠️ BREAKING: throw when registering v2 security without a shared key
 
 ## [0.2.0](https://github.com/AndrewRedican/hyperfrontend/compare/6b5a02be62850b0509b9fd71ad9232655cf5fbbf...47a37497608ac765af3efb30f0b5e01950bae425) - 2026-07-05
 

--- a/libs/features/README.md
+++ b/libs/features/README.md
@@ -39,6 +39,8 @@ SDK, CLI, and dev server for building, embedding, and orchestrating hyperfronten
 
 • 👉 See [**API reference**](https://www.hyperfrontend.dev/docs/libraries/features/#api-reference)
 
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Ffeatures)
+
 ## What is @hyperfrontend/features?
 
 Embedding another team's app inside your page usually means an iframe, a pile of `postMessage` conventions nobody wrote down, and a frame that never quite fits the space you gave it. `@hyperfrontend/features` turns that into a contract: the feature app declares what it sends, what it accepts, and which display modes it supports; the host picks a mode and gets a typed handle back. The messaging protocol underneath is [`@hyperfrontend/nexus`](https://www.hyperfrontend.dev/docs/libraries/nexus/), and this package adds everything around it: iframe management, display modes and sizing, the open/close lifecycle, and a CLI that packages a feature app into an installable shell.

--- a/libs/features/package.json
+++ b/libs/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperfrontend/features",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "SDK, CLI, and dev server for building, embedding, and orchestrating hyperfrontend micro-frontend features.",
   "license": "MIT",
   "sideEffects": false,

--- a/libs/features/src/host/heartbeat.spec.ts
+++ b/libs/features/src/host/heartbeat.spec.ts
@@ -105,7 +105,42 @@ describe('createHeartbeatMonitor', () => {
     expect(onUnresponsive).not.toHaveBeenCalled()
     jest.advanceTimersByTime(1000)
     expect(onUnresponsive).toHaveBeenCalledTimes(1)
-    expect(states).toEqual(['healthy', 'unobservable', 'healthy', 'suspect'])
+    expect(states).toEqual(['healthy', 'unobservable', 'suspect'])
+  })
+
+  it('stays unobservable after watching resumes until a beat proves the feature is there', () => {
+    const states: string[] = []
+    const monitor = createHeartbeatMonitor(jest.fn(), (status) => states.push(status.state))
+    monitor.start()
+    monitor.setObservable(false)
+    monitor.setObservable(true)
+    jest.advanceTimersByTime(2000)
+    expect(states).toEqual(['healthy', 'unobservable'])
+    monitor.beat()
+    expect(states).toEqual(['healthy', 'unobservable', 'healthy'])
+  })
+
+  it('never calls a hidden feature healthy on a beat, because silence there is not evidence either', () => {
+    const states: string[] = []
+    const monitor = createHeartbeatMonitor(jest.fn(), (status) => states.push(status.state))
+    monitor.start()
+    monitor.setObservable(false)
+    monitor.beat()
+    expect(states).toEqual(['healthy', 'unobservable'])
+  })
+
+  it('declares a feature that went quiet while hidden suspect rather than healthy on return', () => {
+    const states: string[] = []
+    const onUnresponsive = jest.fn()
+    const monitor = createHeartbeatMonitor(onUnresponsive, (status) => states.push(status.state))
+    monitor.start()
+    monitor.beat()
+    monitor.setObservable(false)
+    jest.advanceTimersByTime(60_000)
+    monitor.setObservable(true)
+    jest.advanceTimersByTime(3000)
+    expect(states).toEqual(['healthy', 'unobservable', 'suspect'])
+    expect(onUnresponsive).toHaveBeenCalledTimes(1)
   })
 
   it('starts as unobservable when hidden before start', () => {

--- a/libs/features/src/host/heartbeat.ts
+++ b/libs/features/src/host/heartbeat.ts
@@ -2,6 +2,7 @@ import { dateNow } from '@hyperfrontend/immutable-api-utils/built-in-copy/date'
 import { clearInterval, setInterval } from '@hyperfrontend/immutable-api-utils/built-in-copy/timers'
 
 // note: The watchdog counts ticks since the last beat; a beat resets the count. While the page pair is unobservable (either side hidden), ticks pause — a throttled timer's silence is weak evidence. Crossing the miss threshold enters 'suspect' and fires the unresponsive callback once per episode; a later beat recovers to 'healthy' and re-arms it.
+// note: 'healthy' is only ever spoken on evidence — the handshake that starts the watchdog, or a beat. Resuming observation grants a fresh miss budget but says nothing, because nothing has been heard yet.
 const BEAT_INTERVAL_MS = 1000
 const MISS_THRESHOLD = 3
 
@@ -9,8 +10,10 @@ const MISS_THRESHOLD = 3
  * Liveness state of the connected feature, as judged by the watchdog.
  *
  * - `healthy`: beats are arriving within the expected budget.
- * - `unobservable`: the host page or the feature page is hidden, so browser
- *   timer throttling makes silence weak evidence; the watchdog pauses.
+ * - `unobservable`: silence carries no information yet. Either a page is
+ *   hidden, so browser timer throttling makes the quiet meaningless and the
+ *   watchdog pauses, or watching has just resumed and no beat has arrived to
+ *   earn `healthy` back.
  * - `suspect`: the pages are visible and the miss budget is exhausted; the
  *   feature is probably unhealthy.
  * - `gone`: the session is closed or destroyed (or not yet open).
@@ -91,8 +94,9 @@ export function createHeartbeatMonitor(
     beat() {
       missed = 0
       lastBeatAt = dateNow()
-      // why: A beat is positive evidence of life — it ends a suspect episode and re-arms the unresponsive callback for the next one. Suspect implies observable (ticks pause while hidden, and hiding leaves suspect), so recovery is always to healthy.
-      if (timer !== undefined && state === 'suspect') {
+      // why: A beat is the only positive evidence of life there is — it ends a suspect episode, it is what earns `healthy` back after watching resumes, and it re-arms the unresponsive callback for the next episode.
+      // why: While a page is hidden it does no more than keep the budget full. Silence means nothing there, so a beat is not a verdict there either, and the pair stays honestly unobservable.
+      if (timer !== undefined && observable && state !== 'healthy') {
         transition('healthy')
       }
     },
@@ -127,8 +131,8 @@ export function createHeartbeatMonitor(
         return
       }
       // why: Returning to observability grants a fresh miss budget — beats throttled while hidden need time to resume before silence means anything again.
+      // why: It does not grant health. Nothing has been heard since watching stopped, and a frame the browser killed while this page sat in the background will never be heard from again — calling that `healthy` hands every host a proof of life no beat backs, and readmits a dead frame to the scene on every return to the tab. The next beat says healthy; its absence says suspect.
       missed = 0
-      transition('healthy')
     },
     getStatus,
   }

--- a/libs/features/src/host/lifecycle.liveness.browser.spec.ts
+++ b/libs/features/src/host/lifecycle.liveness.browser.spec.ts
@@ -1,0 +1,135 @@
+import type { BrokerHandle, ChannelHandle } from '@hyperfrontend/nexus'
+import type { ShellOptions } from '../shared/types'
+import type { MountResult } from './types'
+import { createEventEmitter } from '../shared/event-emitter'
+import { createHeartbeatMonitor } from './heartbeat'
+import { createShellHandle } from './lifecycle'
+import { observePageVisibility } from './visibility'
+
+interface MockChannel {
+  channel: ChannelHandle
+  trigger(event: string, data?: unknown): void
+  triggerMessage(type: string, data?: unknown): void
+}
+
+function createMockChannel(): MockChannel {
+  const listeners: Record<string, Array<(data?: unknown) => void>> = {}
+  const messageHandlers: Array<(message: { type: string; data?: unknown }) => void> = []
+  const channel = <ChannelHandle>(<unknown>{
+    on: (event: string, handler: (data?: unknown) => void) => {
+      ;(listeners[event] ?? (listeners[event] = [])).push(handler)
+      return () => undefined
+    },
+    onMessage: (handler: (message: { type: string; data?: unknown }) => void) => {
+      messageHandlers.push(handler)
+      return () => undefined
+    },
+    send: jest.fn(),
+    disconnect: jest.fn(),
+    destroy: jest.fn(),
+    connect: jest.fn(),
+  })
+  return {
+    channel,
+    trigger: (event, data) => listeners[event]?.forEach((handler) => handler(data)),
+    triggerMessage: (type, data) => messageHandlers.forEach((handler) => handler({ type, data })),
+  }
+}
+
+const TARGET = <Window>(<unknown>{ name: 'target' })
+
+/**
+ * Drives this page's reported visibility, the way a phone backgrounding the tab does.
+ * @param value - The state `document.visibilityState` should report.
+ */
+function setPageVisibility(value: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => value })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+/**
+ * Builds a shell wired to the real watchdog and the real visibility observer,
+ * mounted as an in-document frame.
+ * @returns The handle, its channel double, and the errors it emitted.
+ */
+function setup() {
+  const mock = createMockChannel()
+  const broker = <BrokerHandle>(<unknown>{ addChannel: jest.fn(() => mock.channel) })
+  const frame = document.createElement('iframe')
+  const mount = jest.fn((): MountResult => ({ target: TARGET, element: frame, present: { mode: 'embedded' }, cleanup: jest.fn() }))
+  const emitter = createEventEmitter()
+  const errors: unknown[] = []
+  emitter.on('error', (error) => errors.push(error))
+  const states: string[] = []
+  emitter.on('status', (status) => states.push((<{ state: string }>status).state))
+  const handle = createShellHandle(broker, <ShellOptions>{ container: '#shell' }, emitter, {
+    contract: { emitted: [], accepted: [] },
+    selectMount: jest.fn(() => mount),
+    registerSecurity: jest.fn(() => undefined),
+    createHeartbeatMonitor,
+    observeVisibility: observePageVisibility,
+  })
+  handle.open()
+  mock.trigger('open')
+  return { handle, mock, errors, states }
+}
+
+// why: This is the failure the whole observability latch exists around, exercised end to end: a frame the browser kills while the tab is in the background can never send the report that says it is visible again, so a host that waits for one waits forever. Every piece has to agree for the verdict to arrive — the lifecycle dropping a report it can no longer believe, and the watchdog refusing to call anything healthy it has not heard from.
+describe('a feature frame killed while the tab was in the background', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    Reflect.deleteProperty(document, 'visibilityState')
+  })
+
+  it('is declared unresponsive once the tab comes back', () => {
+    const ctx = setup()
+    ctx.mock.triggerMessage('__hf:beat')
+    setPageVisibility('hidden')
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
+    // note: The frame dies here. It sends nothing ever again — no beat, and no visibility report to clear the host's copy of its hidden state.
+    setPageVisibility('visible')
+    jest.advanceTimersByTime(3000)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toMatchObject({ reason: 'unresponsive' })
+    expect(ctx.states).toEqual(['healthy', 'unobservable', 'suspect'])
+  })
+
+  it('is never called healthy on the way there, so a host cannot readmit it', () => {
+    const ctx = setup()
+    ctx.mock.triggerMessage('__hf:beat')
+    setPageVisibility('hidden')
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
+    setPageVisibility('visible')
+    expect(ctx.states).toEqual(['healthy', 'unobservable'])
+  })
+})
+
+describe('a feature frame that survives the tab going away', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    Reflect.deleteProperty(document, 'visibilityState')
+  })
+
+  it('earns healthy back on its first beat and is never suspected', () => {
+    const ctx = setup()
+    ctx.mock.triggerMessage('__hf:beat')
+    setPageVisibility('hidden')
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
+    setPageVisibility('visible')
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: false })
+    ctx.mock.triggerMessage('__hf:beat')
+    jest.advanceTimersByTime(2000)
+    ctx.mock.triggerMessage('__hf:beat')
+    jest.advanceTimersByTime(2000)
+    expect(ctx.errors).toHaveLength(0)
+    expect(ctx.states).toEqual(['healthy', 'unobservable', 'healthy'])
+  })
+})

--- a/libs/features/src/host/lifecycle.liveness.spec.ts
+++ b/libs/features/src/host/lifecycle.liveness.spec.ts
@@ -36,10 +36,26 @@ function createMockChannel(): MockChannel {
 
 const TARGET = <Window>(<unknown>{ name: 'target' })
 
-function setup() {
+/** Stands in for the iframe an in-document mount reports back, whose visibility the browser slaves to this page's. */
+const FRAME = <HTMLElement>(<unknown>{ tagName: 'IFRAME' })
+
+/** Options for {@link setup}. */
+interface LivenessSetupOptions {
+  /** `true` mounts the feature in this document (an iframe), as embedded and dialog do; omitted leaves it windowed. */
+  inDocument?: boolean
+}
+
+function setup(options: LivenessSetupOptions = {}) {
   const mock = createMockChannel()
   const broker = <BrokerHandle>(<unknown>{ addChannel: jest.fn(() => mock.channel) })
-  const mount = jest.fn((): MountResult => ({ target: TARGET, present: { mode: 'embedded' }, cleanup: jest.fn() }))
+  const mount = jest.fn(
+    (): MountResult => ({
+      target: TARGET,
+      present: { mode: 'embedded' },
+      cleanup: jest.fn(),
+      ...(options.inDocument === true && { element: FRAME }),
+    })
+  )
   const monitor = { beat: jest.fn(), start: jest.fn(), stop: jest.fn(), setObservable: jest.fn(), getStatus: jest.fn() }
   let stateChange: ((status: unknown) => void) | undefined
   const createHeartbeatMonitor = jest.fn(
@@ -102,13 +118,32 @@ describe('createShellHandle liveness states and observability', () => {
     expect(ctx.monitor.setObservable).toHaveBeenLastCalledWith(true)
   })
 
-  it('stays unobservable while either page is hidden', () => {
+  it('keeps a windowed feature unobservable while it reports itself hidden, whatever this page does', () => {
     const ctx = setup()
     ctx.handle.open()
     ctx.mock.trigger('open')
     ctx.triggerVisibility(true)
     ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
     ctx.triggerVisibility(false)
+    expect(ctx.monitor.setObservable).toHaveBeenLastCalledWith(false)
+  })
+
+  it('stops believing an in-document frame is hidden once this page is not', () => {
+    const ctx = setup({ inDocument: true })
+    ctx.handle.open()
+    ctx.mock.trigger('open')
+    ctx.triggerVisibility(true)
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
+    ctx.triggerVisibility(false)
+    // why: The browser slaves an iframe's visibility to its embedder's, so the report cannot still be true — and a frame killed while this page was in the background can never send the one that would clear it.
+    expect(ctx.monitor.setObservable).toHaveBeenLastCalledWith(true)
+  })
+
+  it('still honours an in-document frame reporting itself hidden while this page is visible', () => {
+    const ctx = setup({ inDocument: true })
+    ctx.handle.open()
+    ctx.mock.trigger('open')
+    ctx.mock.triggerMessage('__hf:visibility', { hidden: true })
     expect(ctx.monitor.setObservable).toHaveBeenLastCalledWith(false)
   })
 

--- a/libs/features/src/host/lifecycle.ts
+++ b/libs/features/src/host/lifecycle.ts
@@ -317,8 +317,12 @@ export function createShellHandle(
     let selfHidden = false
     let peerHidden = false
     const applyObservability = () => activeMonitor.setObservable(!selfHidden && !peerHidden)
+    // why: An in-document frame's visibility is the browser's copy of this page's, so it cannot honestly still be hidden once this page is not — and a frame the browser killed while this page sat in the background can never send the report that clears the flag. Leaving it set pins the watchdog at `unobservable` for the rest of the session, blind to the one failure it exists to catch. A live frame re-reports within a message of this, so the flag costs nothing to drop; a feature in its own window really can be hidden while this page is not, and its report stands.
     visibilityTeardown = wiring.observeVisibility((hidden) => {
       selfHidden = hidden
+      if (!hidden && result.element !== undefined) {
+        peerHidden = false
+      }
       applyObservability()
     })
     channel.on('open', () => {

--- a/libs/logging/README.md
+++ b/libs/logging/README.md
@@ -36,6 +36,7 @@
 Structured logging with configurable severity levels and error-resilient execution.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/logging/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Flogging)
 
 ## What is @hyperfrontend/logging?
 

--- a/libs/network-protocol/README.md
+++ b/libs/network-protocol/README.md
@@ -37,6 +37,7 @@ Production-grade network protocol for secure, real-time cross-window and cross-p
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/network-protocol/)
 • 👉 See [**API reference**](https://www.hyperfrontend.dev/docs/libraries/network-protocol/#api-reference)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fnetwork-protocol)
 
 ## What is @hyperfrontend/network-protocol?
 

--- a/libs/nexus/README.md
+++ b/libs/nexus/README.md
@@ -39,6 +39,8 @@ Secure cross-window communication library for micro-frontends with contract-vali
 
 • 👉 See [**API reference**](https://www.hyperfrontend.dev/docs/libraries/nexus/#api-reference)
 
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fnexus)
+
 ## What is @hyperfrontend/nexus?
 
 Two windows talking over `postMessage` share a string and nothing else: no agreement on which message types exist, no way to tell whether anyone is listening, no signal when the other side goes away. Nexus puts a broker in front of that. One broker per app manages a channel per counterpart window or frame, and every channel carries a contract, the message types each side sends and accepts, exchanged during a three-way handshake. Types outside the contract are dropped, messages from an origin other than the pinned one are ignored, and the connection state is something you subscribe to instead of infer.

--- a/libs/project-scope/README.md
+++ b/libs/project-scope/README.md
@@ -36,6 +36,7 @@
 Comprehensive project analysis, technology stack detection, and transactional virtual file system for Node.js tooling.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/project-scope/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fproject-scope)
 
 ## What is @hyperfrontend/project-scope?
 

--- a/libs/questions/README.md
+++ b/libs/questions/README.md
@@ -36,6 +36,7 @@
 Terminal prompting library with composable, functional API for text, select, confirm, and multiselect prompts
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/questions/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fquestions)
 
 ## What is @hyperfrontend/questions?
 

--- a/libs/state-machine/README.md
+++ b/libs/state-machine/README.md
@@ -37,6 +37,7 @@ Lightweight, functional state management library with Redux-inspired actions/red
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/state-machine/)
 • 👉 See [**API reference**](https://www.hyperfrontend.dev/docs/libraries/state-machine/#api-reference)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fstate-machine)
 
 ## What is @hyperfrontend/state-machine?
 

--- a/libs/utils/data/README.md
+++ b/libs/utils/data/README.md
@@ -36,6 +36,7 @@
 Comprehensive data structure manipulation with circular reference handling and custom class support.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/data/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fdata-utils)
 
 ## What is @hyperfrontend/data-utils?
 

--- a/libs/utils/function/README.md
+++ b/libs/utils/function/README.md
@@ -36,6 +36,7 @@
 Higher-order function utilities for behavioral modification and composition.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/function/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Ffunction-utils)
 
 ## What is @hyperfrontend/function-utils?
 

--- a/libs/utils/immutable-api/README.md
+++ b/libs/utils/immutable-api/README.md
@@ -36,6 +36,7 @@
 Decorators and utilities for creating immutable, tamper-proof object APIs with built-in prototype pollution defense.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/immutable-api/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fimmutable-api-utils)
 
 ## What is @hyperfrontend/immutable-api-utils?
 

--- a/libs/utils/json/README.md
+++ b/libs/utils/json/README.md
@@ -36,6 +36,7 @@
 Zero-dependency JSON Schema Draft v4 validation and schema generation utilities.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/json/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fjson-utils)
 
 ## What is @hyperfrontend/json-utils?
 

--- a/libs/utils/list/README.md
+++ b/libs/utils/list/README.md
@@ -36,6 +36,7 @@
 Purpose-built collection utilities for queue management, filtering, and iteration patterns.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/list/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Flist-utils)
 
 ## What is @hyperfrontend/list-utils?
 

--- a/libs/utils/random-generator/README.md
+++ b/libs/utils/random-generator/README.md
@@ -36,6 +36,7 @@
 Statistical random distributions and UUID generation for simulations, testing, and procedural content.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/random-generator/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Frandom-generator-utils)
 
 ## What is @hyperfrontend/random-generator-utils?
 

--- a/libs/utils/string/README.md
+++ b/libs/utils/string/README.md
@@ -36,6 +36,7 @@
 Isomorphic string encoding utilities with unified APIs for browser and Node.js environments.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/string/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fstring-utils)
 
 ## What is @hyperfrontend/string-utils?
 

--- a/libs/utils/time/README.md
+++ b/libs/utils/time/README.md
@@ -36,6 +36,7 @@
 Functional time utilities for async operations, intervals, and time normalization.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/time/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Ftime-utils)
 
 ## What is @hyperfrontend/time-utils?
 

--- a/libs/utils/ui/README.md
+++ b/libs/utils/ui/README.md
@@ -37,6 +37,7 @@ Modular DOM utilities for dynamic styling, gesture detection, element lifecycle,
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/ui/)
 • 👉 See [**API reference**](https://www.hyperfrontend.dev/docs/libraries/utils/ui/#api-reference)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fui-utils)
 
 ## What is @hyperfrontend/ui-utils?
 

--- a/libs/versioning/README.md
+++ b/libs/versioning/README.md
@@ -35,6 +35,7 @@ Versioning library with changelog parsing, conventional commits, and semver flow
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/versioning/)
 • 👉 See [**roadmap**](https://github.com/AndrewRedican/hyperfrontend/blob/main/roadmap/versioning/)
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fversioning)
 
 ## What is @hyperfrontend/versioning?
 

--- a/tools/eslint-rules/docs/lib-readme-structure.md
+++ b/tools/eslint-rules/docs/lib-readme-structure.md
@@ -39,6 +39,29 @@ Must include a documentation link in format:
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/<name>/)
 ```
 
+### Guides Link
+
+Must also link the package's guides and tutorials, filtered to this package:
+
+```
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=<url-encoded package name>)
+```
+
+The package name is read from `package.json`, so the link is checked against the
+package the README actually ships with rather than the title text. The value is
+URL-encoded exactly as the site's own filter controls encode it
+(`%40hyperfrontend%2Fnexus`), so a link shared from the site and a link written
+in a README are the same URL.
+
+The link addresses a filter, not a list of guide slugs, which is the point: a
+package with no guides yet still gets a working link, and guides written later
+surface from the already-published README without another release. The filtered
+page has a deliberate empty state that invites a guide request.
+
+When a project has no `package.json`, this check is skipped: without a package
+name there is nothing to filter on. `lib-pkg-fields` is the rule that requires
+the field.
+
 ### Required Sections (in order)
 
 1. **What is @hyperfrontend/<name>?** - Library description
@@ -152,6 +175,8 @@ Should come before Installation.
 Utility functions for common operations.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/utils/)
+
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Futils)
 
 ## What is @hyperfrontend/utils?
 

--- a/tools/eslint-rules/src/rules/lib-readme-structure.spec.ts
+++ b/tools/eslint-rules/src/rules/lib-readme-structure.spec.ts
@@ -3,6 +3,7 @@ import { createTempWorkspaceManager } from '../testing'
 import rule, {
   extractBadgesBlock,
   extractDocumentationLink,
+  extractGuidesLink,
   extractShortDescription,
   extractTitle,
   parseMarkdownSections,
@@ -30,11 +31,13 @@ const validProjectJson = {
  *
  * @param config - Configuration for the temporary project.
  * @param config.projectJson - The project.json content.
+ * @param config.packageJson - The package.json content, omitted when the test does not need one.
  * @returns The path to the temporary project directory.
  */
-function createTempProject(config: { projectJson: object }): string {
+function createTempProject(config: { projectJson: object; packageJson?: object }): string {
   const workspace = manager.create({
     projectJson: config.projectJson,
+    packageJson: config.packageJson,
     directories: ['src'],
   })
   return workspace.root
@@ -85,6 +88,8 @@ function createValidReadme(packageName = 'test-library'): string {
 A short description of this library for testing purposes.
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/${packageName}/)
+
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2F${packageName})
 
 ## What is @hyperfrontend/${packageName}?
 
@@ -156,6 +161,7 @@ describe('lib-readme-structure', () => {
       expect(messageIds).toContain('missingBadge')
       expect(messageIds).toContain('missingShortDescription')
       expect(messageIds).toContain('missingDocumentationLink')
+      expect(messageIds).toContain('missingGuidesLink')
       expect(messageIds).toContain('missingSection')
       expect(messageIds).toContain('emptySectionContent')
       expect(messageIds).toContain('sectionOutOfOrder')
@@ -284,6 +290,42 @@ A description`
 ## Content`
       const result = extractDocumentationLink(content)
       expect(result).toEqual({ line: 3 })
+    })
+  })
+
+  describe('extractGuidesLink', () => {
+    it('finds the package-filtered guides link', () => {
+      const content = `# Title
+
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Ftest)
+
+## Content`
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toEqual({ line: 3 })
+    })
+
+    it('returns null when the guides link is absent', () => {
+      const content = '# Title\n\n• 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/test/)'
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toBeNull()
+    })
+
+    it('returns null when the link filters to a different package', () => {
+      const content = '# Title\n\n• 👉 See [**guides**](https://www.hyperfrontend.dev/docs/guides/?package=%40hyperfrontend%2Fother)'
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toBeNull()
+    })
+
+    it('returns null when the guides link carries no package filter', () => {
+      const content = '# Title\n\n• 👉 See [**guides**](https://www.hyperfrontend.dev/docs/guides/)'
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toBeNull()
+    })
+
+    it('returns null when the target is not a parseable URL', () => {
+      const content = '# Title\n\n• 👉 See [**guides**](/docs/guides/?package=%40hyperfrontend%2Ftest)'
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toBeNull()
+    })
+
+    it('returns null when the link is unterminated', () => {
+      const content = '# Title\n\n• 👉 See [**guides**](https://www.hyperfrontend.dev/docs/guides/?package=test'
+      expect(extractGuidesLink(content, '@hyperfrontend/test')).toBeNull()
     })
   })
 
@@ -570,11 +612,50 @@ npm install
     })
 
     it('does not report errors for valid README', () => {
-      const dir = createTempProject({ projectJson: validProjectJson })
+      const dir = createTempProject({ projectJson: validProjectJson, packageJson: { name: '@hyperfrontend/test' } })
       const reportMock = jest.fn()
       const context = {
         filename: join(dir, 'README.md'),
         sourceCode: { getText: () => createValidReadme('test') },
+        report: reportMock,
+      }
+      // @ts-expect-error - partial mock
+      const listener = rule.create(context)
+      const mockNode = { type: 'root' }
+      // @ts-expect-error - partial mock
+      listener.root?.(mockNode)
+
+      expect(reportMock).not.toHaveBeenCalled()
+    })
+
+    it('reports a README that never links its package-filtered guides', () => {
+      const dir = createTempProject({ projectJson: validProjectJson, packageJson: { name: '@hyperfrontend/test' } })
+      const reportMock = jest.fn()
+      const context = {
+        filename: join(dir, 'README.md'),
+        sourceCode: { getText: () => createValidReadme('test').replace(/^• 👉 See \[\*\*guides.*$/m, '') },
+        report: reportMock,
+      }
+      // @ts-expect-error - partial mock
+      const listener = rule.create(context)
+      const mockNode = { type: 'root' }
+      // @ts-expect-error - partial mock
+      listener.root?.(mockNode)
+
+      expect(reportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: 'missingGuidesLink',
+          data: { encodedPackageName: '%40hyperfrontend%2Ftest' },
+        })
+      )
+    })
+
+    it('skips the guides link check when the project has no package.json to name the package', () => {
+      const dir = createTempProject({ projectJson: validProjectJson })
+      const reportMock = jest.fn()
+      const context = {
+        filename: join(dir, 'README.md'),
+        sourceCode: { getText: () => createValidReadme('test').replace(/^• 👉 See \[\*\*guides.*$/m, '') },
         report: reportMock,
       }
       // @ts-expect-error - partial mock

--- a/tools/eslint-rules/src/rules/lib-readme-structure.ts
+++ b/tools/eslint-rules/src/rules/lib-readme-structure.ts
@@ -1,7 +1,7 @@
 import type { Rule } from 'eslint'
 import { dirname } from 'node:path'
 import { createURL } from '@hyperfrontend/immutable-api-utils/built-in-copy/url'
-import { isPublishableLibrary } from '../utils/nx-project'
+import { isPublishableLibrary, readPackageJson } from '../utils/nx-project'
 
 /**
  * The expected base URL for documentation links.
@@ -9,13 +9,26 @@ import { isPublishableLibrary } from '../utils/nx-project'
 const DOCS_BASE_URL = createURL('https://www.hyperfrontend.dev/docs/')
 
 /**
- * Checks if a line contains a URL that starts with the expected documentation base URL.
- * This properly parses URLs to avoid incomplete substring matching vulnerabilities.
- *
- * @param line - The line to check.
- * @returns True if the line contains a valid documentation URL.
+ * The canonical package-filtered guides destination, without its query string.
+ * One route serves every entry point into guides, so a README link and the
+ * site's own filter controls resolve to the same view.
  */
-function containsValidDocumentationUrl(line: string): boolean {
+const GUIDES_PATHNAME = '/docs/guides/'
+
+/**
+ * The query parameter naming the package a guides view is filtered to. Its
+ * value is the npm package name, which the guide corpus already carries in
+ * each unit's metadata, so no package-to-guide mapping is written by hand.
+ */
+const GUIDES_PACKAGE_PARAM = 'package'
+
+/**
+ * Collects the target URLs of every markdown link on a line.
+ *
+ * @param line - The line to scan.
+ * @returns The link targets, in order of appearance.
+ */
+function extractMarkdownUrls(line: string): string[] {
   const urls: string[] = []
   let searchStart = 0
 
@@ -31,18 +44,54 @@ function containsValidDocumentationUrl(line: string): boolean {
     searchStart = urlEnd + 1
   }
 
-  if (urls.length === 0) {
-    return false
-  }
+  return urls
+}
 
-  return urls.some((url) => {
+/**
+ * Tests every markdown link on a line against a predicate, parsing each target
+ * as a URL so an unparseable one is rejected rather than substring-matched.
+ *
+ * @param line - The line to check.
+ * @param matches - Predicate applied to each parsed link target.
+ * @returns True when at least one link on the line satisfies the predicate.
+ */
+function hasLinkMatching(line: string, matches: (url: URL) => boolean): boolean {
+  return extractMarkdownUrls(line).some((url) => {
     try {
-      const parsed = createURL(url)
-      return parsed.origin === DOCS_BASE_URL.origin && parsed.pathname.startsWith(DOCS_BASE_URL.pathname)
+      return matches(createURL(url))
     } catch {
       return false
     }
   })
+}
+
+/**
+ * Checks if a line contains a URL that starts with the expected documentation base URL.
+ * This properly parses URLs to avoid incomplete substring matching vulnerabilities.
+ *
+ * @param line - The line to check.
+ * @returns True if the line contains a valid documentation URL.
+ */
+function containsValidDocumentationUrl(line: string): boolean {
+  return hasLinkMatching(line, (parsed) => parsed.origin === DOCS_BASE_URL.origin && parsed.pathname.startsWith(DOCS_BASE_URL.pathname))
+}
+
+/**
+ * Checks if a line links to the canonical guides destination filtered to a
+ * specific package.
+ *
+ * @param line - The line to check.
+ * @param packageName - The npm package the README documents.
+ * @returns True if the line carries the package-filtered guides URL.
+ */
+function containsPackageGuidesUrl(line: string, packageName: string): boolean {
+  return hasLinkMatching(
+    line,
+    (parsed) =>
+      parsed.origin === DOCS_BASE_URL.origin &&
+      parsed.pathname === GUIDES_PATHNAME &&
+      parsed.searchParams.get(GUIDES_PACKAGE_PARAM) === packageName
+  )
 }
 
 /**
@@ -318,6 +367,30 @@ export function extractDocumentationLink(content: string): DocLinkInfo | null {
   return null
 }
 
+/**
+ * Extracts the package-filtered guides link from the content.
+ *
+ * The link must survive a package having no guides yet: it points at a filter,
+ * not at a list of slugs, so guides written later surface from the published
+ * README without another release.
+ *
+ * @param content - The markdown content.
+ * @param packageName - The npm package the README documents.
+ * @returns The guides link info, or null if not found.
+ */
+export function extractGuidesLink(content: string, packageName: string): DocLinkInfo | null {
+  const lines = content.split('\n')
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = <string>lines[i]
+    if (line.includes('•') && line.includes('👉') && containsPackageGuidesUrl(line, packageName)) {
+      return { line: i + 1 }
+    }
+  }
+
+  return null
+}
+
 const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
@@ -335,6 +408,8 @@ const rule: Rule.RuleModule = {
       emptyShortDescription: 'README short description must not be empty',
       missingDocumentationLink:
         'README must have a documentation link in format: • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/<name>/)',
+      missingGuidesLink:
+        'README must link its guides and tutorials in format: • 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package={{ encodedPackageName }}). The link stays valid while the package has no guides: it addresses the filter, so guides written later surface without another README change.',
       missingSection: "README must have section: '{{ section }}'",
       emptySectionContent: "README section '{{ section }}' must have content",
       sectionOutOfOrder:
@@ -414,6 +489,16 @@ const rule: Rule.RuleModule = {
           context.report({
             node,
             messageId: 'missingDocumentationLink',
+          })
+        }
+
+        // why: The package name is authoritative in package.json; the README title is prose that can drift from it
+        const packageName = readPackageJson(projectRoot)?.name
+        if (packageName && !extractGuidesLink(content, packageName)) {
+          context.report({
+            node,
+            messageId: 'missingGuidesLink',
+            data: { encodedPackageName: encodeURIComponent(packageName) },
           })
         }
 

--- a/tools/package/src/generators/make-publishable/files/README.md.template
+++ b/tools/package/src/generators/make-publishable/files/README.md.template
@@ -37,6 +37,8 @@
 
 • 👉 See [**documentation**](https://www.hyperfrontend.dev/docs/libraries/<%= libName %>/)
 
+• 👉 See [**guides & tutorials**](https://www.hyperfrontend.dev/docs/guides/?package=<%= packageNameEncoded %>)
+
 ## What is <%= packageName %>?
 
 TODO: Provide an overview of the library and its core functionality.


### PR DESCRIPTION
## Description

Makes guides and tutorials a first-class, package-filterable destination across the site and every published README, adds five new guides, and fixes a `@hyperfrontend/features` liveness bug where a frame killed while the page was hidden was never reported as unhealthy.

The guides corpus now has one canonical route (`/docs/guides/`) with `?package=` and `?type=` facets. Package READMEs, library doc pages, the landing page, and the header nav all resolve there, and a new ESLint rule keeps the README link in step with the package name the README actually ships with. Empty filtered views invite a guide request through a prefilled GitHub issue form instead of dead-ending.

## Type of Change

🐛 Bug fix | ✨ Feature | 📝 Docs | 🔧 Build/Config

## Changes Made

- **Guides destination**: added `guide-filters.ts` with a canonical `/docs/guides/` route, `package`/`type` facets, href builder, filter reader, and ownership-first sorting so a package's primary guides rank ahead of ones that merely involve it. Facets set to `all` are dropped from the URL so each view has exactly one address.
- **Guides index UI**: reworked `guides-index-list.tsx` around the two facets, added a `suggest-guide-link` empty state, and rendered guide prerequisites as inline markdown.
- **Guide requests**: added the `guide_request.yml` issue form and `guide-request.ts`, which builds a prefilled GitHub new-issue URL, naming the package only when the reader arrived from a package-scoped view.
- **README convention**: new `lib-readme-structure` check requires a package-filtered guides link, reading the package name from `package.json` rather than the title text; skipped when a project has no `package.json`. Applied the link to all 20 publishable library READMEs, the `make-publishable` generator template, and the readme emitted by `tool-package`.
- **Navigation and landing**: header, mobile menu, and sitemap now share one `mainNavLinks` list; added a `LandingLearnSection` presenting guides, tutorials, demos, and articles as four destinations, plus a Guides entry in the value-proposition links.
- **New content**: four how-to guides (prototype pollution hardening, config validation at startup, the commitizen/commitlint migration, tracking async task state) and one tutorial (building an interactive CLI setup wizard). Reclassified the circular-JSON guide as a how-to.
- **Share menu**: brand icons for each share destination.
- **`@hyperfrontend/features` 0.7.1 (fix)**: `healthy` is now only ever spoken on evidence — the handshake or a beat. Resuming observation grants a fresh miss budget but no longer transitions to `healthy`, and a beat received while hidden keeps the pair honestly `unobservable`. `createShellHandle` also clears the latched `peerHidden` flag for an in-document frame when this page becomes visible, since a killed frame can never send the report that would clear it; leaving it set pinned the watchdog at `unobservable` for the rest of the session.
- **Docs**: workspace troubleshooting scoped to diagnosing hyperfrontend itself; `docs-site` README and the `how-to-guides` / `readme-docs` skills updated for the new conventions.

## Testing

- New unit specs for `guide-filters` and `guide-request` covering href serialization, facet reading, package/type narrowing, ownership sorting, and prefill behaviour with and without a package.
- Extended `lib-readme-structure` rule specs for the guides-link check, including the URL-encoded package name and the no-`package.json` skip path.
- `@hyperfrontend/features` liveness covered by extended `heartbeat.spec.ts` and `lifecycle.liveness.spec.ts`, plus a new `lifecycle.liveness.browser.spec.ts` exercising the hidden-then-killed-frame case against real browser visibility events.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests as needed
- [ ] I have updated relevant documentation
- [ ] I have used `npm run commit` for conventional commit messages

## AI Assistance

Code changes made using Claude with direct supervision.

## Additional Notes

- `@hyperfrontend/features` is released as **0.7.1** (patch). The liveness change is behavioural but not breaking: a host that previously saw `healthy` immediately on returning to the tab now sees `unobservable` until the next beat arrives, which is the correct reading of the evidence. Hosts that treated `unobservable` as a failure state should confirm they wait for `suspect`.
- The README guides link addresses a filter rather than a list of slugs, so a package with no guides yet still ships a working link and guides written later surface from the already-published README without another release.

---

## 📝 CLA Requirement

By submitting this pull request, you acknowledge that:

- You have read and agree to sign our [Contributor License Agreement (CLA)](https://github.com/AndrewRedican/hyperfrontend/blob/main/CLA.md)
- The CLA Assistant bot will automatically check your signature status
- If you haven't signed yet, the bot will provide instructions in the comments
- By signing, you grant the project maintainer exclusive rights to your contributions

For more information, see our [Contributing Guide](https://github.com/AndrewRedican/hyperfrontend/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).

---

Thank you for contributing to hyperfrontend! 🚀
